### PR TITLE
Improve interactivity of theme button

### DIFF
--- a/lib/resources/styles.css
+++ b/lib/resources/styles.css
@@ -96,6 +96,10 @@
   cursor: pointer;
 }
 
+#theme-button .material-symbols-outlined:hover {
+  color: var(--main-hyperlinks-color);
+}
+
 .light-theme #light-theme-button {
   display: none;
 }
@@ -859,6 +863,10 @@ button {
   color: var(--main-icon-color);
   user-select: none;
   cursor: pointer;
+}
+
+#sidenav-left-toggle:hover {
+  color: var(--main-hyperlinks-color);
 }
 
 /* left-nav disappears, and can transition in from the left */

--- a/lib/src/generator/templates.aot_renderers_for_html.dart
+++ b/lib/src/generator/templates.aot_renderers_for_html.dart
@@ -3621,14 +3621,14 @@ String _deduplicated_lib_templates_html__head_html(TemplateDataBase context0) {
   <form class="search navbar-right" role="search">
     <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
   </form>
-  <div class="toggle" id="theme-button">
+  <div class="toggle" id="theme-button" title="Toggle brightness">
     <label for="theme">
       <input type="checkbox" id="theme" value="light-theme">
       <span id="dark-theme-button" class="material-symbols-outlined">
-        brightness_4
+        dark_mode
       </span>
       <span id="light-theme-button" class="material-symbols-outlined">
-        brightness_5
+        light_mode
       </span>
     </label>
   </div>

--- a/lib/templates/html/_head.html
+++ b/lib/templates/html/_head.html
@@ -54,14 +54,14 @@
   <form class="search navbar-right" role="search">
     <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
   </form>
-  <div class="toggle" id="theme-button">
+  <div class="toggle" id="theme-button" title="Toggle brightness">
     <label for="theme">
       <input type="checkbox" id="theme" value="light-theme">
       <span id="dark-theme-button" class="material-symbols-outlined">
-        brightness_4
+        dark_mode
       </span>
       <span id="light-theme-button" class="material-symbols-outlined">
-        brightness_5
+        light_mode
       </span>
     </label>
   </div>


### PR DESCRIPTION
- Add hover color to make hover state more obvious
- Add title to button to provide some more details on what it does
- Use the standard `light_mode` and `dark_mode` symbols. Other Dart sites are starting to use these as well.


**In light mode:**

<img width="154" alt="Hover state of theme button in light mode" src="https://github.com/dart-lang/dartdoc/assets/18372958/2182157d-f2c4-4f79-914d-84d430c4225b">

**In dark mode:**

<img width="196" alt="Hover state of theme button in dark mode" src="https://github.com/dart-lang/dartdoc/assets/18372958/6d3656a2-ebeb-41cd-8315-7505e13d2f24">
