### PR TITLE
no longer write the dartdoc version into generated html files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 8.0.4-wip
 
 * Remove explicit library names. (#3609)
+* No longer write the dartdoc version into generated html files.
 
 ## 8.0.3
 

--- a/lib/src/generator/templates.aot_renderers_for_html.dart
+++ b/lib/src/generator/templates.aot_renderers_for_html.dart
@@ -3499,14 +3499,7 @@ String _deduplicated_lib_templates_html__head_html(TemplateDataBase context0) {
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1, user-scalable=no">''');
-  if (context0.includeVersion) {
-    buffer.writeln();
-    buffer.write('''
-  <meta name="generator" content="made with love by dartdoc">''');
-  }
-  buffer.writeln();
-  buffer.write('''
+  <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1, user-scalable=no">
   <meta name="description" content="''');
   buffer.writeEscaped(context0.metaDescription);
   buffer.write('''">

--- a/lib/src/generator/templates.aot_renderers_for_html.dart
+++ b/lib/src/generator/templates.aot_renderers_for_html.dart
@@ -3503,9 +3503,7 @@ String _deduplicated_lib_templates_html__head_html(TemplateDataBase context0) {
   if (context0.includeVersion) {
     buffer.writeln();
     buffer.write('''
-  <meta name="generator" content="made with love by dartdoc ''');
-    buffer.writeEscaped(context0.version);
-    buffer.write('''">''');
+  <meta name="generator" content="made with love by dartdoc">''');
   }
   buffer.writeln();
   buffer.write('''

--- a/lib/templates/html/_head.html
+++ b/lib/templates/html/_head.html
@@ -5,7 +5,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1, user-scalable=no">
   {{#includeVersion}}
-  <meta name="generator" content="made with love by dartdoc {{version}}">
+  <meta name="generator" content="made with love by dartdoc">
   {{/includeVersion}}
   <meta name="description" content="{{ metaDescription }}">
   <title>{{ title }}</title>

--- a/lib/templates/html/_head.html
+++ b/lib/templates/html/_head.html
@@ -4,9 +4,6 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1, user-scalable=no">
-  {{#includeVersion}}
-  <meta name="generator" content="made with love by dartdoc">
-  {{/includeVersion}}
   <meta name="description" content="{{ metaDescription }}">
   <title>{{ title }}</title>
   {{ #relCanonicalPrefix }}


### PR DESCRIPTION
- no longer write the dartdoc version into generated html files
- fully or partially alleviate https://github.com/dart-lang/dartdoc/issues/3562

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
