### PR TITLE
Surface category one liner on index page

### DIFF
--- a/lib/src/generator/templates.aot_renderers_for_html.dart
+++ b/lib/src/generator/templates.aot_renderers_for_html.dart
@@ -1048,6 +1048,13 @@ String renderIndex(PackageTemplateData context0) {
           <h3>''');
       buffer.writeEscaped(context8.name);
       buffer.write('''</h3>''');
+      if (context8.isDocumented) {
+        buffer.writeln();
+        buffer.write('''
+          <p>''');
+        buffer.write(context8.oneLineDoc);
+        buffer.write('''</p>''');
+      }
       var context9 = context8.publicLibrariesSorted;
       for (var context10 in context9) {
         buffer.write('\n            ');

--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -16290,6 +16290,7 @@ const _invisibleGetters = {
     'alias',
     'element',
     'element2',
+    'extensionTypeErasure',
     'hashCode',
     'isBottom',
     'isDartAsyncFuture',
@@ -16384,6 +16385,7 @@ const _invisibleGetters = {
     'hasDeprecated',
     'hasDoNotStore',
     'hasFactory',
+    'hasImmutable',
     'hasInternal',
     'hasIsTest',
     'hasIsTestGroup',
@@ -16463,6 +16465,7 @@ const _invisibleGetters = {
     'runtimeType'
   },
   'ExecutableMember': {
+    'augmentationSubstitution',
     'children',
     'context',
     'declaration',
@@ -16473,6 +16476,7 @@ const _invisibleGetters = {
     'hasDeprecated',
     'hasDoNotStore',
     'hasFactory',
+    'hasImmutable',
     'hasImplicitReturnType',
     'hasInternal',
     'hasIsTest',
@@ -16499,6 +16503,7 @@ const _invisibleGetters = {
     'isAbstract',
     'isAsynchronous',
     'isAugmentation',
+    'isExtensionTypeMember',
     'isExternal',
     'isGenerator',
     'isLegacy',
@@ -16730,6 +16735,7 @@ const _invisibleGetters = {
     'values'
   },
   'Member': {
+    'augmentationSubstitution',
     'children',
     'context',
     'declaration',
@@ -16740,6 +16746,7 @@ const _invisibleGetters = {
     'hasDeprecated',
     'hasDoNotStore',
     'hasFactory',
+    'hasImmutable',
     'hasInternal',
     'hasIsTest',
     'hasIsTestGroup',
@@ -16881,6 +16888,7 @@ const _invisibleGetters = {
     'typeParameters'
   },
   'ParameterMember': {
+    'augmentationSubstitution',
     'children',
     'context',
     'declaration',
@@ -16893,6 +16901,7 @@ const _invisibleGetters = {
     'hasDeprecated',
     'hasDoNotStore',
     'hasFactory',
+    'hasImmutable',
     'hasImplicitType',
     'hasInternal',
     'hasIsTest',

--- a/lib/templates/html/index.html
+++ b/lib/templates/html/index.html
@@ -19,6 +19,9 @@
         {{/defaultCategory.publicLibrariesSorted}}
         {{#categoriesWithPublicLibraries}}
           <h3>{{name}}</h3>
+          {{#isDocumented}}
+          <p>{{{ oneLineDoc }}}</p>
+          {{/isDocumented}}
           {{#publicLibrariesSorted}}
             {{>library}}
           {{/publicLibrariesSorted}}


### PR DESCRIPTION
Surface the first line of category documentation on the documentation index page.

Contributes to https://github.com/dart-lang/dartdoc/issues/3618, by enabling the first line a category/topic's documentation to show up on the index page. If a category does not have a documentation page (such as the Dart SDK's categories), this doesn't change anything.

Example from test_package index page:

<img width="586" alt="Example of surfaced category" src="https://github.com/dart-lang/dartdoc/assets/18372958/d48867b9-cde2-4bfd-93d8-c6dde22474e9">