### PR TITLE
Write out extension type constructor docs

### DIFF
--- a/lib/src/generator/generator_frontend.dart
+++ b/lib/src/generator/generator_frontend.dart
@@ -194,6 +194,15 @@ class GeneratorFrontEnd implements Generator {
           _generatorBackend.generateExtensionType(
               packageGraph, lib, extensionType);
 
+          for (var constructor
+              in filterNonDocumented(extensionType.constructors)) {
+            if (!constructor.isCanonical) continue;
+
+            indexAccumulator.add(constructor);
+            _generatorBackend.generateConstructor(
+                packageGraph, lib, extensionType, constructor);
+          }
+
           for (var constant
               in filterNonDocumented(extensionType.constantFields)) {
             indexAccumulator.add(constant);

--- a/test/templates/extension_type_test.dart
+++ b/test/templates/extension_type_test.dart
@@ -89,7 +89,7 @@ class FooSub extends Foo<int> {}
 
 extension type One<E>(Foo<E> it) {
   /// A named constructor.
-  MyIterable.named(Foo<E> e);
+  One.named(Foo<E> e);
 
   /// An instance method.
   void m1() {}
@@ -143,6 +143,28 @@ dartdoc:
         matches(
           '<span class="kind-class">One&lt;<wbr>'
           '<span class="type-parameter">E</span>&gt;</span>',
+        )
+      ]);
+    });
+
+    test('primary constructor page is rendered', () async {
+      var constructorPageLines = resourceProvider
+          .readLines([packagePath, 'doc', 'lib', 'One', 'One.html']);
+      constructorPageLines.expectMainContentContainsAllInOrder([
+        matches(
+          '<span class="kind-constructor">One&lt;<wbr>'
+          '<span class="type-parameter">E</span>&gt;</span> constructor',
+        )
+      ]);
+    });
+
+    test('named constructor page is rendered', () async {
+      var constructorPageLines = resourceProvider
+          .readLines([packagePath, 'doc', 'lib', 'One', 'One.named.html']);
+      constructorPageLines.expectMainContentContainsAllInOrder([
+        matches(
+          '<span class="kind-constructor">One&lt;<wbr>'
+          '<span class="type-parameter">E</span>&gt;.named</span> constructor',
         )
       ]);
     });
@@ -209,18 +231,13 @@ dartdoc:
       ]);
     });
 
-    test(
-      'page contains (static) constants',
-      // TODO(srawlins): Implement.
-      skip: true,
-      () async {
-        oneLines.expectMainContentContainsAllInOrder([
-          matches('<h2>Constants</h2>'),
-          matches('<a href="../lib/One/c1-constant.html">c1</a>'),
-          matches('A constant.'),
-        ]);
-      },
-    );
+    test('page contains (static) constants', () async {
+      oneLines.expectMainContentContainsAllInOrder([
+        matches('<h2>Constants</h2>'),
+        matches('<a href="../lib/One/c1-constant.html">c1</a>'),
+        matches('A constant.'),
+      ]);
+    });
 
     test('page contains representation field', () async {
       oneLines.expectMainContentContainsAllInOrder([


### PR DESCRIPTION
I somehow forgot extension type constructor docs. Here we generate extension type constructor docs, and tests.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
