### PR TITLE
Adjust alert/aside design

### DIFF
--- a/lib/resources/styles.css
+++ b/lib/resources/styles.css
@@ -1226,6 +1226,7 @@ li.inherited a {
 
 .markdown-alert-title {
   display: flex;
+  align-items: center;
   gap: 0.4rem;
   margin-bottom: 0.5rem;
 

--- a/lib/resources/styles.css
+++ b/lib/resources/styles.css
@@ -34,6 +34,8 @@
 
   /* alerts */
   --alert-info: #e7f8ff;
+  --alert-tip: #ecfaf7;
+  --alert-important: #e2dbff;
   --alert-warning: #fcf8e3;
   --alert-error: #fde9ee;
 }
@@ -71,9 +73,11 @@
   --main-icon-color: white;
 
   /* alerts */
-  --alert-info: #1976d2;
-  --alert-warning: #ffe57f;
-  --alert-error: #cf6679;
+  --alert-info: #043875;
+  --alert-tip: #065517;
+  --alert-important: #4a00b4;
+  --alert-warning: #7b6909;
+  --alert-error: #7a0c17;
 }
 
 #theme {
@@ -1213,11 +1217,7 @@ li.inherited a {
 .markdown-alert {
   margin-top: 1rem;
   margin-bottom: 1rem;
-  padding: 30px;
-}
-
-.markdown-alert p:nth-child(2) {
-  display: inline;
+  padding: 1.25rem;
 }
 
 .markdown-alert>:last-child {
@@ -1225,15 +1225,16 @@ li.inherited a {
 }
 
 .markdown-alert-title {
-  font-weight: bold;  
+  display: flex;
+  gap: 0.4rem;
+  margin-bottom: 0.5rem;
+
+  font-weight: bold;
+  -webkit-font-smoothing: antialiased;
 }
 
-.markdown-alert-title:after {
-  content: ':';
-}
-
-p.markdown-alert-title {
-  display: inline;
+.markdown-alert-title:before {
+  font: 24px / 1 'Material Symbols Outlined';
 }
 
 /* note, tip, important, warning, caution */
@@ -1242,18 +1243,38 @@ p.markdown-alert-title {
   background-color: var(--alert-info);
 }
 
+.markdown-alert-note .markdown-alert-title:before {
+  content: 'info';
+}
+
 .markdown-alert.markdown-alert-tip {
-  background-color: var(--alert-info);
+  background-color: var(--alert-tip);
+}
+
+.markdown-alert-tip .markdown-alert-title:before {
+  content: 'lightbulb';
 }
 
 .markdown-alert.markdown-alert-important {
-  background-color: var(--alert-info);
+  background-color: var(--alert-important);
+}
+
+.markdown-alert-important .markdown-alert-title:before {
+  content: 'feedback';
 }
 
 .markdown-alert.markdown-alert-warning {
   background-color: var(--alert-warning);
 }
 
+.markdown-alert-warning .markdown-alert-title:before {
+  content: 'warning';
+}
+
 .markdown-alert.markdown-alert-caution {
   background-color: var(--alert-error);
+}
+
+.markdown-alert-caution .markdown-alert-title:before {
+  content: 'report';
 }

--- a/lib/src/generator/templates.aot_renderers_for_html.dart
+++ b/lib/src/generator/templates.aot_renderers_for_html.dart
@@ -3531,7 +3531,7 @@ String _deduplicated_lib_templates_html__head_html(TemplateDataBase context0) {
   buffer.write('''
   <link rel="preconnect" href="https://fonts.gstatic.com">
   <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@48,400,0,0" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0" rel="stylesheet">
   ''');
   buffer.writeln();
   buffer.write('''

--- a/lib/templates/html/_head.html
+++ b/lib/templates/html/_head.html
@@ -20,7 +20,7 @@
   {{! TODO(jdkoren): unwrap ^useBaseHref sections when the option is removed.}}
   <link rel="preconnect" href="https://fonts.gstatic.com">
   <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@48,400,0,0" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0" rel="stylesheet">
   {{! **Update versions for static assets when changed to force browsers to refresh them.** }}
   <link rel="stylesheet" href="{{^useBaseHref}}%%__HTMLBASE_dartdoc_internal__%%{{/useBaseHref}}static-assets/github.css?v1">
   <link rel="stylesheet" href="{{^useBaseHref}}%%__HTMLBASE_dartdoc_internal__%%{{/useBaseHref}}static-assets/styles.css?v1">


### PR DESCRIPTION
Makes some adjustments to:

- More closely match developer's expectations from GitHub alerts
- Reduce spacing for to better align with upcoming changes to dart.dev's alerts
- Increase contrast of alert text in dark mode
- Add a unique icon and color for each type

**Dark mode:**

<img width="484" alt="New dark mode styles" src="https://github.com/dart-lang/dartdoc/assets/18372958/877edd55-0945-4516-8e10-7d54bfe99c63">

**Light mode:**

<img width="481" alt="New light mode styles" src="https://github.com/dart-lang/dartdoc/assets/18372958/9c3e6b53-8ef5-43ab-8519-50af081d5cfe">


