### PR TITLE
add a test for the 'external' option for categories

### DIFF
--- a/test/dartdoc_options_test.dart
+++ b/test/dartdoc_options_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:analyzer/file_system/file_system.dart';
+import 'package:analyzer/file_system/memory_file_system.dart';
 import 'package:dartdoc/src/dartdoc_options.dart';
 import 'package:dartdoc/src/io_utils.dart';
 import 'package:dartdoc/src/package_meta.dart';
@@ -756,6 +757,33 @@ dartdoc:
         () {
       expect(dartdocOptionSetFiles['parentOverride'].valueAt(secondDirFirstSub),
           equals('parent'));
+    });
+  });
+
+  group('CategoryConfiguration', () {
+    const configData = '''
+CategoryOne:
+  external:
+    - name: 'package:web'
+      url: https://pub.dev/documentation/web/latest/
+      docs: Lorem ipsum.
+''';
+
+    test('parses external items', () {
+      final resourceProvider = MemoryResourceProvider();
+      final yamlMap = loadYaml(configData) as YamlMap;
+      final result =
+          CategoryConfiguration.fromYamlMap(yamlMap, '', resourceProvider);
+      expect(result.categoryDefinitions, hasLength(1));
+
+      final name = result.categoryDefinitions.keys.first;
+      final definition = result.categoryDefinitions[name]!;
+      expect(name, 'CategoryOne');
+      expect(definition.externalItems, hasLength(1));
+
+      final item = definition.externalItems.first;
+      expect(item.name, 'package:web');
+      expect(item.url, 'https://pub.dev/documentation/web/latest/');
     });
   });
 }


### PR DESCRIPTION
- add a test for the 'external' option for categories

I thought this was part of https://github.com/dart-lang/dartdoc/pull/3631 but it looks like I hadn't added it to the PR.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
