### PR TITLE
Change all late final Iterable fields to Lists

### DIFF
--- a/lib/src/element_type.dart
+++ b/lib/src/element_type.dart
@@ -220,7 +220,7 @@ class ParameterizedElementType extends DefinedElementType with Rendered {
       packageGraph.rendererFactory.parameterizedElementTypeRenderer;
 
   @override
-  late final Iterable<ElementType> typeArguments = type.typeArguments
+  late final List<ElementType> typeArguments = type.typeArguments
       .map((f) => modelBuilder.typeFrom(f, library))
       .toList(growable: false);
 }
@@ -238,7 +238,7 @@ mixin Aliased implements ElementType, ModelBuilderInterface {
   late final ModelElement aliasElement =
       modelBuilder.fromElement(typeAliasElement);
 
-  late final Iterable<ElementType> aliasArguments = type.alias!.typeArguments
+  late final List<ElementType> aliasArguments = type.alias!.typeArguments
       .map((f) => modelBuilder.typeFrom(f, library))
       .toList(growable: false);
 }
@@ -422,7 +422,7 @@ class CallableElementType extends DefinedElementType with Rendered, Callable {
       packageGraph.rendererFactory.callableElementTypeRenderer;
 
   @override
-  late final Iterable<ElementType> typeArguments = type.alias?.typeArguments
+  late final List<ElementType> typeArguments = type.alias?.typeArguments
           .map((f) => modelBuilder.typeFrom(f, library))
           .toList(growable: false) ??
       const [];

--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -2121,7 +2121,7 @@ class _Renderer_Constructable extends RendererBase<Constructable> {
                   renderVariable: (CT_ c, Property<CT_> self,
                           List<String> remainingNames) =>
                       self.renderSimpleVariable(
-                          c, remainingNames, 'Iterable<Constructor>'),
+                          c, remainingNames, 'List<Constructor>'),
                   renderIterable: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
                     return c.constructors.map((e) => _render_Constructor(
@@ -2913,7 +2913,7 @@ class _Renderer_Container extends RendererBase<Container> {
                   renderVariable: (CT_ c, Property<CT_> self,
                           List<String> remainingNames) =>
                       self.renderSimpleVariable(
-                          c, remainingNames, 'Iterable<Operator>'),
+                          c, remainingNames, 'List<Operator>'),
                   renderIterable: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
                     return c.declaredOperators.map((e) =>
@@ -4684,7 +4684,7 @@ class _Renderer_Enum extends RendererBase<Enum> {
                   renderVariable: (CT_ c, Property<CT_> self,
                           List<String> remainingNames) =>
                       self.renderSimpleVariable(
-                          c, remainingNames, 'Iterable<Field>'),
+                          c, remainingNames, 'List<Field>'),
                   renderIterable: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
                     return c.publicEnumValues.map((e) =>
@@ -7444,7 +7444,7 @@ class _Renderer_InheritingContainer extends RendererBase<InheritingContainer> {
                   renderVariable: (CT_ c, Property<CT_> self,
                           List<String> remainingNames) =>
                       self.renderSimpleVariable(
-                          c, remainingNames, 'Iterable<Method>'),
+                          c, remainingNames, 'List<Method>'),
                   renderIterable: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
                     return c.declaredMethods.map((e) =>
@@ -8235,7 +8235,7 @@ class _Renderer_Library extends RendererBase<Library> {
                   renderVariable: (CT_ c, Property<CT_> self,
                           List<String> remainingNames) =>
                       self.renderSimpleVariable(
-                          c, remainingNames, 'Iterable<String>'),
+                          c, remainingNames, 'List<String>'),
                   renderIterable: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
                     return c.allOriginalModelElementNames.map((e) =>
@@ -8449,7 +8449,7 @@ class _Renderer_Library extends RendererBase<Library> {
                   renderVariable: (CT_ c, Property<CT_> self,
                           List<String> remainingNames) =>
                       self.renderSimpleVariable(
-                          c, remainingNames, 'Iterable<ExtensionType>'),
+                          c, remainingNames, 'List<ExtensionType>'),
                   renderIterable: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
                     return c.extensionTypes.map((e) => _render_ExtensionType(
@@ -8462,7 +8462,7 @@ class _Renderer_Library extends RendererBase<Library> {
                   renderVariable: (CT_ c, Property<CT_> self,
                           List<String> remainingNames) =>
                       self.renderSimpleVariable(
-                          c, remainingNames, 'Iterable<Extension>'),
+                          c, remainingNames, 'List<Extension>'),
                   renderIterable: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
                     return c.extensions.map((e) =>
@@ -8688,7 +8688,7 @@ class _Renderer_Library extends RendererBase<Library> {
                   renderVariable: (CT_ c, Property<CT_> self,
                           List<String> remainingNames) =>
                       self.renderSimpleVariable(
-                          c, remainingNames, 'Iterable<TopLevelVariable>'),
+                          c, remainingNames, 'List<TopLevelVariable>'),
                   renderIterable: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
                     return c.properties.map((e) => _render_TopLevelVariable(
@@ -13126,7 +13126,7 @@ class _Renderer_ParameterizedElementType
                       renderVariable: (CT_ c, Property<CT_> self,
                               List<String> remainingNames) =>
                           self.renderSimpleVariable(
-                              c, remainingNames, 'Iterable<ElementType>'),
+                              c, remainingNames, 'List<ElementType>'),
                       renderIterable: (CT_ c, RendererBase<CT_> r,
                           List<MustachioNode> ast, StringSink sink) {
                         return c.typeArguments.map((e) => _render_ElementType(
@@ -14471,7 +14471,7 @@ class _Renderer_TopLevelContainer extends RendererBase<TopLevelContainer> {
                   renderVariable: (CT_ c, Property<CT_> self,
                           List<String> remainingNames) =>
                       self.renderSimpleVariable(
-                          c, remainingNames, 'Iterable<Container>'),
+                          c, remainingNames, 'List<Container>'),
                   renderIterable: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
                     return c.publicClassesSorted.map((e) =>
@@ -14521,7 +14521,7 @@ class _Renderer_TopLevelContainer extends RendererBase<TopLevelContainer> {
                   renderVariable: (CT_ c, Property<CT_> self,
                           List<String> remainingNames) =>
                       self.renderSimpleVariable(
-                          c, remainingNames, 'Iterable<Enum>'),
+                          c, remainingNames, 'List<Enum>'),
                   renderIterable: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
                     return c.publicEnumsSorted.map((e) =>
@@ -14533,7 +14533,7 @@ class _Renderer_TopLevelContainer extends RendererBase<TopLevelContainer> {
                   renderVariable: (CT_ c, Property<CT_> self,
                           List<String> remainingNames) =>
                       self.renderSimpleVariable(
-                          c, remainingNames, 'Iterable<Class>'),
+                          c, remainingNames, 'List<Class>'),
                   renderIterable: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
                     return c.publicExceptionsSorted.map((e) =>
@@ -14558,7 +14558,7 @@ class _Renderer_TopLevelContainer extends RendererBase<TopLevelContainer> {
                   renderVariable: (CT_ c, Property<CT_> self,
                           List<String> remainingNames) =>
                       self.renderSimpleVariable(
-                          c, remainingNames, 'Iterable<ExtensionType>'),
+                          c, remainingNames, 'List<ExtensionType>'),
                   renderIterable: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
                     return c.publicExtensionTypesSorted.map((e) =>
@@ -14583,7 +14583,7 @@ class _Renderer_TopLevelContainer extends RendererBase<TopLevelContainer> {
                   renderVariable: (CT_ c, Property<CT_> self,
                           List<String> remainingNames) =>
                       self.renderSimpleVariable(
-                          c, remainingNames, 'Iterable<Extension>'),
+                          c, remainingNames, 'List<Extension>'),
                   renderIterable: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
                     return c.publicExtensionsSorted.map((e) =>
@@ -14608,7 +14608,7 @@ class _Renderer_TopLevelContainer extends RendererBase<TopLevelContainer> {
                   renderVariable: (CT_ c, Property<CT_> self,
                           List<String> remainingNames) =>
                       self.renderSimpleVariable(
-                          c, remainingNames, 'Iterable<ModelFunctionTyped>'),
+                          c, remainingNames, 'List<ModelFunctionTyped>'),
                   renderIterable: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
                     return c.publicFunctionsSorted.map((e) =>
@@ -14633,7 +14633,7 @@ class _Renderer_TopLevelContainer extends RendererBase<TopLevelContainer> {
                   renderVariable: (CT_ c, Property<CT_> self,
                           List<String> remainingNames) =>
                       self.renderSimpleVariable(
-                          c, remainingNames, 'Iterable<Mixin>'),
+                          c, remainingNames, 'List<Mixin>'),
                   renderIterable: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
                     return c.publicMixinsSorted.map((e) =>
@@ -14658,7 +14658,7 @@ class _Renderer_TopLevelContainer extends RendererBase<TopLevelContainer> {
                   renderVariable: (CT_ c, Property<CT_> self,
                           List<String> remainingNames) =>
                       self.renderSimpleVariable(
-                          c, remainingNames, 'Iterable<TopLevelVariable>'),
+                          c, remainingNames, 'List<TopLevelVariable>'),
                   renderIterable: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
                     return c.publicPropertiesSorted.map((e) =>
@@ -14683,7 +14683,7 @@ class _Renderer_TopLevelContainer extends RendererBase<TopLevelContainer> {
                   renderVariable: (CT_ c, Property<CT_> self,
                           List<String> remainingNames) =>
                       self.renderSimpleVariable(
-                          c, remainingNames, 'Iterable<Typedef>'),
+                          c, remainingNames, 'List<Typedef>'),
                   renderIterable: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
                     return c.publicTypedefsSorted.map((e) =>

--- a/lib/src/model/container.dart
+++ b/lib/src/model/container.dart
@@ -105,7 +105,7 @@ abstract class Container extends ModelElement
       publicInstanceMethods.toList(growable: false)..sort();
 
   @nonVirtual
-  late final Iterable<Operator> declaredOperators =
+  late final List<Operator> declaredOperators =
       declaredMethods.whereType<Operator>().toList(growable: false);
 
   @override

--- a/lib/src/model/enum.dart
+++ b/lib/src/model/enum.dart
@@ -48,8 +48,9 @@ class Enum extends InheritingContainer
       declaredFields.where((f) => f is! EnumField && f.isConst);
 
   @override
-  late final Iterable<Field> publicEnumValues =
-      model_utils.filterNonPublic(allFields).whereType<EnumField>();
+  late final List<Field> publicEnumValues = model_utils
+      .filterNonPublic(allFields.whereType<EnumField>())
+      .toList(growable: false);
 
   @override
   bool get hasPublicEnumValues => publicEnumValues.isNotEmpty;

--- a/lib/src/model/inheriting_container.dart
+++ b/lib/src/model/inheriting_container.dart
@@ -19,7 +19,7 @@ import 'package:meta/meta.dart';
 /// Note that [Constructor]s are not considered to be modifiers so a
 /// [hasModifiers] override is not necessary for this mixin.
 mixin Constructable on InheritingContainer {
-  late final Iterable<Constructor> constructors = element.constructors
+  late final List<Constructor> constructors = element.constructors
       .map((e) => modelBuilder.from(e, library) as Constructor)
       .toList(growable: false);
 
@@ -246,8 +246,9 @@ abstract class InheritingContainer extends Container
   }
 
   @override
-  late final Iterable<Method> declaredMethods =
-      element.methods.map((e) => modelBuilder.from(e, library) as Method);
+  late final List<Method> declaredMethods = element.methods
+      .map((e) => modelBuilder.from(e, library) as Method)
+      .toList(growable: false);
 
   @override
   late final List<TypeParameter> typeParameters = element.typeParameters

--- a/lib/src/model/library.dart
+++ b/lib/src/model/library.dart
@@ -102,7 +102,7 @@ class Library extends ModelElement
   /// documented with this library, but these ModelElements and names correspond
   /// to the defining library where each originally came from with respect
   /// to inheritance and reexporting.  Most useful for error reporting.
-  late final Iterable<String> allOriginalModelElementNames =
+  late final List<String> allOriginalModelElementNames =
       allModelElements.map((e) {
     if (e is GetterSetterCombo) {
       Accessor? getter;
@@ -142,13 +142,13 @@ class Library extends ModelElement
   Iterable<Class> get classes => allClasses.where((c) => !c.isErrorOrException);
 
   @override
-  late final Iterable<Extension> extensions = _exportedAndLocalElements
+  late final List<Extension> extensions = _exportedAndLocalElements
       .whereType<ExtensionElement>()
       .map((e) => modelBuilder.from(e, this) as Extension)
       .toList(growable: false);
 
   @override
-  late final Iterable<ExtensionType> extensionTypes = _exportedAndLocalElements
+  late final List<ExtensionType> extensionTypes = _exportedAndLocalElements
       .whereType<ExtensionTypeElement>()
       .map((e) => modelBuilder.from(e, this) as ExtensionType)
       .toList(growable: false);
@@ -331,16 +331,16 @@ class Library extends ModelElement
     // This code should not be used for Dart SDK libraries.
     assert(!element.source.uri.isScheme('dart'));
     var fullName = element.source.fullName;
-     if (!pathContext.isWithin(fullName, package.packagePath) &&
-         package.packagePath.contains('/google3/')) {
-       // In google3, `fullName` is specified as if the root of google3 was `/`.
-       // And `package.packagePath` contains the true google3 root.
-       var root = pathContext
-           .joinAll(pathContext.split(package.packagePath)..removeLast());
-       fullName = '$root$fullName';
-     }
-     var relativePath =
-         pathContext.relative(fullName, from: package.packagePath);
+    if (!pathContext.isWithin(fullName, package.packagePath) &&
+        package.packagePath.contains('/google3/')) {
+      // In google3, `fullName` is specified as if the root of google3 was `/`.
+      // And `package.packagePath` contains the true google3 root.
+      var root = pathContext
+          .joinAll(pathContext.split(package.packagePath)..removeLast());
+      fullName = '$root$fullName';
+    }
+    var relativePath =
+        pathContext.relative(fullName, from: package.packagePath);
     assert(relativePath.startsWith('lib${pathContext.separator}'));
     const libDirectoryLength = 'lib/'.length;
     return relativePath.substring(libDirectoryLength);
@@ -355,7 +355,7 @@ class Library extends ModelElement
 
   /// All variables ("properties") except constants.
   @override
-  late final Iterable<TopLevelVariable> properties =
+  late final List<TopLevelVariable> properties =
       _variables.where((v) => !v.isConst).toList(growable: false);
 
   @override

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -631,7 +631,7 @@ class PackageGraph with CommentReferable, Nameable, ModelBuilder {
   }
 
   @visibleForTesting
-  late final Iterable<Library> libraries =
+  late final List<Library> libraries =
       packages.expand((p) => p.libraries).toList(growable: false)..sort();
 
   int get libraryCount => libraries.length;
@@ -905,7 +905,7 @@ class PackageGraph with CommentReferable, Nameable, ModelBuilder {
     return allElements;
   }
 
-  late final Iterable<ModelElement> allLocalModelElements = [
+  late final List<ModelElement> allLocalModelElements = [
     for (var library in _localLibraries) ...library.allModelElements
   ];
 

--- a/lib/src/model/top_level_container.dart
+++ b/lib/src/model/top_level_container.dart
@@ -57,19 +57,19 @@ mixin TopLevelContainer implements Nameable {
   // TODO(jcollins-g):  Setting this type parameter to `Container` magically
   // fixes a number of type problems in the AOT compiler, but I am mystified as
   // to why that should be the case.
-  late final Iterable<Container> publicClassesSorted =
+  late final List<Container> publicClassesSorted =
       publicClasses.toList(growable: false)..sort();
 
   Iterable<Extension> get publicExtensions =>
       model_utils.filterNonPublic(extensions);
 
-  late final Iterable<Extension> publicExtensionsSorted =
+  late final List<Extension> publicExtensionsSorted =
       publicExtensions.toList(growable: false)..sort();
 
   Iterable<ExtensionType> get publicExtensionTypes =>
       model_utils.filterNonPublic(extensionTypes);
 
-  late final Iterable<ExtensionType> publicExtensionTypesSorted =
+  late final List<ExtensionType> publicExtensionTypesSorted =
       publicExtensionTypes.toList(growable: false)..sort();
 
   Iterable<TopLevelVariable> get publicConstants =>
@@ -80,34 +80,34 @@ mixin TopLevelContainer implements Nameable {
 
   Iterable<Enum> get publicEnums => model_utils.filterNonPublic(enums);
 
-  late final Iterable<Enum> publicEnumsSorted =
-      publicEnums.toList(growable: false)..sort();
+  late final List<Enum> publicEnumsSorted = publicEnums.toList(growable: false)
+    ..sort();
 
   Iterable<Class> get _publicExceptions =>
       model_utils.filterNonPublic(exceptions);
 
-  late final Iterable<Class> publicExceptionsSorted =
+  late final List<Class> publicExceptionsSorted =
       _publicExceptions.toList(growable: false)..sort();
 
   Iterable<ModelFunctionTyped> get publicFunctions =>
       model_utils.filterNonPublic(functions!);
 
-  late final Iterable<ModelFunctionTyped> publicFunctionsSorted =
+  late final List<ModelFunctionTyped> publicFunctionsSorted =
       publicFunctions.toList(growable: false)..sort();
 
   Iterable<Mixin> get publicMixins => model_utils.filterNonPublic(mixins);
 
-  late final Iterable<Mixin> publicMixinsSorted =
+  late final List<Mixin> publicMixinsSorted =
       publicMixins.toList(growable: false)..sort();
 
   Iterable<TopLevelVariable> get publicProperties =>
       model_utils.filterNonPublic(properties);
 
-  late final Iterable<TopLevelVariable> publicPropertiesSorted =
+  late final List<TopLevelVariable> publicPropertiesSorted =
       publicProperties.toList(growable: false)..sort();
 
   Iterable<Typedef> get publicTypedefs => model_utils.filterNonPublic(typedefs);
 
-  late final Iterable<Typedef> publicTypedefsSorted =
+  late final List<Typedef> publicTypedefsSorted =
       publicTypedefs.toList(growable: false)..sort();
 }


### PR DESCRIPTION
I noticed a `late final Iterable<...>` field and thought to myself, "uh oh! That could be an expensive field!" The idea is that Iterables are lazy, so even if the field is "final", the Iterable calculations are re-executed on each access. So storing a lazily evaluated Iterable on a field seemed very scary 😱 . It may warrant a lint rule.

Luckily, as I walked through the cases I found with grep, most of the values at runtime are Lists, not Iterables. Shwew. Still, I ran through and changed all of the signatures for future-proofing.

Two fields that _were_ Iterables were converted to Lists. I did not benchmark.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
