### PR TITLE
Stop relying on language version 2.0 in dartdoc tests.

### DIFF
--- a/test/src/utils.dart
+++ b/test/src/utils.dart
@@ -215,13 +215,13 @@ two:lib/
       "name": "one",
       "rootUri": "../../one",
       "packageUri": "lib/",
-      "languageVersion": "2.0"
+      "languageVersion": "3.0"
     },
     {
       "name": "two",
       "rootUri": "../",
       "packageUri": "lib/",
-      "languageVersion": "2.0"
+      "languageVersion": "3.0"
     }
   ],
   "generated": "2020-07-07T15:25:30.566271Z",


### PR DESCRIPTION
Dart no longer supports language versions prior to 2.12, so dartdoc tests need to use a modern language version.

Changing the tests to use a language version of 3.0 helps unblock the removal of legacy (pre-null-safety) support from the Dart analyzer.

- Thanks for your contribution! Please replace this text with a description of what this PR is changing or adding and why, list any relevant issues, and review the contribution guidelines below.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
