### PR TITLE
Remove unnecessary imports of 'package:collection' `IterableExtension`

### DIFF
--- a/lib/src/model/directives/categorization.dart
+++ b/lib/src/model/directives/categorization.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:collection/collection.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:meta/meta.dart';
 
@@ -63,7 +62,7 @@ mixin Categorization on DocumentationComment implements Indexable {
 
   @visibleForTesting
   List<Category> get categories => [
-        ...?categoryNames?.map((n) => package.nameToCategory[n]).whereNotNull()
+        ...?categoryNames?.map((n) => package.nameToCategory[n]).nonNulls
       ]..sort();
 
   Iterable<Category> get displayedCategories {

--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -670,8 +670,7 @@ abstract class ModelElement extends Canonicalization
       var getterDeprecated = pie.getter?.metadata.any((a) => a.isDeprecated);
       var setterDeprecated = pie.setter?.metadata.any((a) => a.isDeprecated);
 
-      var deprecatedValues =
-          [getterDeprecated, setterDeprecated].whereNotNull();
+      var deprecatedValues = [getterDeprecated, setterDeprecated].nonNulls;
 
       // At least one of these should be non-null. Otherwise things are weird
       assert(deprecatedValues.isNotEmpty);

--- a/lib/src/special_elements.dart
+++ b/lib/src/special_elements.dart
@@ -60,7 +60,7 @@ enum SpecialClass {
 /// Given an SDK, resolve URIs for the libraries containing our special
 /// classes.
 Set<String> specialLibraryFiles(DartSdk sdk) =>
-    SpecialClass.values.map((e) => e._path(sdk)).whereNotNull().toSet();
+    SpecialClass.values.map((e) => e._path(sdk)).nonNulls.toSet();
 
 /// Class for managing special [Class] objects inside Dartdoc.
 class SpecialClasses {


### PR DESCRIPTION
* Replace `.whereNotNull()` with `.nonNulls` which is now in Dart core.
* `.firstOrNull`, `.lastOrNull`, `.singleOrNull` and `.elementAtOrNull(i)` are also in Dart core and even under the same name, so simply drop the import of 'package:collection' whenever possible.

Not updating the changelog because there's 0 visible change to users.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
