### PR TITLE
Remove @api directive.

### DIFF
--- a/lib/src/model/directives/categorization.dart
+++ b/lib/src/model/directives/categorization.dart
@@ -7,7 +7,7 @@ import 'package:dartdoc/src/model/model.dart';
 import 'package:meta/meta.dart';
 
 final RegExp _categoryRegExp = RegExp(
-    r'[ ]*{@(api|category|subCategory|image|samples) (.+?)}[ ]*\n?',
+    r'[ ]*{@(category|subCategory|image|samples) (.+?)}[ ]*\n?',
     multiLine: true);
 
 /// Mixin parsing the `@category` directive for ModelElements.
@@ -28,7 +28,6 @@ mixin Categorization on DocumentationComment implements Indexable {
       _hasCategorization = true;
       switch (match[1]) {
         case 'category':
-        case 'api':
           categorySet.add(match[2]!.trim());
         case 'subCategory':
           subCategorySet.add(match[2]!.trim());

--- a/lib/src/model/documentation_comment.dart
+++ b/lib/src/model/documentation_comment.dart
@@ -158,7 +158,6 @@ mixin DocumentationComment
     'youtube',
 
     // Other directives, parsed by `model/directives/*.dart`:
-    'api',
     'canonicalFor',
     'category',
     'hideConstantImplementations',


### PR DESCRIPTION
Removing `@api` directive since it's not used anywhere.

Small CL to keep it separate from the other directives, in case it somehow breaks something. (highly unlikely)

Part of fixing https://github.com/dart-lang/dartdoc/issues/3565

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
