### PR TITLE
Improve display text for libraries

### DIFF
--- a/lib/src/element_type.dart
+++ b/lib/src/element_type.dart
@@ -64,6 +64,12 @@ abstract class ElementType
   /// Name with generics and nullability indication.
   String get nameWithGenerics;
 
+  @override
+  String get displayName => throw UnimplementedError();
+
+  @override
+  String get breadcrumbName => throw UnimplementedError();
+
   DartType get instantiatedType;
 
   Iterable<ElementType> get typeArguments;

--- a/lib/src/generator/generator_frontend.dart
+++ b/lib/src/generator/generator_frontend.dart
@@ -74,7 +74,7 @@ class GeneratorFrontEnd implements Generator {
 
       for (var lib in filterNonDocumented(package.libraries)) {
         if (!multiplePackages) {
-          logInfo('Generating docs for library ${lib.name} from '
+          logInfo('Generating docs for library ${lib.breadcrumbName} from '
               '${lib.element.source.uri}...');
         }
         if (!lib.isAnonymous && !lib.hasDocumentation) {

--- a/lib/src/generator/template_data.dart
+++ b/lib/src/generator/template_data.dart
@@ -215,8 +215,11 @@ class LibraryTemplateData extends TemplateData<Library>
   List<Documentable> get navLinks => [_packageGraph.defaultPackage];
 
   @override
-  String get layoutTitle => _layoutTitle(library.name, Kind.library.toString(),
-      isDeprecated: library.isDeprecated);
+  String get layoutTitle => _layoutTitle(
+        library.breadcrumbName,
+        Kind.library.toString(),
+        isDeprecated: library.isDeprecated,
+      );
 
   @override
   Library get self => library;

--- a/lib/src/generator/template_data.dart
+++ b/lib/src/generator/template_data.dart
@@ -104,9 +104,9 @@ abstract class TemplateData<T extends Documentable> extends TemplateDataBase {
   String? get belowSidebarPath => self.belowSidebarPath;
 
   String _layoutTitle(
-    String name,
-    String? kind, {
-    required bool isDeprecated,
+    String name, {
+    String? kind,
+    bool isDeprecated = false,
   }) =>
       _packageGraph.rendererFactory.templateRenderer
           .composeLayoutTitle(name, kind, isDeprecated);
@@ -140,8 +140,11 @@ class PackageTemplateData extends TemplateData<Package> {
   Package get self => package;
 
   @override
-  String get layoutTitle =>
-      _layoutTitle(package.name, package.kind.toString(), isDeprecated: false);
+  String get layoutTitle => _layoutTitle(
+        package.name,
+        kind: package.kind.toString(),
+      );
+
   @override
   String get metaDescription =>
       '${package.name} API docs, for the Dart programming language.';
@@ -187,9 +190,10 @@ class CategoryTemplateData extends TemplateData<Category>
   String get title => '${category.name} ${category.kind} - Dart API';
 
   @override
-  String get layoutTitle =>
-      _layoutTitle(category.name, category.kind.toString(),
-          isDeprecated: false);
+  String get layoutTitle => _layoutTitle(
+        category.name,
+        kind: category.kind.toString(),
+      );
 
   @override
   String get metaDescription =>
@@ -221,7 +225,6 @@ class LibraryTemplateData extends TemplateData<Library>
   @override
   String get layoutTitle => _layoutTitle(
         library.breadcrumbName,
-        null, // Do not display the word, 'library'
         isDeprecated: library.isDeprecated,
       );
 
@@ -291,9 +294,12 @@ abstract class InheritingContainerTemplateData<T extends InheritingContainer>
       '${library.name} library, for the Dart programming language.';
 
   @override
-  String get layoutTitle =>
-      _layoutTitle(clazz.nameWithLinkedGenerics, clazz.fullkind,
-          isDeprecated: clazz.isDeprecated);
+  String get layoutTitle => _layoutTitle(
+        clazz.nameWithLinkedGenerics,
+        kind: clazz.fullkind,
+        isDeprecated: clazz.isDeprecated,
+      );
+
   @override
   List<Documentable> get navLinks => [_packageGraph.defaultPackage, library];
 }
@@ -328,9 +334,12 @@ class ExtensionTemplateData<T extends Extension> extends TemplateData<T>
       '${library.name} library, for the Dart programming language.';
 
   @override
-  String get layoutTitle =>
-      _layoutTitle(extension.name, extension.kind.toString(),
-          isDeprecated: false);
+  String get layoutTitle => _layoutTitle(
+        extension.name, kind: extension.kind.toString(),
+        // TODO(srawlins): Why can't an extension be deprecated?
+        isDeprecated: false,
+      );
+
   @override
   List<Documentable> get navLinks => [_packageGraph.defaultPackage, library];
 }
@@ -366,9 +375,12 @@ final class ExtensionTypeTemplateData<T extends ExtensionType>
       '${library.name} library, for the Dart programming language.';
 
   @override
-  String get layoutTitle =>
-      _layoutTitle(extensionType.name, extensionType.kind.toString(),
-          isDeprecated: false);
+  String get layoutTitle => _layoutTitle(
+        extensionType.name,
+        kind: extensionType.kind.toString(),
+        // TODO(srawlins): Use real deprecation here.
+        isDeprecated: false,
+      );
 
   @override
   List<Documentable> get navLinks => [_packageGraph.defaultPackage, library];
@@ -398,8 +410,12 @@ class ConstructorTemplateData extends TemplateData<Constructor>
   Constructor get self => constructor;
 
   @override
-  String get layoutTitle => _layoutTitle(constructor.name, constructor.fullKind,
-      isDeprecated: constructor.isDeprecated);
+  String get layoutTitle => _layoutTitle(
+        constructor.name,
+        kind: constructor.fullKind,
+        isDeprecated: constructor.isDeprecated,
+      );
+
   @override
   List<Documentable> get navLinks => [_packageGraph.defaultPackage, library];
   @override
@@ -447,10 +463,14 @@ class FunctionTemplateData extends TemplateData<ModelFunction>
   @override
   String get title =>
       '${function.name} function - ${library.name} library - Dart API';
+
   @override
-  String get layoutTitle =>
-      _layoutTitle(function.nameWithGenerics, Kind.function.toString(),
-          isDeprecated: function.isDeprecated);
+  String get layoutTitle => _layoutTitle(
+        function.nameWithGenerics,
+        kind: Kind.function.toString(),
+        isDeprecated: function.isDeprecated,
+      );
+
   @override
   String get metaDescription =>
       'API docs for the ${function.name} function from the '
@@ -485,10 +505,14 @@ class MethodTemplateData extends TemplateData<Method>
   String get title =>
       '${method.name} method - ${container.name} ${container.kind} - '
       '${library.name} library - Dart API';
+
   @override
-  String get layoutTitle =>
-      _layoutTitle(method.nameWithGenerics, method.fullkind,
-          isDeprecated: method.isDeprecated);
+  String get layoutTitle => _layoutTitle(
+        method.nameWithGenerics,
+        kind: method.fullkind,
+        isDeprecated: method.isDeprecated,
+      );
+
   @override
   String get metaDescription =>
       'API docs for the ${method.name} method from the ${container.name} '
@@ -525,9 +549,14 @@ class PropertyTemplateData extends TemplateData<Field>
   String get title => '${property.name} ${property.kind} - '
       '${container.name} ${container.kind} - '
       '${library.name} library - Dart API';
+
   @override
-  String get layoutTitle => _layoutTitle(property.name, property.fullkind,
-      isDeprecated: property.isDeprecated);
+  String get layoutTitle => _layoutTitle(
+        property.name,
+        kind: property.fullkind,
+        isDeprecated: property.isDeprecated,
+      );
+
   @override
   String get metaDescription =>
       'API docs for the ${property.name} ${property.kind} from the '
@@ -559,10 +588,14 @@ class TypedefTemplateData extends TemplateData<Typedef>
   @override
   String get title =>
       '${typeDef.name} typedef - ${library.name} library - Dart API';
+
   @override
-  String get layoutTitle =>
-      _layoutTitle(typeDef.nameWithGenerics, Kind.typedef.toString(),
-          isDeprecated: typeDef.isDeprecated);
+  String get layoutTitle => _layoutTitle(
+        typeDef.nameWithGenerics,
+        kind: Kind.typedef.toString(),
+        isDeprecated: typeDef.isDeprecated,
+      );
+
   @override
   String get metaDescription =>
       'API docs for the ${typeDef.name} typedef from the '
@@ -591,9 +624,14 @@ class TopLevelPropertyTemplateData extends TemplateData<TopLevelVariable>
   @override
   String get title =>
       '${property.name} $_type - ${library.name} library - Dart API';
+
   @override
-  String get layoutTitle =>
-      _layoutTitle(property.name, _type, isDeprecated: property.isDeprecated);
+  String get layoutTitle => _layoutTitle(
+        property.name,
+        kind: _type,
+        isDeprecated: property.isDeprecated,
+      );
+
   @override
   String get metaDescription =>
       'API docs for the ${property.name} $_type from the '

--- a/lib/src/generator/template_data.dart
+++ b/lib/src/generator/template_data.dart
@@ -103,7 +103,11 @@ abstract class TemplateData<T extends Documentable> extends TemplateDataBase {
 
   String? get belowSidebarPath => self.belowSidebarPath;
 
-  String _layoutTitle(String name, String kind, {required bool isDeprecated}) =>
+  String _layoutTitle(
+    String name,
+    String? kind, {
+    required bool isDeprecated,
+  }) =>
       _packageGraph.rendererFactory.templateRenderer
           .composeLayoutTitle(name, kind, isDeprecated);
 }
@@ -217,7 +221,7 @@ class LibraryTemplateData extends TemplateData<Library>
   @override
   String get layoutTitle => _layoutTitle(
         library.breadcrumbName,
-        Kind.library.toString(),
+        null, // Do not display the word, 'library'
         isDeprecated: library.isDeprecated,
       );
 

--- a/lib/src/generator/templates.aot_renderers_for_html.dart
+++ b/lib/src/generator/templates.aot_renderers_for_html.dart
@@ -1109,17 +1109,25 @@ String renderLibrary(LibraryTemplateData context0) {
   var context1 = context0.self;
   buffer.writeln();
   buffer.write('''
-      <div>''');
+      <div>
+        ''');
   buffer.write(_renderLibrary_partial_source_link_1(context1));
-  buffer.write('''<h1><span class="kind-library">''');
-  buffer.write(context1.name);
-  buffer.write('''</span> ''');
+  buffer.writeln();
+  buffer.write('''
+        <h1>
+          <span class="kind-library">''');
+  buffer.write(context1.displayName);
+  buffer.write('''</span>
+          ''');
   buffer.writeEscaped(context1.kind.toString());
   buffer.write(' ');
   buffer.write(_renderLibrary_partial_feature_set_2(context1));
   buffer.write(' ');
   buffer.write(_renderLibrary_partial_categorization_3(context1));
-  buffer.write('''</h1></div>''');
+  buffer.writeln();
+  buffer.write('''
+        </h1>
+      </div>''');
   buffer.writeln();
   var context2 = context0.library;
   buffer.write('\n    ');
@@ -3579,7 +3587,7 @@ String _deduplicated_lib_templates_html__head_html(TemplateDataBase context0) {
     <li><a href="''');
     buffer.write(context4.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context4.name);
+    buffer.writeEscaped(context4.breadcrumbName);
     buffer.write('''</a></li>''');
   }
   var context5 = context0.navLinksWithGenerics;
@@ -3589,7 +3597,7 @@ String _deduplicated_lib_templates_html__head_html(TemplateDataBase context0) {
     <li><a href="''');
     buffer.write(context6.href);
     buffer.write('''">''');
-    buffer.writeEscaped(context6.name);
+    buffer.writeEscaped(context6.breadcrumbName);
     if (context6.hasGenericParameters == true) {
       buffer.write('''<span class="signature">''');
       buffer.write(context6.genericParameters);

--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -4399,6 +4399,50 @@ class _Renderer_ElementType extends RendererBase<ElementType> {
                 ..._Renderer_CommentReferable.propertyMap<CT_>(),
                 ..._Renderer_Nameable.propertyMap<CT_>(),
                 ..._Renderer_ModelBuilder.propertyMap<CT_>(),
+                'breadcrumbName': Property(
+                  getValue: (CT_ c) => c.breadcrumbName,
+                  renderVariable:
+                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
+                    if (remainingNames.isEmpty) {
+                      return self.getValue(c).toString();
+                    }
+                    var name = remainingNames.first;
+                    var nextProperty =
+                        _Renderer_String.propertyMap().getValue(name);
+                    return nextProperty.renderVariable(
+                        self.getValue(c) as String,
+                        nextProperty,
+                        [...remainingNames.skip(1)]);
+                  },
+                  isNullValue: (CT_ c) => false,
+                  renderValue: (CT_ c, RendererBase<CT_> r,
+                      List<MustachioNode> ast, StringSink sink) {
+                    _render_String(c.breadcrumbName, ast, r.template, sink,
+                        parent: r);
+                  },
+                ),
+                'displayName': Property(
+                  getValue: (CT_ c) => c.displayName,
+                  renderVariable:
+                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
+                    if (remainingNames.isEmpty) {
+                      return self.getValue(c).toString();
+                    }
+                    var name = remainingNames.first;
+                    var nextProperty =
+                        _Renderer_String.propertyMap().getValue(name);
+                    return nextProperty.renderVariable(
+                        self.getValue(c) as String,
+                        nextProperty,
+                        [...remainingNames.skip(1)]);
+                  },
+                  isNullValue: (CT_ c) => false,
+                  renderValue: (CT_ c, RendererBase<CT_> r,
+                      List<MustachioNode> ast, StringSink sink) {
+                    _render_String(c.displayName, ast, r.template, sink,
+                        parent: r);
+                  },
+                ),
                 'instantiatedType': Property(
                   getValue: (CT_ c) => c.instantiatedType,
                   renderVariable: (CT_ c, Property<CT_> self,
@@ -8276,6 +8320,28 @@ class _Renderer_Library extends RendererBase<Library> {
                         parent: r);
                   },
                 ),
+                'breadcrumbName': Property(
+                  getValue: (CT_ c) => c.breadcrumbName,
+                  renderVariable:
+                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
+                    if (remainingNames.isEmpty) {
+                      return self.getValue(c).toString();
+                    }
+                    var name = remainingNames.first;
+                    var nextProperty =
+                        _Renderer_String.propertyMap().getValue(name);
+                    return nextProperty.renderVariable(
+                        self.getValue(c) as String,
+                        nextProperty,
+                        [...remainingNames.skip(1)]);
+                  },
+                  isNullValue: (CT_ c) => false,
+                  renderValue: (CT_ c, RendererBase<CT_> r,
+                      List<MustachioNode> ast, StringSink sink) {
+                    _render_String(c.breadcrumbName, ast, r.template, sink,
+                        parent: r);
+                  },
+                ),
                 'characterLocation': Property(
                   getValue: (CT_ c) => c.characterLocation,
                   renderVariable: (CT_ c, Property<CT_> self,
@@ -8349,6 +8415,28 @@ class _Renderer_Library extends RendererBase<Library> {
                   renderValue: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
                     _render_String(c.dirName, ast, r.template, sink, parent: r);
+                  },
+                ),
+                'displayName': Property(
+                  getValue: (CT_ c) => c.displayName,
+                  renderVariable:
+                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
+                    if (remainingNames.isEmpty) {
+                      return self.getValue(c).toString();
+                    }
+                    var name = remainingNames.first;
+                    var nextProperty =
+                        _Renderer_String.propertyMap().getValue(name);
+                    return nextProperty.renderVariable(
+                        self.getValue(c) as String,
+                        nextProperty,
+                        [...remainingNames.skip(1)]);
+                  },
+                  isNullValue: (CT_ c) => false,
+                  renderValue: (CT_ c, RendererBase<CT_> r,
+                      List<MustachioNode> ast, StringSink sink) {
+                    _render_String(c.displayName, ast, r.template, sink,
+                        parent: r);
                   },
                 ),
                 'element': Property(
@@ -8594,28 +8682,6 @@ class _Renderer_Library extends RendererBase<Library> {
                     _render_String(c.name, ast, r.template, sink, parent: r);
                   },
                 ),
-                'nameFromPath': Property(
-                  getValue: (CT_ c) => c.nameFromPath,
-                  renderVariable:
-                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
-                    if (remainingNames.isEmpty) {
-                      return self.getValue(c).toString();
-                    }
-                    var name = remainingNames.first;
-                    var nextProperty =
-                        _Renderer_String.propertyMap().getValue(name);
-                    return nextProperty.renderVariable(
-                        self.getValue(c) as String,
-                        nextProperty,
-                        [...remainingNames.skip(1)]);
-                  },
-                  isNullValue: (CT_ c) => false,
-                  renderValue: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    _render_String(c.nameFromPath, ast, r.template, sink,
-                        parent: r);
-                  },
-                ),
                 'package': Property(
                   getValue: (CT_ c) => c.package,
                   renderVariable:
@@ -8671,19 +8737,6 @@ class _Renderer_Library extends RendererBase<Library> {
                       List<MustachioNode> ast, StringSink sink) {
                     _render_String(c.packageName, ast, r.template, sink,
                         parent: r);
-                  },
-                ),
-                'prefixToLibrary': Property(
-                  getValue: (CT_ c) => c.prefixToLibrary,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(
-                          c, remainingNames, 'Map<String, Set<Library>>'),
-                  isNullValue: (CT_ c) => false,
-                  renderValue: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    renderSimple(c.prefixToLibrary, ast, r.template, sink,
-                        parent: r, getters: _invisibleGetters['Map']!);
                   },
                 ),
                 'properties': Property(
@@ -11544,6 +11597,50 @@ class _Renderer_Nameable extends RendererBase<Nameable> {
           CT_,
           () => {
                 ..._Renderer_Object.propertyMap<CT_>(),
+                'breadcrumbName': Property(
+                  getValue: (CT_ c) => c.breadcrumbName,
+                  renderVariable:
+                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
+                    if (remainingNames.isEmpty) {
+                      return self.getValue(c).toString();
+                    }
+                    var name = remainingNames.first;
+                    var nextProperty =
+                        _Renderer_String.propertyMap().getValue(name);
+                    return nextProperty.renderVariable(
+                        self.getValue(c) as String,
+                        nextProperty,
+                        [...remainingNames.skip(1)]);
+                  },
+                  isNullValue: (CT_ c) => false,
+                  renderValue: (CT_ c, RendererBase<CT_> r,
+                      List<MustachioNode> ast, StringSink sink) {
+                    _render_String(c.breadcrumbName, ast, r.template, sink,
+                        parent: r);
+                  },
+                ),
+                'displayName': Property(
+                  getValue: (CT_ c) => c.displayName,
+                  renderVariable:
+                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
+                    if (remainingNames.isEmpty) {
+                      return self.getValue(c).toString();
+                    }
+                    var name = remainingNames.first;
+                    var nextProperty =
+                        _Renderer_String.propertyMap().getValue(name);
+                    return nextProperty.renderVariable(
+                        self.getValue(c) as String,
+                        nextProperty,
+                        [...remainingNames.skip(1)]);
+                  },
+                  isNullValue: (CT_ c) => false,
+                  renderValue: (CT_ c, RendererBase<CT_> r,
+                      List<MustachioNode> ast, StringSink sink) {
+                    _render_String(c.displayName, ast, r.template, sink,
+                        parent: r);
+                  },
+                ),
                 'fullyQualifiedName': Property(
                   getValue: (CT_ c) => c.fullyQualifiedName,
                   renderVariable:
@@ -16886,10 +16983,12 @@ const _invisibleGetters = {
     'allLibraries',
     'allLibrariesAdded',
     'allLocalModelElements',
+    'breadcrumbName',
     'config',
     'dartCoreObject',
     'defaultPackage',
     'defaultPackageName',
+    'displayName',
     'documentedExtensions',
     'documentedPackages',
     'extensions',

--- a/lib/src/model/library.dart
+++ b/lib/src/model/library.dart
@@ -338,7 +338,7 @@ class Library extends ModelElement
     assert(!element.source.uri.isScheme('dart'));
     var relativePath = pathContext.relative(element.source.fullName,
         from: package.packagePath);
-    assert(relativePath.startsWith('lib/'));
+    assert(relativePath.startsWith('lib${pathContext.separator}'));
     const libDirectoryLength = 'lib/'.length;
     return relativePath.substring(libDirectoryLength);
   }

--- a/lib/src/model/nameable.dart
+++ b/lib/src/model/nameable.dart
@@ -16,6 +16,12 @@ abstract mixin class Nameable {
     ...name.split(locationSplitter).where((s) => s.isNotEmpty)
   };
 
+  /// The name to use as text in the rendered documentation.
+  String get displayName => name;
+
+  /// The name to use in breadcrumbs in the rendered documentation.
+  String get breadcrumbName => name;
+
   /// Utility getter/cache for `_MarkdownCommentReference._getResultsForClass`.
   // TODO(jcollins-g): This should really be the same as 'name', but isn't
   // because of accessors and operators.

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -59,6 +59,12 @@ class PackageGraph with CommentReferable, Nameable, ModelBuilder {
   @override
   String get name => '';
 
+  @override
+  String get displayName => throw UnimplementedError();
+
+  @override
+  String get breadcrumbName => throw UnimplementedError();
+
   /// Adds [resolvedLibrary] to the package graph, adding it to [allLibraries],
   /// and to the [Package] which is created from the [PackageMeta] for the
   /// library.

--- a/lib/src/render/model_element_renderer.dart
+++ b/lib/src/render/model_element_renderer.dart
@@ -31,7 +31,8 @@ class ModelElementRendererHtml extends ModelElementRenderer {
   @override
   String renderLinkedName(ModelElement modelElement) {
     var cssClass = modelElement.isDeprecated ? ' class="deprecated"' : '';
-    return '<a$cssClass href="${modelElement.href}">${modelElement.name}</a>';
+    return '<a$cssClass href="${modelElement.href}">'
+        '${modelElement.displayName}</a>';
   }
 
   @override

--- a/lib/src/render/template_renderer.dart
+++ b/lib/src/render/template_renderer.dart
@@ -3,18 +3,19 @@
 // BSD-style license that can be found in the LICENSE file.
 
 abstract class LayoutRenderer {
-  String composeLayoutTitle(String name, String kind, bool isDeprecated);
+  String composeLayoutTitle(String name, String? kind, bool isDeprecated);
 }
 
 class HtmlLayoutRenderer implements LayoutRenderer {
   const HtmlLayoutRenderer();
 
   @override
-  String composeLayoutTitle(String name, String kind, bool isDeprecated) {
+  String composeLayoutTitle(String name, String? kind, bool isDeprecated) {
+    var kindText = kind == null ? '' : ' $kind';
     if (isDeprecated) {
-      return '<span class="deprecated">$name</span> $kind';
+      return '<span class="deprecated">$name</span>$kindText';
     } else {
-      return '$name $kind';
+      return '$name$kindText';
     }
   }
 }
@@ -23,11 +24,12 @@ class MdLayoutRenderer implements LayoutRenderer {
   const MdLayoutRenderer();
 
   @override
-  String composeLayoutTitle(String name, String kind, bool isDeprecated) {
+  String composeLayoutTitle(String name, String? kind, bool isDeprecated) {
+    var kindText = kind == null ? '' : ' $kind';
     if (isDeprecated) {
-      return '~~$name~~ $kind';
+      return '~~$name~~$kindText';
     } else {
-      return '$name $kind';
+      return '$name$kindText';
     }
   }
 }

--- a/lib/src/validator.dart
+++ b/lib/src/validator.dart
@@ -36,7 +36,7 @@ class Validator {
   /// Don't call this method more than once, and only after you've
   /// generated all docs for the Package.
   void validateLinks() {
-    logInfo('Validating...');
+    logInfo('Validating links...');
     runtimeStats.resetAccumulators({
       'readCountForLinkValidation',
       'readCountForIndexValidation',

--- a/lib/templates/html/_head.html
+++ b/lib/templates/html/_head.html
@@ -40,12 +40,12 @@
 <header id="title">
   <span id="sidenav-left-toggle" class="material-symbols-outlined" role="button" tabindex="0">menu</span>
   <ol class="breadcrumbs gt-separated dark hidden-xs">
-    {{#navLinks}}
-    <li><a href="{{{href}}}">{{name}}</a></li>
-    {{/navLinks}}
-    {{#navLinksWithGenerics}}
-    <li><a href="{{{href}}}">{{name}}{{#hasGenericParameters}}<span class="signature">{{{genericParameters}}}</span>{{/hasGenericParameters}}</a></li>
-    {{/navLinksWithGenerics}}
+    {{ #navLinks }}
+    <li><a href="{{{ href }}}">{{ breadcrumbName }}</a></li>
+    {{ /navLinks }}
+    {{ #navLinksWithGenerics }}
+    <li><a href="{{{ href }}}">{{ breadcrumbName }}{{ #hasGenericParameters }}<span class="signature">{{{ genericParameters }}}</span>{{ /hasGenericParameters }}</a></li>
+    {{ /navLinksWithGenerics }}
     {{^hasHomepage}}
     <li class="self-crumb">{{{ layoutTitle }}}</li>
     {{/hasHomepage}}

--- a/lib/templates/html/library.html
+++ b/lib/templates/html/library.html
@@ -6,9 +6,15 @@
       data-above-sidebar="{{ aboveSidebarPath }}"
       data-below-sidebar="{{ belowSidebarPath }}">
       {{ !-- TODO(srawlins): Add annotations. }}
-    {{#self}}
-      <div>{{>source_link}}<h1><span class="kind-library">{{{name}}}</span> {{kind}} {{>feature_set}} {{>categorization}}</h1></div>
-    {{/self}}
+    {{ #self }}
+      <div>
+        {{ >source_link }}
+        <h1>
+          <span class="kind-library">{{{ displayName }}}</span>
+          {{ kind }} {{ >feature_set }} {{ >categorization }}
+        </h1>
+      </div>
+    {{ /self }}
 
     {{#library}}
     {{>documentation}}


### PR DESCRIPTION
Fixes https://github.com/dart-lang/dartdoc/issues/1658 and fixes https://github.com/dart-lang/dartdoc/issues/1000.

The changes in this PR do not ever print the full import URI (like `package:googleapis/admob/v1.dart`) or even the import path with the `.dart` extension (like `admob/v1.dart`), except in the breadcrumb. Mainly this PR uses the basename of the library with its directory path _after_ `lib/` (like `admob/v1`). Here are some screenshots:

<img width="557" alt="Screenshot 2023-10-25 at 11 17 44 AM" src="https://github.com/dart-lang/dartdoc/assets/103167/b83657c3-c791-44fc-aecd-1cee9090bc8c">

---

<img width="572" alt="Screenshot 2023-11-01 at 10 20 47 PM" src="https://github.com/dart-lang/dartdoc/assets/103167/0cdddf69-379b-4ad7-8c19-afa0db23c6a2">

---

<img width="544" alt="Screenshot 2023-11-01 at 10 21 04 PM" src="https://github.com/dart-lang/dartdoc/assets/103167/fb393876-e30a-4e15-a7f7-545f940b2838">

---

<img width="604" alt="Screenshot 2023-10-25 at 11 54 47 AM" src="https://github.com/dart-lang/dartdoc/assets/103167/a96027a9-1314-482e-91d5-d27d6b041037">

---

<img width="692" alt="Screenshot 2023-11-02 at 1 13 59 PM" src="https://github.com/dart-lang/dartdoc/assets/103167/1700b6d2-bf63-459d-b096-840b442fc66b">

---

<img width="680" alt="Screenshot 2023-11-02 at 1 14 08 PM" src="https://github.com/dart-lang/dartdoc/assets/103167/656a274e-7323-42a8-ace1-e2527a18b8f1">

---

Additionally:

* Make `Library.prefixToLibrary` private.
* Refactor `Library.dirName` to just inline all of its helper methods. I think it is much more readable this way.
* Remove `Library.nameFromPath` (as part of the above).

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
