### PR TITLE
Avoid Lists of MapEntries.

### DIFF
--- a/lib/src/model/comment_referable.dart
+++ b/lib/src/model/comment_referable.dart
@@ -227,24 +227,13 @@ extension CommentReferableEntryGenerators on Iterable<CommentReferable> {
       };
 
   /// Generates entries from this Iterable.
-  Iterable<MapEntry<String, CommentReferable>> generateEntries() =>
-      map((r) => MapEntry(r.referenceName, r));
+  Map<String, CommentReferable> get asMapByName => {
+        for (var r in this) r.referenceName: r,
+      };
 
   /// Returns all values not of this type.
   List<CommentReferable> whereNotType<T>() => [
         for (var referable in this)
           if (referable is! T) referable,
       ];
-}
-
-/// A set of utility methods to add entries to
-/// [CommentReferable.referenceChildren].
-extension CommentReferableEntryBuilder on Map<String, CommentReferable> {
-  /// Like [Map.putIfAbsent] except works on an iterable of entries.
-  void addEntriesIfAbsent(
-      Iterable<MapEntry<String, CommentReferable>> entries) {
-    for (var entry in entries) {
-      if (!containsKey(entry.key)) this[entry.key] = entry.value;
-    }
-  }
 }

--- a/lib/src/model/container.dart
+++ b/lib/src/model/container.dart
@@ -231,34 +231,25 @@ abstract class Container extends ModelElement
   /// For subclasses to add items after the main pass but before the
   /// parameter-global.
   @visibleForOverriding
-  Iterable<MapEntry<String, CommentReferable>> get extraReferenceChildren;
+  Map<String, CommentReferable> get extraReferenceChildren;
 
   @override
   @mustCallSuper
-  late final Map<String, CommentReferable> referenceChildren = () {
-    var referenceChildren = <String, CommentReferable>{
-      for (var element in allModelElements
-          .whereNotType<Accessor>()
-          .whereNotType<Constructor>())
-        element.referenceName: element,
-    };
-
-    referenceChildren.addEntriesIfAbsent(extraReferenceChildren);
-    // Process unscoped parameters last to make sure they don't override
-    // other options.
-    for (var modelElement in allModelElements) {
+  late final Map<String, CommentReferable> referenceChildren =
+      <String, CommentReferable>{
+    for (var modelElement in allModelElements)
       // Don't complain about references to parameter names, but prefer
       // referring to anything else.
       // TODO(jcollins-g): Figure out something good to do in the ecosystem
       // here to wean people off the habit of unscoped parameter references.
-      if (modelElement.hasParameters) {
-        referenceChildren
-            .addEntriesIfAbsent(modelElement.parameters.generateEntries());
-      }
-    }
-    referenceChildren['this'] = this;
-    return referenceChildren;
-  }();
+      if (modelElement.hasParameters) ...modelElement.parameters.asMapByName,
+    ...extraReferenceChildren,
+    for (var element in allModelElements
+        .whereNotType<Accessor>()
+        .whereNotType<Constructor>())
+      element.referenceName: element,
+    'this': this,
+  };
 
   @override
   Iterable<CommentReferable> get referenceParents => [definingLibrary, library];

--- a/lib/src/model/extension.dart
+++ b/lib/src/model/extension.dart
@@ -112,8 +112,7 @@ class Extension extends Container implements EnclosedElement {
 
   @override
   @visibleForOverriding
-  Iterable<MapEntry<String, CommentReferable>> get extraReferenceChildren =>
-      const [];
+  Map<String, CommentReferable> get extraReferenceChildren => const {};
 
   @override
   String get relationshipsClass => 'clazz-relationships';

--- a/lib/src/model/extension_type.dart
+++ b/lib/src/model/extension_type.dart
@@ -85,8 +85,7 @@ class ExtensionType extends InheritingContainer
 
   @override
   @visibleForOverriding
-  Iterable<MapEntry<String, CommentReferable>> get extraReferenceChildren =>
-      const [];
+  Map<String, CommentReferable> get extraReferenceChildren => const {};
 
   @override
   String get relationshipsClass => 'clazz-relationships';

--- a/lib/src/model/inheriting_container.dart
+++ b/lib/src/model/inheriting_container.dart
@@ -36,14 +36,16 @@ mixin Constructable on InheritingContainer {
       for (var container in publicSuperChain
           .map((t) => t.modelElement)
           .whereType<Container>()) ...{
+        if (container is Constructable)
+          ..._mapConstructorsByName(container.constructors),
         for (var modelElement in [
           // TODO(jcollins-g): wean important users off of relying on static
           // method inheritance (dart-lang/dartdoc#2698).
           ...container.staticFields, ...container.staticMethods
         ])
           modelElement.referenceName: modelElement,
-        if (container is Constructable)
-          ..._mapConstructorsByName(container.constructors)
+        //if (container is Constructable)
+        //  ..._mapConstructorsByName(container.constructors)
       },
       ..._mapConstructorsByName(constructors),
     };

--- a/lib/src/model/inheriting_container.dart
+++ b/lib/src/model/inheriting_container.dart
@@ -53,18 +53,15 @@ mixin Constructable on InheritingContainer {
   bool get hasPublicConstructors => publicConstructorsSorted.isNotEmpty;
 
   static Map<String, CommentReferable> _mapConstructorsByName(
-      Iterable<Constructor> constructors) {
-    var x = {
-      for (var constructor in constructors) ...{
-        constructor.referenceName: constructor,
-        '${constructor.enclosingElement.referenceName}.${constructor.referenceName}':
-            constructor,
-        if (constructor.isDefaultConstructor) 'new': constructor,
-      },
-    };
-    print('constructor names: $x');
-    return x;
-  }
+          Iterable<Constructor> constructors) =>
+      {
+        for (var constructor in constructors) ...{
+          constructor.referenceName: constructor,
+          '${constructor.enclosingElement.referenceName}.${constructor.referenceName}':
+              constructor,
+          if (constructor.isDefaultConstructor) 'new': constructor,
+        },
+      };
 }
 
 /// A [Container] that participates in inheritance in Dart.

--- a/lib/src/model/library.dart
+++ b/lib/src/model/library.dart
@@ -427,8 +427,8 @@ class Library extends ModelElement
     var referenceChildrenBuilder = <String, CommentReferable>{};
     var definedNamesModelElements = element.exportNamespace.definedNames.values
         .map(modelBuilder.fromElement);
-    referenceChildrenBuilder.addEntries(
-        definedNamesModelElements.whereNotType<Accessor>().generateEntries());
+    referenceChildrenBuilder
+        .addAll(definedNamesModelElements.whereNotType<Accessor>().asMapByName);
     // TODO(jcollins-g): warn and get rid of this case where it shows up.
     // If a user is hiding parts of a prefix import, the user should not
     // refer to hidden members via the prefix, because that can be

--- a/lib/src/model/mixin.dart
+++ b/lib/src/model/mixin.dart
@@ -46,8 +46,7 @@ class Mixin extends InheritingContainer with TypeImplementing {
 
   @override
   @visibleForOverriding
-  Iterable<MapEntry<String, CommentReferable>> get extraReferenceChildren =>
-      const [];
+  Map<String, CommentReferable> get extraReferenceChildren => const {};
 
   @override
   bool get hasModifiers => super.hasModifiers || hasPublicSuperclassConstraints;

--- a/lib/src/model/package.dart
+++ b/lib/src/model/package.dart
@@ -398,14 +398,15 @@ class Package extends LibraryContainer
 
   @override
   late final Map<String, CommentReferable> referenceChildren = {
-    for (var library in publicLibrariesSorted) library.referenceName: library,
-  }
-    // Do not override any preexisting data, and insert based on the
-    // public library sort order.
-    // TODO(jcollins-g): warn when results require package-global
-    // lookups like this.
-    ..addEntriesIfAbsent(
-        publicLibrariesSorted.expand((l) => l.referenceChildren.entries));
+    // Do not override any preexisting data, and insert based on the public
+    // library sort order.
+    // TODO(jcollins-g): warn when results require package-global lookups like
+    // this.
+    for (var library in publicLibrariesSorted) ...{
+      library.referenceName: library,
+      ...library.referenceChildren,
+    }
+  };
 
   @override
   Iterable<CommentReferable> get referenceParents => [packageGraph];

--- a/test/src/utils.dart
+++ b/test/src/utils.dart
@@ -301,20 +301,20 @@ Future<void> writeDartdocResources(ResourceProvider resourceProvider) async {
   }
 }
 
-/// For comparison purposes, return an equivalent [MatchingLinkResult]
-/// for the defining element returned.  May return [originalResult].
-/// We do this to eliminate canonicalization effects from comparison,
-/// as the original lookup code returns canonicalized results and the
-/// new lookup code is only guaranteed to return equivalent results.
+/// For comparison purposes, return an equivalent [MatchingLinkResult] for the
+/// defining element returned. May return [originalResult]. We do this to
+/// eliminate canonicalization effects from comparison, as the original lookup
+/// code returns canonicalized results and the new lookup code is only
+/// guaranteed to return equivalent results.
 MatchingLinkResult definingLinkResult(MatchingLinkResult originalResult) {
-  var definingReferable =
-      originalResult.commentReferable?.definingCommentReferable;
-
-  if (definingReferable != null &&
-      definingReferable != originalResult.commentReferable) {
-    return MatchingLinkResult(definingReferable);
+  var commentReferable = originalResult.commentReferable;
+  if (commentReferable == null) {
+    return originalResult;
   }
-  return originalResult;
+  var definingReferable = commentReferable.definingCommentReferable;
+  return definingReferable == originalResult.commentReferable
+      ? originalResult
+      : MatchingLinkResult(definingReferable);
 }
 
 MatchingLinkResult referenceLookup(Warnable element, String codeRef) =>


### PR DESCRIPTION
They are pretty hard to reason about, and also some "put all if absent" code was employed to wrangle them. But it turns out that `a.putAllIfAbsent(b)` is the same as `b.addAll(a)`. So this code can be simplified all around by just using Maps as they are meant to be used.

Also InheritingContainer.extraReferenceChildren is no longer `sync*`, which may represent a performance boost.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
