### PR TITLE
add support for github style markdown alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Remove explicit library names. (#3609)
 * No longer write the dartdoc version into generated html files.
+* Add support for GitHub markdown alert syntax
+  (https://docs.github.com/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts).
 
 ## 8.0.3
 

--- a/lib/resources/styles.css
+++ b/lib/resources/styles.css
@@ -1197,3 +1197,67 @@ li.inherited a {
    content: "" !important;
   }
 }
+
+/* github alert styles */
+
+.markdown-alert {
+  padding: .5rem 1rem;
+  border-left: 0.25em solid var(--main-sidebar-color);
+  margin-bottom: 1rem;
+}
+
+.markdown-body p {
+  margin-top: 0;
+  margin-bottom: 16px;
+}
+
+.markdown-alert>:last-child {
+  margin-bottom: 0;
+}
+
+.markdown-alert-title {
+  font-weight: 600;
+  color: var(--main-sidebar-color);
+}
+
+/* note, tip, important, warning, caution */
+
+.markdown-alert-note {
+  border-left-color: var(--main-tag-color);
+}
+
+.markdown-alert-note .markdown-alert-title {
+  color: var(--main-tag-color);
+}
+
+.markdown-alert-tip {
+  border-left-color: var(--main-var-color);
+}
+
+.markdown-alert-tip .markdown-alert-title {
+  color: var(--main-var-color);
+}
+
+.markdown-alert-important {
+  border-left-color: var(--main-comment-color);
+}
+
+.markdown-alert-important .markdown-alert-title {
+  color: var(--main-comment-color);
+}
+
+.markdown-alert-warning {
+  border-left-color: var(--main-section-color);
+}
+
+.markdown-alert-warning .markdown-alert-title {
+  color: var(--main-section-color);
+}
+
+.markdown-alert-caution {
+  border-left-color: var(--main-string-color);
+}
+
+.markdown-alert-caution .markdown-alert-title {
+  color: var(--main-string-color);
+}

--- a/lib/resources/styles.css
+++ b/lib/resources/styles.css
@@ -1216,18 +1216,18 @@ li.inherited a {
 }
 
 .markdown-alert-title {
-  font-weight: 600;
+  font-weight: 500;
   color: var(--main-sidebar-color);
 }
 
 /* note, tip, important, warning, caution */
 
 .markdown-alert-note {
-  border-left-color: var(--main-tag-color);
+  border-left-color: var(--main-hyperlinks-color);
 }
 
 .markdown-alert-note .markdown-alert-title {
-  color: var(--main-tag-color);
+  color: var(--main-hyperlinks-color);
 }
 
 .markdown-alert-tip {
@@ -1239,25 +1239,25 @@ li.inherited a {
 }
 
 .markdown-alert-important {
-  border-left-color: var(--main-comment-color);
+  border-left-color: var(--main-tag-color);
 }
 
 .markdown-alert-important .markdown-alert-title {
-  color: var(--main-comment-color);
+  color: var(--main-tag-color);
 }
 
 .markdown-alert-warning {
-  border-left-color: var(--main-section-color);
-}
-
-.markdown-alert-warning .markdown-alert-title {
-  color: var(--main-section-color);
-}
-
-.markdown-alert-caution {
   border-left-color: var(--main-string-color);
 }
 
-.markdown-alert-caution .markdown-alert-title {
+.markdown-alert-warning .markdown-alert-title {
   color: var(--main-string-color);
+}
+
+.markdown-alert-caution {
+  border-left-color: var(--main-section-color);
+}
+
+.markdown-alert-caution .markdown-alert-title {
+  color: var(--main-section-color);
 }

--- a/lib/src/dartdoc.dart
+++ b/lib/src/dartdoc.dart
@@ -250,9 +250,6 @@ class Dartdoc {
   }
 
   /// Runs [generateDocs] function and properly handles the errors.
-  ///
-  /// Passing in a [postProcessCallback] to do additional processing after
-  /// the documentation is generated.
   void executeGuarded() {
     onCheckProgress.listen(logProgress);
     // This function should *never* `await runZonedGuarded` because the errors

--- a/lib/src/markdown_processor.dart
+++ b/lib/src/markdown_processor.dart
@@ -132,6 +132,7 @@ final List<md.InlineSyntax> _markdownSyntaxes = [
 ];
 
 final List<md.BlockSyntax> _markdownBlockSyntaxes = [
+  const md.AlertBlockSyntax(),
   const md.FencedCodeBlockSyntax(),
   const md.HeaderWithIdSyntax(),
   const md.SetextHeaderWithIdSyntax(),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   glob: ^2.1.1
   html: ^0.15.3
   logging: ^1.1.1
-  markdown: ^7.1.0
+  markdown: ^7.2.1
   meta: ^1.9.1
   package_config: ^2.1.0
   path: ^1.8.3


### PR DESCRIPTION
- add support for github style markdown alerts

Starting as a draft - I'm not quite sure where to put a test for this.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
