### PR TITLE
Fix the 'serve testing-package' task to generate docs

### DIFF
--- a/tool/task.dart
+++ b/tool/task.dart
@@ -469,17 +469,18 @@ Map<String, String> createThrowawayPubCache() {
 final String _defaultPubCache = Platform.environment['PUB_CACHE'] ??
     path.context.resolveTildePath('~/.pub-cache');
 
-Future<void> docTestingPackage() async {
+Future<String> docTestingPackage() async {
   var testPackagePath = testPackage.absolute.path;
   var launcher = SubprocessLauncher('doc-test-package');
   await launcher.runStreamedDartCommand(['pub', 'get'],
       workingDirectory: testPackagePath);
+  var outputPath = _testingPackageDocsDir.absolute.path;
   await launcher.runStreamedDartCommand(
     [
       '--enable-asserts',
       path.join(Directory.current.absolute.path, 'bin', 'dartdoc.dart'),
       '--output',
-      _testingPackageDocsDir.absolute.path,
+      outputPath,
       '--example-path-prefix',
       'examples',
       '--include-source',
@@ -489,6 +490,7 @@ Future<void> docTestingPackage() async {
     ],
     workingDirectory: testPackagePath,
   );
+  return outputPath;
 }
 
 final Directory _testingPackageDocsDir =
@@ -649,6 +651,7 @@ Future<void> _serveDocsFrom(String servePath, int port, String context) async {
 }
 
 Future<void> serveTestingPackageDocs() async {
+  var outputPath = await docTestingPackage();
   print('launching dhttpd on port 8002 for SDK');
   var launcher = SubprocessLauncher('serve-test-package-docs');
   await launcher.runStreamed(Platform.resolvedExecutable, [
@@ -659,7 +662,7 @@ Future<void> serveTestingPackageDocs() async {
     '--port',
     '8002',
     '--path',
-    _testingPackageDocsDir.absolute.path,
+    outputPath,
   ]);
 }
 


### PR DESCRIPTION
It previously did not _generate_ docs before serving them. Which would work fine if you ran the generation command separate. But in all of the other "serve" commands, you get the building and the serving in one command.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
