### PR TITLE
Remove 'format' flag and most markdown dependencies.

### DIFF
--- a/lib/src/dartdoc.dart
+++ b/lib/src/dartdoc.dart
@@ -12,7 +12,6 @@ import 'package:dartdoc/src/failure.dart';
 import 'package:dartdoc/src/generator/empty_generator.dart';
 import 'package:dartdoc/src/generator/generator.dart';
 import 'package:dartdoc/src/generator/html_generator.dart';
-import 'package:dartdoc/src/generator/markdown_generator.dart';
 import 'package:dartdoc/src/logging.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/package_meta.dart';
@@ -173,15 +172,10 @@ class Dartdoc {
       maxFileCount: context.maxFileCount,
       maxTotalSize: context.maxTotalSize,
     );
-    var generator = await switch (context.format) {
-      'html' => initHtmlGenerator(context, writer: writer),
-      'md' => initMarkdownGenerator(context, writer: writer),
-      _ => throw DartdocFailure('Unsupported output format: ${context.format}')
-    };
     return Dartdoc._(
       context,
       outputDir,
-      generator,
+      await initHtmlGenerator(context, writer: writer),
       packageBuilder,
     );
   }

--- a/lib/src/dartdoc_options.dart
+++ b/lib/src/dartdoc_options.dart
@@ -1330,9 +1330,6 @@ class DartdocOptionContext extends DartdocOptionContextBase
 
   bool get showStats => optionSet['showStats'].valueAt(context);
 
-  /// Output format, e.g. 'html', 'md'
-  String get format => optionSet['format'].valueAt(context);
-
   // TODO(jdkoren): temporary while we confirm href base behavior doesn't break
   // important clients
   bool get useBaseHref => optionSet['useBaseHref'].valueAt(context);
@@ -1712,10 +1709,6 @@ List<DartdocOption> createDartdocOptions(
         hide: true),
     DartdocOptionArgOnly<bool>('showStats', false, resourceProvider,
         help: 'Show statistics useful for debugging.', hide: true),
-    DartdocOptionArgOnly<String>('format', 'html', resourceProvider,
-        help: 'The format of documentation to generate: `md` for markdown, '
-            '`html` for html.',
-        hide: false),
     DartdocOptionArgOnly<String>('maxFileCount', '0', resourceProvider,
         help:
             'The maximum number of files dartdoc is allowed to create (0 for no limit).',

--- a/lib/src/generator/templates.dart
+++ b/lib/src/generator/templates.dart
@@ -118,23 +118,17 @@ abstract class Templates {
   static Future<Templates> fromContext(DartdocGeneratorOptionContext context,
       {bool forceRuntimeTemplates = false}) async {
     var templatesDir = context.templatesDir;
-    var format = context.format;
-
     if (templatesDir != null) {
       return RuntimeTemplates._create(
-          context.resourceProvider.getFolder(templatesDir), format,
+          context.resourceProvider.getFolder(templatesDir),
           resourceProvider: context.resourceProvider);
     } else if (forceRuntimeTemplates) {
       var directory = await context.resourceProvider
-          .getResourceFolder('package:dartdoc/templates/$format');
-      return RuntimeTemplates._create(directory, format,
+          .getResourceFolder('package:dartdoc/templates/html');
+      return RuntimeTemplates._create(directory,
           resourceProvider: context.resourceProvider);
-    } else if (format == 'html') {
-      return HtmlAotTemplates();
-    } else if (format == 'md') {
-      return MarkdownAotTemplates();
     } else {
-      throw ArgumentError.value(format, 'format');
+      return HtmlAotTemplates();
     }
   }
 }
@@ -393,17 +387,17 @@ class RuntimeTemplates implements Templates {
   final Template _typedefTemplate;
 
   /// Creates a [Templates] from a custom set of template files, found in [dir].
-  static Future<Templates> _create(Folder dir, String format,
+  static Future<Templates> _create(Folder dir,
       {required ResourceProvider resourceProvider}) async {
     Future<Template> loadTemplate(String templatePath) {
-      var templateFile = dir.getChildAssumingFile('$templatePath.$format');
+      var templateFile = dir.getChildAssumingFile('$templatePath.html');
       if (!templateFile.exists) {
         throw DartdocFailure(
-            'Missing required template file: $templatePath.$format');
+            'Missing required template file: $templatePath.html');
       }
       return Template.parse(templateFile,
           partialResolver: (String partialName) async =>
-              dir.getChildAssumingFile('_$partialName.$format'));
+              dir.getChildAssumingFile('_$partialName.html'));
     }
 
     var indexTemplate = await loadTemplate('index');

--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -16375,7 +16375,6 @@ const _invisibleGetters = {
     'exclude',
     'excludeFooterVersion',
     'flutterRoot',
-    'format',
     'hashCode',
     'include',
     'includeExternal',
@@ -16626,7 +16625,6 @@ const _invisibleGetters = {
   'FileStructure': {
     'dirName',
     'fileName',
-    'fileType',
     'hasIndependentFile',
     'hashCode',
     'href',

--- a/lib/src/model/class.dart
+++ b/lib/src/model/class.dart
@@ -24,8 +24,7 @@ class Class extends InheritingContainer
   ];
 
   @override
-  String get sidebarPath =>
-      '${library.dirName}/$name-class-sidebar.${fileStructure.fileType}';
+  String get sidebarPath => '${library.dirName}/$name-class-sidebar.html';
 
   @override
   late final List<InheritingContainer> inheritanceChain = [

--- a/lib/src/model/enum.dart
+++ b/lib/src/model/enum.dart
@@ -35,8 +35,7 @@ class Enum extends InheritingContainer
   ];
 
   @override
-  String get sidebarPath =>
-      '${library.dirName}/$name-enum-sidebar.${fileStructure.fileType}';
+  String get sidebarPath => '${library.dirName}/$name-enum-sidebar.html';
 
   @override
   Kind get kind => Kind.enum_;

--- a/lib/src/model/extension.dart
+++ b/lib/src/model/extension.dart
@@ -97,8 +97,7 @@ class Extension extends Container implements EnclosedElement {
   String get filePath => '${library.dirName}/${fileStructure.fileName}';
 
   @override
-  String get sidebarPath =>
-      '${library.dirName}/$name-extension-sidebar.${fileStructure.fileType}';
+  String get sidebarPath => '${library.dirName}/$name-extension-sidebar.html';
 
   Map<String, CommentReferable>? _referenceChildren;
   @override

--- a/lib/src/model/extension_type.dart
+++ b/lib/src/model/extension_type.dart
@@ -71,7 +71,7 @@ class ExtensionType extends InheritingContainer
 
   @override
   String get sidebarPath =>
-      '${library.dirName}/$name-extension-type-sidebar.${fileStructure.fileType}';
+      '${library.dirName}/$name-extension-type-sidebar.html';
 
   Map<String, CommentReferable>? _referenceChildren;
   @override

--- a/lib/src/model/field.dart
+++ b/lib/src/model/field.dart
@@ -141,8 +141,7 @@ class Field extends ModelElement
   }
 
   @override
-  String get fileName =>
-      '${isConst ? '$name-constant' : name}.${fileStructure.fileType}';
+  String get fileName => '${isConst ? '$name-constant' : name}.html';
 
   @override
   String get aboveSidebarPath => enclosingElement.sidebarPath;

--- a/lib/src/model/library.dart
+++ b/lib/src/model/library.dart
@@ -250,8 +250,7 @@ class Library extends ModelElement
   @override
   String get filePath => '${library.dirName}/${fileStructure.fileName}';
 
-  String get sidebarPath =>
-      '${library.dirName}/$dirName-library-sidebar.${fileStructure.fileType}';
+  String get sidebarPath => '${library.dirName}/$dirName-library-sidebar.html';
 
   /// The library template manually includes 'packages' in the left/above
   /// sidebar.

--- a/lib/src/model/mixin.dart
+++ b/lib/src/model/mixin.dart
@@ -24,8 +24,7 @@ class Mixin extends InheritingContainer with TypeImplementing {
   ];
 
   @override
-  String get sidebarPath =>
-      '${library.dirName}/$name-mixin-sidebar.${fileStructure.fileType}';
+  String get sidebarPath => '${library.dirName}/$name-mixin-sidebar.html';
 
   @override
   late final List<InheritingContainer> inheritanceChain = [

--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -600,8 +600,9 @@ abstract class ModelElement extends Canonicalization
   @Deprecated('replace with fileStructure.fileName')
   String get fileName => fileStructure.fileName;
 
-  @Deprecated('replace with fileStructure.fileType')
-  String get fileType => fileStructure.fileType;
+  @Deprecated('Will be removed.')
+  // TODO(kallentu): Remove the usages of this getter to default to html.
+  String get fileType => 'html';
 
   /// The full path of the output file in which this element will be primarily
   /// documented.

--- a/lib/src/model/package.dart
+++ b/lib/src/model/package.dart
@@ -198,9 +198,8 @@ class Package extends LibraryContainer
   // In theory, a remote package could be documented in any supported format.
   // In practice, devs depend on Dart, Flutter, and/or packages fetched
   // from pub.dev, and we know that all of those use html docs.
-  String get fileType => package.documentedWhere == DocumentLocation.remote
-      ? 'html'
-      : config.format;
+  // TODO(kallentu): Remove the usages of this getter to default to html.
+  String get fileType => 'html';
 
   @override
   String get fullyQualifiedName => 'package:$name';

--- a/lib/src/model/package_builder.dart
+++ b/lib/src/model/package_builder.dart
@@ -64,7 +64,7 @@ class PubPackageBuilder implements PackageBuilder {
       }
     }
 
-    var rendererFactory = RendererFactory.forFormat(_config.format);
+    var rendererFactory = const HtmlRenderFactory();
     runtimeStats.resetAccumulators([
       'elementTypeInstantiation',
       'modelElementCacheInsertion',

--- a/lib/src/render/renderer_factory.dart
+++ b/lib/src/render/renderer_factory.dart
@@ -22,6 +22,7 @@ abstract class RendererFactory {
   /// Retrieves the appropriate [RendererFactory] according to the
   /// specified [format]. Currently supports `html` or `md` otherwise
   /// throws an [ArgumentError].
+  // TODO(kallentu): Remove.
   factory RendererFactory.forFormat(String format) => switch (format) {
         'html' => const HtmlRenderFactory(),
         'md' => MdRenderFactory(),

--- a/test/generator/file_structure_test.dart
+++ b/test/generator/file_structure_test.dart
@@ -71,18 +71,4 @@ Hello there, I am an *amazing* markdown file.
     expect(aMethod.fileStructure.fileName, equals('aMethod.html'));
     expect(operatorPlus.fileStructure.fileName, equals('operator_plus.html'));
   }
-
-  void test_fileNamesForMarkdownElements() async {
-    var library = await bootPackageWithLibrary('''
-class AClass {
-}
-''', additionalArguments: ['--format=md']);
-    var AClass = library.classes.named('AClass');
-    // The inherited toString implementation is not canonical, so be sure
-    // to get the canonical reference.
-    var AClassToString =
-        AClass.inheritedMethods.named('toString').canonicalModelElement!;
-    expect(AClass.fileStructure.fileName, equals('AClass-class.md'));
-    expect(AClassToString.fileStructure.fileName, equals('toString.html'));
-  }
 }

--- a/test/options_test.dart
+++ b/test/options_test.dart
@@ -197,41 +197,6 @@ An example in an unusual dir.
         contains('<code class="language-dart">An example in an unusual dir.'));
   }
 
-  void test_formatOption_md_generatesMarkdownFiles() async {
-    await createPackage(
-      packageName,
-      libFiles: [
-        d.file('library_1.dart', '''
-library library_1;
-class Foo {}
-'''),
-      ],
-    );
-    await (await buildDartdoc(additionalArguments: ['--format', 'md']))
-        .generateDocsBase();
-    final indexContent = resourceProvider
-        .getFile(
-            path.joinAll([packagePath, 'doc', 'library_1', 'Foo-class.md']))
-        .readAsStringSync();
-    expect(indexContent, contains('# Foo class'));
-  }
-
-  void test_formatOption_bad_resultsInDartdocFailure() async {
-    await createPackage(
-      packageName,
-      libFiles: [
-        d.file('library_1.dart', '''
-library library_1;
-class Foo {}
-'''),
-      ],
-    );
-    expect(
-        () => buildDartdoc(additionalArguments: ['--format', 'bad']),
-        throwsA(const TypeMatcher<DartdocFailure>().having((f) => f.message,
-            'message', startsWith('Unsupported output format'))));
-  }
-
   void test_includeOption_canBeSpecifiedInOptionsFile() async {
     await createPackage(
       packageName,


### PR DESCRIPTION
Relevant work for https://github.com/dart-lang/dartdoc/issues/3535.

Part 1 of removing markdown in Dartdoc. I added TODOs for the parts I'll include next CL, I prefer doing this in smaller chunks (for example, made a todo in `RendererFactory` because I'll do the larger removal later.).

- Removed the `format` option.
- For behaviour that relied on that flag result, defaulted to `html`.
- Removed markdown specific tests.
- Removed format option tests.

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
