### PR TITLE
Remove padding around inner frame

### DIFF
--- a/lib/resources/styles.css
+++ b/lib/resources/styles.css
@@ -164,7 +164,6 @@ main {
   flex: 1;
   display: flex;
   flex-direction: row;
-  padding: 20px;
   min-height: 0;
 }
 


### PR DESCRIPTION
This leads to weird spacing at the bottom of the page, and generally the docs look better with this padding removed on all sides.