### PR TITLE
Use a timeout factor of 3 in the integration test

### DIFF
--- a/test/end2end/dartdoc_integration_test.dart
+++ b/test/end2end/dartdoc_integration_test.dart
@@ -2,7 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library dartdoc.dartdoc_integration_test;
+@Timeout.factor(3)
+library;
 
 import 'dart:async';
 import 'dart:io';
@@ -48,7 +49,7 @@ void main() {
           contains('package:test_package has no documentable libraries')),
     );
     await process.shouldExit(0);
-  }, timeout: Timeout.factor(2));
+  });
 
   group('invoking dartdoc on a basic package', () {
     late String packagePath;
@@ -70,7 +71,7 @@ void main() {
       await process.shouldExit(0);
       var docs = Directory(path.join(packagePath, 'doc', 'api'));
       expect(docs.existsSync(), isFalse);
-    }, timeout: Timeout.factor(2));
+    });
 
     test('with --quiet is quiet and does generate docs', () async {
       var process = await runDartdoc(
@@ -83,7 +84,7 @@ void main() {
       await process.shouldExit(0);
       var indexHtml = Directory(path.join(packagePath, 'doc', 'api'));
       expect(indexHtml.listSync(), isNotEmpty);
-    }, timeout: Timeout.factor(2));
+    });
 
     test('with invalid options return non-zero and print a fatal-error',
         () async {
@@ -150,8 +151,8 @@ void main() {
           emitsThrough(
               '{"level":"WARNING","message":"Found 1 warning and 0 errors."}'));
       await process.shouldExit(0);
-    }, timeout: Timeout.factor(2));
-  }, timeout: Timeout.factor(8));
+    });
+  });
 
   test('with tool errors cause non-zero exit when warnings are off', () async {
     // TODO(srawlins): Remove test_package_tool_error and generate afresh.
@@ -171,7 +172,7 @@ void main() {
       workingDirectory: packagePath,
     );
     await process.shouldExit(1);
-  }, timeout: Timeout.factor(2));
+  });
 
   test('with missing FLUTTER_ROOT exception reports an error', () async {
     // TODO(srawlins): Remove test_package_flutter_plugin and generate afresh.
@@ -185,10 +186,15 @@ void main() {
       includeParentEnvironment: false,
     );
     await expectLater(
-        process.stderr,
-        emitsThrough(matches(
-            'Top level package requires Flutter but FLUTTER_ROOT environment variable not set|'
-            'test_package_flutter_plugin requires the Flutter SDK, version solving failed')));
+      process.stderr,
+      emitsThrough(
+        matches(
+          'Top level package requires Flutter but FLUTTER_ROOT environment '
+          'variable not set|test_package_flutter_plugin requires the Flutter '
+          'SDK, version solving failed',
+        ),
+      ),
+    );
     await process.shouldExit(1);
   });
 }


### PR DESCRIPTION
This should help it from timing out on the mac bot.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
