### PR TITLE
Remove some unused fields from ElementType

### DIFF
--- a/lib/src/element_type.dart
+++ b/lib/src/element_type.dart
@@ -283,15 +283,11 @@ abstract class DefinedElementType extends ElementType {
         f as ParameterizedType, library, packageGraph, modelElement);
   }
 
-  Element get element => modelElement.element;
-
   @override
   String get name => type.documentableElement!.name!;
 
   @override
   String get fullyQualifiedName => modelElement.fullyQualifiedName;
-
-  bool get isParameterType => type is TypeParameterType;
 
   /// Whether the underlying, canonical element is public.
   ///
@@ -299,9 +295,9 @@ abstract class DefinedElementType extends ElementType {
   /// would ordinarily do.
   @override
   bool get isPublic {
-    var canonicalClass = modelElement.packageGraph
-            .findCanonicalModelElementFor(modelElement.element) ??
-        modelElement;
+    var canonicalClass =
+        packageGraph.findCanonicalModelElementFor(modelElement.element) ??
+            modelElement;
     return canonicalClass.isPublic;
   }
 
@@ -360,7 +356,7 @@ abstract class DefinedElementType extends ElementType {
   @internal
   @override
   CommentReferable get definingCommentReferable =>
-      modelBuilder.fromElement(element);
+      modelBuilder.fromElement(modelElement.element);
 }
 
 /// Any callable [ElementType] will mix-in this class, whether anonymous or not,

--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -3753,18 +3753,6 @@ class _Renderer_DefinedElementType extends RendererBase<DefinedElementType> {
           CT_,
           () => {
                 ..._Renderer_ElementType.propertyMap<CT_>(),
-                'element': Property(
-                  getValue: (CT_ c) => c.element,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(c, remainingNames, 'Element'),
-                  isNullValue: (CT_ c) => false,
-                  renderValue: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    renderSimple(c.element, ast, r.template, sink,
-                        parent: r, getters: _invisibleGetters['Element']!);
-                  },
-                ),
                 'fullyQualifiedName': Property(
                   getValue: (CT_ c) => c.fullyQualifiedName,
                   renderVariable:
@@ -3798,13 +3786,6 @@ class _Renderer_DefinedElementType extends RendererBase<DefinedElementType> {
                     renderSimple(c.instantiatedType, ast, r.template, sink,
                         parent: r, getters: _invisibleGetters['DartType']!);
                   },
-                ),
-                'isParameterType': Property(
-                  getValue: (CT_ c) => c.isParameterType,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(c, remainingNames, 'bool'),
-                  getBool: (CT_ c) => c.isParameterType == true,
                 ),
                 'isPublic': Property(
                   getValue: (CT_ c) => c.isPublic,

--- a/lib/src/model/inheriting_container.dart
+++ b/lib/src/model/inheriting_container.dart
@@ -361,18 +361,19 @@ abstract class InheritingContainer extends Container
     while (parent != null) {
       typeChain.add(parent);
       final parentType = parent.type;
-      if (parentType is InterfaceType) {
-        // Avoid adding [Object] to the [superChain] ([_supertype] already has
-        // this check).
-        if (parentType.superclass?.superclass == null) {
-          break;
-        } else {
-          parent = modelBuilder.typeFrom(parentType.superclass!, library)
-              as DefinedElementType?;
-        }
-      } else {
-        parent = (parent.modelElement as Class).supertype;
+      if (parentType is! InterfaceType) {
+        throw StateError('ancestor of $this is $parent with model element '
+            '${parent.modelElement}');
       }
+
+      var superclass = parentType.superclass;
+      // Avoid adding [Object] to the [superChain] ([_supertype] already has
+      // this check).
+      if (superclass == null || superclass.superclass == null) {
+        break;
+      }
+      parent =
+          modelBuilder.typeFrom(superclass, library) as DefinedElementType?;
     }
     return typeChain;
   }


### PR DESCRIPTION
Remove `element` and `isParameterType` from ElementType. Refactor `InheritingContainer.superChain`.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
