### PR TITLE
Fix breadcrumbs for google3

### DIFF
--- a/lib/src/model/library.dart
+++ b/lib/src/model/library.dart
@@ -330,8 +330,17 @@ class Library extends ModelElement
   String get _importPath {
     // This code should not be used for Dart SDK libraries.
     assert(!element.source.uri.isScheme('dart'));
-    var relativePath = pathContext.relative(element.source.fullName,
-        from: package.packagePath);
+    var fullName = element.source.fullName;
+     if (!pathContext.isWithin(fullName, package.packagePath) &&
+         package.packagePath.contains('/google3/')) {
+       // In google3, `fullName` is specified as if the root of google3 was `/`.
+       // And `package.packagePath` contains the true google3 root.
+       var root = pathContext
+           .joinAll(pathContext.split(package.packagePath)..removeLast());
+       fullName = '$root$fullName';
+     }
+     var relativePath =
+         pathContext.relative(fullName, from: package.packagePath);
     assert(relativePath.startsWith('lib${pathContext.separator}'));
     const libDirectoryLength = 'lib/'.length;
     return relativePath.substring(libDirectoryLength);


### PR DESCRIPTION
google3's `fullName` implementation is causing ugly breadcrumb text with lots of `../../../` inside. This fixes it.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
