### PR TITLE
Privatize several members on PackageGraph

### DIFF
--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -12509,18 +12509,6 @@ class _Renderer_Package extends RendererBase<Package> {
                         parent: r);
                   },
                 ),
-                'publicLibraries': Property(
-                  getValue: (CT_ c) => c.publicLibraries,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(
-                          c, remainingNames, 'Iterable<Library>'),
-                  renderIterable: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    return c.publicLibraries.map((e) =>
-                        _render_Library(e, ast, r.template, sink, parent: r));
-                  },
-                ),
                 'referenceChildren': Property(
                   getValue: (CT_ c) => c.referenceChildren,
                   renderVariable: (CT_ c, Property<CT_> self,
@@ -16917,7 +16905,6 @@ const _invisibleGetters = {
   'ModelNode': {'hashCode', 'runtimeType', 'sourceCode'},
   'ModelObjectBuilder': {'hashCode', 'runtimeType'},
   'PackageGraph': {
-    'allCanonicalModelElements',
     'allConstructedModelElements',
     'allExtensionsAdded',
     'allHrefs',
@@ -16933,7 +16920,6 @@ const _invisibleGetters = {
     'defaultPackageName',
     'displayName',
     'documentedExtensions',
-    'documentedPackages',
     'extensions',
     'hasEmbedderSdk',
     'hasFooterVersion',
@@ -16941,7 +16927,6 @@ const _invisibleGetters = {
     'implementors',
     'inheritThrough',
     'inheritanceManager',
-    'invisibleAnnotations',
     'libraries',
     'libraryCount',
     'libraryExports',
@@ -16961,7 +16946,6 @@ const _invisibleGetters = {
     'rendererFactory',
     'resourceProvider',
     'runtimeType',
-    'sdk',
     'sdkLibrarySources',
     'specialClasses'
   },

--- a/lib/src/model/annotation.dart
+++ b/lib/src/model/annotation.dart
@@ -5,6 +5,7 @@
 import 'package:analyzer/dart/element/element.dart';
 import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/model/attribute.dart';
+import 'package:dartdoc/src/model/class.dart';
 import 'package:dartdoc/src/model/getter_setter_combo.dart';
 import 'package:dartdoc/src/model/library.dart';
 import 'package:dartdoc/src/model/model_object_builder.dart';
@@ -56,8 +57,8 @@ class Annotation extends Attribute with ModelBuilder {
   bool get isPublic =>
       modelType.isPublic &&
       modelType is DefinedElementType &&
-      !packageGraph.invisibleAnnotations
-          .contains((modelType as DefinedElementType).modelElement);
+      packageGraph.isAnnotationVisible(
+          (modelType as DefinedElementType).modelElement as Class);
 
   @override
   bool operator ==(Object other) =>

--- a/lib/src/model/annotation.dart
+++ b/lib/src/model/annotation.dart
@@ -54,11 +54,19 @@ class Annotation extends Attribute with ModelBuilder {
   }
 
   @override
-  bool get isPublic =>
-      modelType.isPublic &&
-      modelType is DefinedElementType &&
-      packageGraph.isAnnotationVisible(
-          (modelType as DefinedElementType).modelElement as Class);
+  bool get isPublic {
+    final modelType = this.modelType;
+    if (!modelType.isPublic) {
+      return false;
+    }
+    if (modelType is! DefinedElementType) {
+      return false;
+    }
+
+    var modelElement = modelType.modelElement;
+    return modelElement is Class &&
+        packageGraph.isAnnotationVisible(modelElement);
+  }
 
   @override
   bool operator ==(Object other) =>

--- a/lib/src/model/library.dart
+++ b/lib/src/model/library.dart
@@ -218,8 +218,7 @@ class Library extends ModelElement
 
       nameFromPath = _restoredUri;
       if (nameFromPath.startsWith(schemaToHide)) {
-        nameFromPath =
-            nameFromPath.substring(schemaToHide.length, nameFromPath.length);
+        nameFromPath = nameFromPath.substring(schemaToHide.length);
       }
       if (nameFromPath.endsWith('.dart')) {
         const dartExtensionLength = '.dart'.length;

--- a/lib/src/model/package.dart
+++ b/lib/src/model/package.dart
@@ -254,14 +254,6 @@ class Package extends LibraryContainer
   @override
   Package get package => this;
 
-  // Workaround for mustache4dart issue where templates do not recognize
-  // inherited properties as being in-context.
-  @override
-  Iterable<Library> get publicLibraries {
-    assert(libraries.every((l) => l.packageMeta == packageMeta));
-    return super.publicLibraries;
-  }
-
   /// The default, unnamed category.
   ///
   /// This is initialized by [initializeCategories].

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -36,17 +36,22 @@ import 'package:meta/meta.dart';
 class PackageGraph with CommentReferable, Nameable, ModelBuilder {
   PackageGraph.uninitialized(
     this.config,
-    this.sdk,
+    DartSdk sdk,
     this.hasEmbedderSdk,
     this.rendererFactory,
     this.packageMetaProvider,
-  ) : packageMeta = config.topLevelPackageMeta {
+  )   : packageMeta = config.topLevelPackageMeta,
+        sdkLibrarySources = {
+          for (var lib in sdk.sdkLibraries) sdk.mapDartUri(lib.shortName): lib
+        } {
     // Make sure the default package exists, even if it has no libraries.
     // This can happen for packages that only contain embedder SDKs.
     Package.fromPackageMeta(packageMeta, this);
   }
 
   final InheritanceManager3 inheritanceManager = InheritanceManager3();
+
+  final Map<Source?, SdkLibrary> sdkLibrarySources;
 
   void dispose() {
     // Clear out any cached tool snapshots and temporary directories.
@@ -132,7 +137,7 @@ class PackageGraph with CommentReferable, Nameable, ModelBuilder {
     // Emit warnings for any local package that has no libraries.
     // This must be done after the [allModelElements] traversal to be sure that
     // all packages are picked up.
-    for (var package in documentedPackages) {
+    for (var package in _documentedPackages) {
       for (var library in package.libraries) {
         _addToImplementors(library.allClasses);
         _addToImplementors(library.mixins);
@@ -356,12 +361,6 @@ class PackageGraph with CommentReferable, Nameable, ModelBuilder {
 
   ResourceProvider get resourceProvider => config.resourceProvider;
 
-  final DartSdk sdk;
-
-  late final Map<Source?, SdkLibrary> sdkLibrarySources = {
-    for (var lib in sdk.sdkLibraries) sdk.mapDartUri(lib.shortName): lib
-  };
-
   final Map<String, String> _macros = {};
   final Map<String, String> _htmlFragments = {};
   bool allLibrariesAdded = false;
@@ -491,7 +490,7 @@ class PackageGraph with CommentReferable, Nameable, ModelBuilder {
       publicPackages.where((p) => p.isLocal).toList(growable: false);
 
   /// Documented packages are documented somewhere (local or remote).
-  Iterable<Package> get documentedPackages =>
+  Iterable<Package> get _documentedPackages =>
       packages.where((p) => p.documentedWhere != DocumentLocation.missing);
 
   /// A mapping of all the [Library]s that export a given [LibraryElement].
@@ -671,7 +670,7 @@ class PackageGraph with CommentReferable, Nameable, ModelBuilder {
 
   /// The set of [Class] objects that are similar to 'pragma' in that we should
   /// never count them as documentable annotations.
-  late final Set<Class> invisibleAnnotations = () {
+  late final Set<Class> _invisibleAnnotations = () {
     var pragmaSpecialClass = specialClasses[SpecialClass.pragma];
     if (pragmaSpecialClass == null) {
       return const <Class>{};
@@ -679,8 +678,8 @@ class PackageGraph with CommentReferable, Nameable, ModelBuilder {
     return {pragmaSpecialClass};
   }();
 
-  bool isAnnotationVisible(Class clazz) =>
-      !invisibleAnnotations.contains(clazz);
+  bool isAnnotationVisible(Class class_) =>
+      !_invisibleAnnotations.contains(class_);
 
   @override
   String toString() {
@@ -897,9 +896,6 @@ class PackageGraph with CommentReferable, Nameable, ModelBuilder {
     for (var library in _localLibraries) ...library.allModelElements
   ];
 
-  Iterable<ModelElement> get allCanonicalModelElements =>
-      allLocalModelElements.where((e) => e.isCanonical);
-
   /// Glob lookups can be expensive.  Cache per filename.
   final _configSetsNodocFor = HashMap<String, bool>();
 
@@ -958,7 +954,7 @@ class PackageGraph with CommentReferable, Nameable, ModelBuilder {
     // on ambiguous resolution (see below) will change where they
     // resolve based on internal implementation details.
     var sortedPackages = packages.toList(growable: false)..sort(byName);
-    var sortedDocumentedPackages = documentedPackages.toList(growable: false)
+    var sortedDocumentedPackages = _documentedPackages.toList(growable: false)
       ..sort(byName);
     // Packages are the top priority.
     children.addEntries(sortedPackages.generateEntries());

--- a/test/options_test.dart
+++ b/test/options_test.dart
@@ -217,7 +217,8 @@ An example in an unusual dir.
     );
     final packageGraph =
         await (await createPackageBuilder()).buildPackageGraph();
-    final classFoo = packageGraph.allCanonicalModelElements
+    final classFoo = packageGraph.allLocalModelElements
+        .where((e) => e.isCanonical)
         .whereType<Class>()
         .firstWhere((c) => c.name == 'Foo');
     expect(classFoo.documentationAsHtml,
@@ -366,7 +367,8 @@ class Foo {}
     );
     final packageGraph =
         await (await createPackageBuilder()).buildPackageGraph();
-    final classFoo = packageGraph.allCanonicalModelElements
+    final classFoo = packageGraph.allLocalModelElements
+        .where((e) => e.isCanonical)
         .whereType<Class>()
         .firstWhere((c) => c.name == 'Foo');
     expect(classFoo.displayedCategories, isNotEmpty);


### PR DESCRIPTION
* Privatize `PackageGraph.documentedPackages`, `PackageGraph.invisibleAnnotations`,
* Remove `Package.publicLibraries`, just inline into one call site.
* Remove `PackageGraph.sdk`, which was only used to initialize `sdkLibrarySources`, and `PackageGraph.allCanonicalModelElements`, inlining into the one call site.
* Initialize `sdkLibrarySources` in the constructor.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
