### PR TITLE
Move several E2E integration test cases to options_test

### DIFF
--- a/lib/options.dart
+++ b/lib/options.dart
@@ -127,7 +127,11 @@ DartdocProgramOptionContext? parseOptions(
     exitCode = 64;
     return null;
   }
-  startLogging(config);
+  startLogging(
+    isJson: config.json,
+    isQuiet: config.quiet,
+    showProgress: config.showProgress,
+  );
   return config;
 }
 

--- a/test/end2end/dartdoc_integration_test.dart
+++ b/test/end2end/dartdoc_integration_test.dart
@@ -60,60 +60,6 @@ void main() {
       ]);
     });
 
-    test('with --no-generate-docs is quiet and does not generate docs',
-        () async {
-      var process = await runDartdoc(
-        ['--no-generate-docs'],
-        workingDirectory: packagePath,
-      );
-      await expectLater(
-          process.stderr, emitsThrough('Found 1 warning and 0 errors.'));
-      await process.shouldExit(0);
-      var docs = Directory(path.join(packagePath, 'doc', 'api'));
-      expect(docs.existsSync(), isFalse);
-    });
-
-    test('with --quiet is quiet and does generate docs', () async {
-      var process = await runDartdoc(
-        ['--quiet'],
-        workingDirectory: packagePath,
-      );
-      await expectLater(process.stderr, emitsThrough(matches('^  warning:')));
-      await expectLater(
-          process.stderr, emitsThrough('Found 1 warning and 0 errors.'));
-      await process.shouldExit(0);
-      var indexHtml = Directory(path.join(packagePath, 'doc', 'api'));
-      expect(indexHtml.listSync(), isNotEmpty);
-    });
-
-    test('with invalid options return non-zero and print a fatal-error',
-        () async {
-      var process = await runDartdoc(
-        ['--nonexisting'],
-        workingDirectory: packagePath,
-      );
-      await expectLater(
-          process.stderr,
-          emitsThrough(
-              ' fatal error: Could not find an option named "nonexisting".'));
-      await process.shouldExit(64);
-    });
-
-    test('missing a required file path prints a fatal error', () async {
-      var process = await runDartdoc(
-        ['--input', 'non-existant'],
-        workingDirectory: packagePath,
-      );
-      var fullPath = path.canonicalize(path.join(packagePath, 'non-existant'));
-      await expectLater(
-        process.stderr,
-        emitsThrough(
-            ' fatal error: Argument --input, set to non-existant, resolves to '
-            'missing path: "$fullPath"'),
-      );
-      await process.shouldExit(64);
-    });
-
     test('with --help prints command line args', () async {
       var process = await runDartdoc(
         ['--help'],
@@ -134,22 +80,6 @@ void main() {
       var dartdocMeta = pubPackageMetaProvider.fromFilename(_dartdocPath)!;
       await expectLater(process.stdout,
           emitsThrough('dartdoc version: ${dartdocMeta.version}'));
-      await process.shouldExit(0);
-    });
-
-    test('Validate JSON output', () async {
-      var process = await runDartdoc(
-        [
-          //dartdocPath,
-          '--no-include-source',
-          '--json',
-        ],
-        workingDirectory: packagePath,
-      );
-      await expectLater(
-          process.stdout,
-          emitsThrough(
-              '{"level":"WARNING","message":"Found 1 warning and 0 errors."}'));
       await process.shouldExit(0);
     });
   });

--- a/test/end2end/dartdoc_test.dart
+++ b/test/end2end/dartdoc_test.dart
@@ -50,10 +50,7 @@ void main() {
           [createDartdocProgramOptions, createLoggingOptions],
           pubPackageMetaProvider);
       optionSet.parseArguments([]);
-      startLogging(DartdocLoggingOptionContext(
-          optionSet,
-          _resourceProvider.getFolder(_pathContext.current),
-          _resourceProvider));
+      startLogging(isJson: false, isQuiet: true, showProgress: false);
 
       // Set up the pub metadata for our test packages.
       runPubGet(testPackageToolError.path);

--- a/test/options_test.dart
+++ b/test/options_test.dart
@@ -632,9 +632,9 @@ class Foo {}
     // With the `--quiet` option, nothing should be printed to stdout, and only
     // warnings should be printed to stderr.
     expect(outBuffer, isEmpty);
-    expect(errBuffer.toString(), equals('''
+    expect(errBuffer.toString(), matches(r'''
   warning: library_1 has no library level documentation comments
-    from library_1: (file:///temp/test_package/lib/library_1.dart:1:9)
+    from library_1: \(.*lib/library_1.dart:1:9\)
 Found 1 warning and 0 errors.
 '''));
   });
@@ -661,9 +661,9 @@ class Foo {}
     // With the `--no-generate-docs` option, nothing should be printed to
     // stdout, and only warnings should be printed to stderr.
     expect(outBuffer, isEmpty);
-    expect(errBuffer.toString(), equals('''
+    expect(errBuffer.toString(), equals(r'''
   warning: library_1 has no library level documentation comments
-    from library_1: (file:///temp/test_package/lib/library_1.dart:1:9)
+    from library_1: \(.*lib/library_1.dart:1:9\)
 Found 1 warning and 0 errors.
 '''));
 

--- a/test/options_test.dart
+++ b/test/options_test.dart
@@ -632,11 +632,11 @@ class Foo {}
     // With the `--quiet` option, nothing should be printed to stdout, and only
     // warnings should be printed to stderr.
     expect(outBuffer, isEmpty);
-    expect(errBuffer.toString(), matches(r'''
+    expect(errBuffer.toString(), matches(RegExp(r'''
   warning: library_1 has no library level documentation comments
     from library_1: \(.*lib/library_1.dart:1:9\)
 Found 1 warning and 0 errors.
-'''));
+''')));
   });
 
   test(
@@ -661,11 +661,11 @@ class Foo {}
     // With the `--no-generate-docs` option, nothing should be printed to
     // stdout, and only warnings should be printed to stderr.
     expect(outBuffer, isEmpty);
-    expect(errBuffer.toString(), equals(r'''
+    expect(errBuffer.toString(), matches(RegExp(r'''
   warning: library_1 has no library level documentation comments
     from library_1: \(.*lib/library_1.dart:1:9\)
 Found 1 warning and 0 errors.
-'''));
+''')));
 
     final outputDirectory = resourceProvider.getFolder(
       path.join(packagePath, 'doc', 'api'),

--- a/test/src/utils.dart
+++ b/test/src/utils.dart
@@ -16,6 +16,7 @@ import 'package:dartdoc/src/dartdoc_options.dart';
 import 'package:dartdoc/src/failure.dart';
 import 'package:dartdoc/src/generator/generator.dart';
 import 'package:dartdoc/src/generator/resource_loader.dart';
+import 'package:dartdoc/src/logging.dart';
 import 'package:dartdoc/src/markdown_processor.dart';
 import 'package:dartdoc/src/matching_link_result.dart';
 import 'package:dartdoc/src/model/model_element.dart';
@@ -59,12 +60,15 @@ Future<DartdocOptionContext> contextFromArgv(
 Future<DartdocGeneratorOptionContext> generatorContextFromArgv(
     List<String> argv, PackageMetaProvider packageMetaProvider) async {
   var optionSet = DartdocOptionRoot.fromOptionGenerators(
-      'dartdoc',
-      [
-        createDartdocOptions,
-        createGeneratorOptions,
-      ],
-      packageMetaProvider);
+    'dartdoc',
+    [
+      createDartdocProgramOptions,
+      createLoggingOptions,
+      createDartdocOptions,
+      createGeneratorOptions,
+    ],
+    packageMetaProvider,
+  );
   optionSet.parseArguments(argv);
   return DartdocGeneratorOptionContext.fromDefaultContextLocation(
       optionSet, packageMetaProvider.resourceProvider);


### PR DESCRIPTION
Some tests in `dartdoc_integration_test` were flaking on the the Mac bot, timing out. I still have no idea why, but converting them to smaller tests may fix the issue (might be in processing stdout of the external application). If they're still flaky, we can diagnose them better as unit tests.

In moving these test cases, `dartdoc_integration_test` takes 110 fewer seconds, and `options_test` takes 2 more seconds.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
