### PR TITLE
Deprecate public exports in lib/dartdoc.dart.

### DIFF
--- a/bin/dartdoc.dart
+++ b/bin/dartdoc.dart
@@ -6,8 +6,11 @@ library dartdoc.bin;
 
 import 'dart:async';
 
-import 'package:dartdoc/dartdoc.dart';
 import 'package:dartdoc/options.dart';
+import 'package:dartdoc/src/dartdoc.dart';
+import 'package:dartdoc/src/model/model.dart';
+import 'package:dartdoc/src/package_config_provider.dart';
+import 'package:dartdoc/src/package_meta.dart';
 
 /// Analyzes Dart files and generates a representation of included libraries,
 /// classes, and members. Uses the current directory to look for libraries.

--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// A documentation generator for Dart.
+@Deprecated('Will be removed in a later version of DartDoc.')
 library dartdoc;
 
 export 'package:dartdoc/src/dartdoc.dart';

--- a/lib/options.dart
+++ b/lib/options.dart
@@ -1,7 +1,7 @@
 import 'dart:io' show stderr, exitCode;
 
 import 'package:args/args.dart';
-import 'package:dartdoc/dartdoc.dart' show dartdocVersion, programName;
+import 'package:dartdoc/src/dartdoc.dart' show dartdocVersion, programName;
 import 'package:dartdoc/src/dartdoc_options.dart';
 import 'package:dartdoc/src/generator/generator.dart';
 import 'package:dartdoc/src/logging.dart';

--- a/test/end2end/dartdoc_test.dart
+++ b/test/end2end/dartdoc_test.dart
@@ -7,8 +7,8 @@ library dartdoc.dartdoc_test;
 import 'dart:async';
 
 import 'package:analyzer/file_system/file_system.dart';
-import 'package:dartdoc/dartdoc.dart' show Dartdoc, DartdocResults;
 import 'package:dartdoc/options.dart';
+import 'package:dartdoc/src/dartdoc.dart' show Dartdoc, DartdocResults;
 import 'package:dartdoc/src/dartdoc_options.dart';
 import 'package:dartdoc/src/failure.dart';
 import 'package:dartdoc/src/io_utils.dart';

--- a/test/html_generator_test.dart
+++ b/test/html_generator_test.dart
@@ -4,8 +4,8 @@
 
 import 'package:analyzer/file_system/file_system.dart';
 import 'package:analyzer/file_system/memory_file_system.dart';
-import 'package:dartdoc/dartdoc.dart' show DartdocFileWriter;
 import 'package:dartdoc/options.dart';
+import 'package:dartdoc/src/dartdoc.dart' show DartdocFileWriter;
 import 'package:dartdoc/src/dartdoc_options.dart';
 import 'package:dartdoc/src/generator/generator.dart';
 import 'package:dartdoc/src/generator/generator_backend.dart';

--- a/test/mustachio/renderers_output_test.dart
+++ b/test/mustachio/renderers_output_test.dart
@@ -9,8 +9,8 @@ import 'dart:io';
 
 import 'package:analyzer/file_system/file_system.dart';
 import 'package:analyzer/file_system/memory_file_system.dart';
-import 'package:dartdoc/dartdoc.dart' show Dartdoc, DartdocFileWriter;
 import 'package:dartdoc/options.dart';
+import 'package:dartdoc/src/dartdoc.dart' show Dartdoc, DartdocFileWriter;
 import 'package:dartdoc/src/dartdoc_options.dart';
 import 'package:dartdoc/src/generator/generator.dart';
 import 'package:dartdoc/src/generator/html_generator.dart';


### PR DESCRIPTION
Public exports deprecated for 8.0.1 bump eventually and will be fully removed in 9.0.0.
- Updated the tests to avoid using the import.



---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
