### PR TITLE
Roll analyzer and release 8.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 8.0.5
+
+* Require `analyzer: ^6.4.1`.
+
 ## 8.0.4
 
 * Remove explicit library names. (#3609)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dartdoc
-version: 8.0.4
+version: 8.0.5
 description: A non-interactive HTML documentation generator for Dart source code.
 repository: https://github.com/dart-lang/dartdoc
 
@@ -7,7 +7,7 @@ environment:
   sdk: ^3.2.0
 
 dependencies:
-  analyzer: ^6.4.0
+  analyzer: ^6.4.1
   args: ^2.4.1
   collection: ^1.17.0
   crypto: ^3.0.3


### PR DESCRIPTION
Rolling analyzer as required per https://github.com/dart-lang/sdk/issues/54754 so that it can roll into Flutter.