### PR TITLE
Tidy spacing in templates

### DIFF
--- a/lib/src/generator/templates.aot_renderers_for_html.dart
+++ b/lib/src/generator/templates.aot_renderers_for_html.dart
@@ -282,19 +282,19 @@ String renderClass(ClassTemplateData context0) {
   buffer.writeln();
   buffer.write('''
 
-  <div
-      id="dartdoc-main-content"
-      class="main-content"
-      data-above-sidebar="''');
+<div
+    id="dartdoc-main-content"
+    class="main-content"
+    data-above-sidebar="''');
   buffer.writeEscaped(context0.aboveSidebarPath);
   buffer.write('''"
-      data-below-sidebar="''');
+    data-below-sidebar="''');
   buffer.writeEscaped(context0.belowSidebarPath);
   buffer.write('''">''');
   var context1 = context0.self;
   buffer.writeln();
   buffer.write('''
-      <div>''');
+    <div>''');
   buffer.write(_renderClass_partial_source_link_1(context1));
   buffer.write('''<h1><span class="kind-class">''');
   buffer.write(context1.nameWithGenerics);
@@ -325,37 +325,37 @@ String renderClass(ClassTemplateData context0) {
     if (context2.hasPublicImplementors) {
       buffer.writeln();
       buffer.write('''
-        <dt>Implementers</dt>
-        <dd><ul class="comma-separated clazz-relationships">''');
+          <dt>Implementers</dt>
+          <dd><ul class="comma-separated clazz-relationships">''');
       var context3 = context2.publicImplementorsSorted;
       for (var context4 in context3) {
         buffer.writeln();
         buffer.write('''
-          <li>''');
+              <li>''');
         buffer.write(context4.linkedName);
         buffer.write('''</li>''');
       }
       buffer.writeln();
       buffer.write('''
-        </ul></dd>''');
+          </ul></dd>''');
     }
     buffer.writeln();
     if (context2.hasPotentiallyApplicableExtensions) {
       buffer.writeln();
       buffer.write('''
-        <dt>Available Extensions</dt>
-        <dd><ul class="comma-separated clazz-relationships">''');
+          <dt>Available Extensions</dt>
+          <dd><ul class="comma-separated clazz-relationships">''');
       var context5 = context2.potentiallyApplicableExtensionsSorted;
       for (var context6 in context5) {
         buffer.writeln();
         buffer.write('''
-          <li>''');
+              <li>''');
         buffer.write(context6.linkedName);
         buffer.write('''</li>''');
       }
       buffer.writeln();
       buffer.write('''
-        </ul></dd>''');
+          </ul></dd>''');
     }
     buffer.write('\n\n        ');
     buffer.write(_renderClass_partial_container_annotations_8(context2));
@@ -516,27 +516,27 @@ String renderEnum(EnumTemplateData context0) {
   buffer.writeln();
   buffer.write('''
 
-  <div
-      id="dartdoc-main-content"
-      class="main-content"
-      data-above-sidebar="''');
+<div
+    id="dartdoc-main-content"
+    class="main-content"
+    data-above-sidebar="''');
   buffer.writeEscaped(context0.aboveSidebarPath);
   buffer.write('''"
-      data-below-sidebar="''');
+    data-below-sidebar="''');
   buffer.writeEscaped(context0.belowSidebarPath);
   buffer.write('''">''');
   var context1 = context0.self;
   buffer.writeln();
   buffer.write('''
-      <div>''');
+    <div>''');
   buffer.write(_renderEnum_partial_source_link_1(context1));
   buffer.writeln();
   buffer.write('''
-        <h1>
-          <span class="kind-enum">''');
+      <h1>
+        <span class="kind-enum">''');
   buffer.write(context1.nameWithGenerics);
   buffer.write('''</span>
-          ''');
+        ''');
   buffer.writeEscaped(context1.kind.toString());
   buffer.write(' ');
   buffer.write(_renderEnum_partial_feature_set_2(context1));
@@ -544,8 +544,8 @@ String renderEnum(EnumTemplateData context0) {
   buffer.write(_renderEnum_partial_categorization_3(context1));
   buffer.writeln();
   buffer.write('''
-        </h1>
-      </div>''');
+      </h1>
+    </div>''');
   buffer.writeln();
   var context2 = context0.eNum;
   buffer.write('\n    ');
@@ -554,20 +554,20 @@ String renderEnum(EnumTemplateData context0) {
   if (context2.hasModifiers) {
     buffer.writeln();
     buffer.write('''
-    <section>
-      <dl class="dl-horizontal">
-        ''');
+      <section>
+        <dl class="dl-horizontal">
+          ''');
     buffer.write(_renderEnum_partial_super_chain_5(context2));
-    buffer.write('\n        ');
+    buffer.write('\n          ');
     buffer.write(_renderEnum_partial_interfaces_6(context2));
-    buffer.write('\n        ');
+    buffer.write('\n          ');
     buffer.write(_renderEnum_partial_mixed_in_types_7(context2));
-    buffer.write('\n        ');
+    buffer.write('\n          ');
     buffer.write(_renderEnum_partial_container_annotations_8(context2));
     buffer.writeln();
     buffer.write('''
-      </dl>
-    </section>''');
+        </dl>
+      </section>''');
   }
   buffer.write('\n\n    ');
   buffer.write(_renderEnum_partial_constructors_9(context2));
@@ -575,45 +575,45 @@ String renderEnum(EnumTemplateData context0) {
   if (context2.hasPublicEnumValues) {
     buffer.writeln();
     buffer.write('''
-    <section class="summary offset-anchor" id="values">
-      <h2>Values</h2>
+      <section class="summary offset-anchor" id="values">
+        <h2>Values</h2>
 
-      <dl class="properties">''');
+        <dl class="properties">''');
     var context3 = context2.publicEnumValues;
     for (var context4 in context3) {
-      buffer.write('\n          ');
+      buffer.write('\n            ');
       buffer.write(_renderEnum_partial_constant_10(context4));
     }
     buffer.writeln();
     buffer.write('''
-      </dl>
-    </section>''');
+        </dl>
+      </section>''');
   }
   buffer.writeln();
   if (context2.hasPublicInstanceFields) {
     buffer.writeln();
     buffer.write('''
-    <section
-        class="
-          summary
-          offset-anchor''');
+      <section
+          class="
+            summary
+            offset-anchor''');
     if (context2.publicInheritedInstanceFields) {
       buffer.write('''inherited''');
     }
     buffer.write('''"
-        id="instance-properties">
-      <h2>Properties</h2>
+          id="instance-properties">
+        <h2>Properties</h2>
 
-      <dl class="properties">''');
+        <dl class="properties">''');
     var context5 = context2.publicInstanceFieldsSorted;
     for (var context6 in context5) {
-      buffer.write('\n        ');
+      buffer.write('\n          ');
       buffer.write(_renderEnum_partial_property_11(context6));
     }
     buffer.writeln();
     buffer.write('''
-      </dl>
-    </section>''');
+        </dl>
+      </section>''');
   }
   buffer.write('\n\n    ');
   buffer.write(_renderEnum_partial_instance_methods_12(context2));
@@ -627,23 +627,23 @@ String renderEnum(EnumTemplateData context0) {
   buffer.write(_renderEnum_partial_static_constants_16(context2));
   buffer.writeln();
   buffer.write('''
-  </div><!-- /.main-content -->
+</div><!-- /.main-content -->
 
-  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
-    ''');
+<div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
+  ''');
   buffer.write(_renderEnum_partial_search_sidebar_17(context0));
   buffer.writeln();
   buffer.write('''
-    <h5>''');
+  <h5>''');
   buffer.writeEscaped(context0.parent!.name);
   buffer.write(' ');
   buffer.writeEscaped(context0.parent!.kind.toString());
   buffer.write('''</h5>
-    <div id="dartdoc-sidebar-left-content"></div>
-  </div>
+  <div id="dartdoc-sidebar-left-content"></div>
+</div>
 
-  <div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">
-  </div><!-- /.sidebar-offcanvas -->
+<div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">
+</div><!-- /.sidebar-offcanvas -->
 
 ''');
   buffer.write(_renderEnum_partial_footer_18(context0));
@@ -879,7 +879,7 @@ String renderExtensionType<T extends ExtensionType>(
   if (context2.hasPublicInstanceFields) {
     buffer.writeln();
     buffer.write('''
-    <section class="summary offset-anchor" id="instance-properties">
+      <section class="summary offset-anchor" id="instance-properties">
         <h2>Properties</h2>
 
         <dl class="properties">''');
@@ -891,7 +891,7 @@ String renderExtensionType<T extends ExtensionType>(
     buffer.writeln();
     buffer.write('''
         </dl>
-    </section>''');
+      </section>''');
   }
   buffer.write('\n\n    ');
   buffer.write(_renderExtensionType_partial_instance_methods_9(context2));
@@ -904,16 +904,16 @@ String renderExtensionType<T extends ExtensionType>(
   buffer.write('\n    ');
   buffer.write(_renderExtensionType_partial_static_constants_13(context2));
   buffer.writeln();
+  buffer.writeln();
   buffer.write('''
-
 </div><!-- /.main-content -->
 
 <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
-    ''');
+  ''');
   buffer.write(_renderExtensionType_partial_search_sidebar_14(context0));
   buffer.writeln();
   buffer.write('''
-    <h5>''');
+  <h5>''');
   buffer.writeEscaped(context0.parent!.name);
   buffer.write(' ');
   buffer.writeEscaped(context0.parent!.kind.toString());
@@ -925,7 +925,6 @@ String renderExtensionType<T extends ExtensionType>(
 
 ''');
   buffer.write(_renderExtensionType_partial_footer_15(context0));
-  buffer.writeln();
   buffer.writeln();
 
   return buffer.toString();
@@ -1473,19 +1472,19 @@ String renderMixin(MixinTemplateData context0) {
   buffer.writeln();
   buffer.write('''
 
-  <div
-      id="dartdoc-main-content"
-      class="main-content"
-      data-above-sidebar="''');
+<div
+    id="dartdoc-main-content"
+    class="main-content"
+    data-above-sidebar="''');
   buffer.writeEscaped(context0.aboveSidebarPath);
   buffer.write('''"
-      data-below-sidebar="''');
+    data-below-sidebar="''');
   buffer.writeEscaped(context0.belowSidebarPath);
   buffer.write('''">''');
   var context1 = context0.self;
   buffer.writeln();
   buffer.write('''
-      <div>''');
+    <div>''');
   buffer.write(_renderMixin_partial_source_link_1(context1));
   buffer.write('''<h1><span class="kind-mixin">''');
   buffer.write(context1.nameWithGenerics);
@@ -1498,7 +1497,7 @@ String renderMixin(MixinTemplateData context0) {
   buffer.write('''</h1></div>''');
   buffer.writeln();
   var context2 = context0.mixin;
-  buffer.write('\n    ');
+  buffer.write('\n  ');
   buffer.write(_renderMixin_partial_documentation_4(context2));
   buffer.writeln();
   if (context2.hasModifiers) {
@@ -1509,19 +1508,19 @@ String renderMixin(MixinTemplateData context0) {
     if (context2.hasPublicSuperclassConstraints) {
       buffer.writeln();
       buffer.write('''
-        <dt>Superclass Constraints</dt>
-        <dd><ul class="comma-separated dark mixin-relationships">''');
+          <dt>Superclass Constraints</dt>
+          <dd><ul class="comma-separated dark mixin-relationships">''');
       var context3 = context2.publicSuperclassConstraints;
       for (var context4 in context3) {
         buffer.writeln();
         buffer.write('''
-          <li>''');
+              <li>''');
         buffer.write(context4.linkedName);
         buffer.write('''</li>''');
       }
       buffer.writeln();
       buffer.write('''
-        </ul></dd>''');
+          </ul></dd>''');
     }
     buffer.write('\n\n        ');
     buffer.write(_renderMixin_partial_super_chain_5(context2));
@@ -1531,21 +1530,21 @@ String renderMixin(MixinTemplateData context0) {
     if (context2.hasPublicImplementors) {
       buffer.writeln();
       buffer.write('''
-        <dt>Mixin Applications</dt>
-        <dd>
-          <ul class="comma-separated mixin-relationships">''');
+          <dt>Mixin Applications</dt>
+          <dd>
+            <ul class="comma-separated mixin-relationships">''');
       var context5 = context2.publicImplementorsSorted;
       for (var context6 in context5) {
         buffer.writeln();
         buffer.write('''
-            <li>''');
+              <li>''');
         buffer.write(context6.linkedName);
         buffer.write('''</li>''');
       }
       buffer.writeln();
       buffer.write('''
-          </ul>
-        </dd>''');
+            </ul>
+          </dd>''');
     }
     buffer.write('\n\n        ');
     buffer.write(_renderMixin_partial_annotations_7(context2));
@@ -1568,7 +1567,7 @@ String renderMixin(MixinTemplateData context0) {
       <dl class="properties">''');
     var context7 = context2.publicInstanceFields;
     for (var context8 in context7) {
-      buffer.write('\n        ');
+      buffer.write('\n          ');
       buffer.write(_renderMixin_partial_property_8(context8));
     }
     buffer.writeln();
@@ -1588,23 +1587,23 @@ String renderMixin(MixinTemplateData context0) {
   buffer.write(_renderMixin_partial_static_constants_13(context2));
   buffer.writeln();
   buffer.write('''
-  </div> <!-- /.main-content -->
+</div> <!-- /.main-content -->
 
-  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
-    ''');
+<div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
+  ''');
   buffer.write(_renderMixin_partial_search_sidebar_14(context0));
   buffer.writeln();
   buffer.write('''
-    <h5>''');
+  <h5>''');
   buffer.writeEscaped(context0.parent!.name);
   buffer.write(' ');
   buffer.writeEscaped(context0.parent!.kind.toString());
   buffer.write('''</h5>
-    <div id="dartdoc-sidebar-left-content"></div>
-  </div>
+  <div id="dartdoc-sidebar-left-content"></div>
+</div>
 
-  <div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">
-  </div><!--/.sidebar-offcanvas-->
+<div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">
+</div><!--/.sidebar-offcanvas-->
 
 ''');
   buffer.write(_renderMixin_partial_footer_15(context0));
@@ -1619,19 +1618,19 @@ String renderProperty(PropertyTemplateData context0) {
   buffer.writeln();
   buffer.write('''
 
-  <div
-      id="dartdoc-main-content"
-      class="main-content"
-      data-above-sidebar="''');
+<div
+    id="dartdoc-main-content"
+    class="main-content"
+    data-above-sidebar="''');
   buffer.writeEscaped(context0.aboveSidebarPath);
   buffer.write('''"
-      data-below-sidebar="''');
+    data-below-sidebar="''');
   buffer.writeEscaped(context0.belowSidebarPath);
   buffer.write('''">''');
   var context1 = context0.self;
   buffer.writeln();
   buffer.write('''
-      <div>''');
+    <div>''');
   buffer.write(_renderProperty_partial_source_link_1(context1));
   buffer.write('''<h1><span class="kind-property">''');
   buffer.writeEscaped(context1.name);
@@ -1645,21 +1644,21 @@ String renderProperty(PropertyTemplateData context0) {
   if (context2.hasNoGetterSetter) {
     buffer.writeln();
     buffer.write('''
-        <section class="multi-line-signature">
-          ''');
+      <section class="multi-line-signature">
+        ''');
     buffer.write(_renderProperty_partial_annotations_3(context2));
-    buffer.write('\n          ');
+    buffer.write('\n        ');
     buffer.write(context2.modelType.linkedName);
-    buffer.write('\n          ');
+    buffer.write('\n        ');
     buffer.write(_renderProperty_partial_name_summary_4(context2));
-    buffer.write('\n          ');
+    buffer.write('\n        ');
     buffer.write(_renderProperty_partial_attributes_5(context2));
     buffer.writeln();
     buffer.write('''
-        </section>
-        ''');
+      </section>
+      ''');
     buffer.write(_renderProperty_partial_documentation_6(context2));
-    buffer.write('\n        ');
+    buffer.write('\n      ');
     buffer.write(_renderProperty_partial_source_code_7(context2));
   }
   buffer.writeln();
@@ -1676,23 +1675,23 @@ String renderProperty(PropertyTemplateData context0) {
   }
   buffer.writeln();
   buffer.write('''
-  </div> <!-- /.main-content -->
+</div> <!-- /.main-content -->
 
-  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
-    ''');
+<div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
+  ''');
   buffer.write(_renderProperty_partial_search_sidebar_10(context0));
   buffer.writeln();
   buffer.write('''
-    <h5>''');
+  <h5>''');
   buffer.writeEscaped(context0.parent!.name);
   buffer.write(' ');
   buffer.writeEscaped(context0.parent!.kind.toString());
   buffer.write('''</h5>
-    <div id="dartdoc-sidebar-left-content"></div>
-  </div><!--/.sidebar-offcanvas-->
+  <div id="dartdoc-sidebar-left-content"></div>
+</div><!--/.sidebar-offcanvas-->
 
-  <div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">
-  </div><!--/.sidebar-offcanvas-->
+<div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">
+</div><!--/.sidebar-offcanvas-->
 
 ''');
   buffer.write(_renderProperty_partial_footer_11(context0));
@@ -3791,7 +3790,7 @@ String _deduplicated_lib_templates_html__extension_html(Extension context0) {
   buffer.write('''<dt id="''');
   buffer.writeEscaped(context0.htmlId);
   buffer.write('''">
-    <span class="name ''');
+  <span class="name ''');
   if (context0.isDeprecated) {
     buffer.write('''deprecated''');
   }
@@ -3805,7 +3804,7 @@ String _deduplicated_lib_templates_html__extension_html(Extension context0) {
   buffer.write('''
 </dt>
 <dd>
-    ''');
+  ''');
   buffer.write(context0.oneLineDoc);
   buffer.writeln();
   buffer.write('''
@@ -3955,7 +3954,8 @@ String _deduplicated_lib_templates_html__property_html(
   buffer.write(context0.arrow);
   buffer.write(' ');
   buffer.write(context0.modelType.linkedName);
-  buffer.write('''</span> ''');
+  buffer.write('''</span>
+  ''');
   buffer.write(
       __deduplicated_lib_templates_html__property_html_partial_categorization_0(
           context0));
@@ -4863,7 +4863,8 @@ String
   buffer.write(context1.arrow);
   buffer.write(' ');
   buffer.write(context1.modelType.linkedName);
-  buffer.write('''</span> ''');
+  buffer.write('''</span>
+  ''');
   buffer.write(
       ___deduplicated_lib_templates_html__static_properties_html_partial_property_0_partial_categorization_0(
           context1));
@@ -5215,41 +5216,41 @@ String _deduplicated_lib_templates_html__accessor_getter_html(
   if (context1 != null) {
     buffer.writeln();
     buffer.write('''
-<section id="getter">
+  <section id="getter">
 
-<section class="multi-line-signature">
-  ''');
+    <section class="multi-line-signature">
+      ''');
     buffer.write(
         __deduplicated_lib_templates_html__accessor_getter_html_partial_annotations_0(
             context1));
     buffer.writeln();
     buffer.write('''
-  <span class="returntype">''');
+      <span class="returntype">''');
     buffer.write(context1.modelType.returnType.linkedName);
     buffer.write('''</span>
-  ''');
+      ''');
     buffer.write(
         __deduplicated_lib_templates_html__accessor_getter_html_partial_name_summary_1(
             context1));
-    buffer.write('\n  ');
+    buffer.write('\n      ');
     buffer.write(
         __deduplicated_lib_templates_html__accessor_getter_html_partial_attributes_2(
             context1));
     buffer.writeln();
     buffer.write('''
-</section>
+    </section>
 
-''');
+    ''');
     buffer.write(
         __deduplicated_lib_templates_html__accessor_getter_html_partial_documentation_3(
             context1));
-    buffer.writeln();
+    buffer.write('\n    ');
     buffer.write(
         __deduplicated_lib_templates_html__accessor_getter_html_partial_source_code_4(
             context1));
     buffer.writeln();
     buffer.write('''
-</section>''');
+  </section>''');
   }
   buffer.writeln();
 
@@ -5359,42 +5360,42 @@ String _deduplicated_lib_templates_html__accessor_setter_html(
   if (context1 != null) {
     buffer.writeln();
     buffer.write('''
-<section id="setter">
+  <section id="setter">
 
-<section class="multi-line-signature">
-  ''');
+    <section class="multi-line-signature">
+      ''');
     buffer.write(
         __deduplicated_lib_templates_html__accessor_setter_html_partial_annotations_0(
             context1));
     buffer.writeln();
     buffer.write('''
-  <span class="returntype">void</span>
-  ''');
+      <span class="returntype">void</span>
+      ''');
     buffer.write(
         __deduplicated_lib_templates_html__accessor_setter_html_partial_name_summary_1(
             context1));
     buffer.write('''<span class="signature">(<wbr>''');
     buffer.write(context1.linkedParamsNoMetadata);
     buffer.write(''')</span>
-  ''');
+      ''');
     buffer.write(
         __deduplicated_lib_templates_html__accessor_setter_html_partial_attributes_2(
             context1));
     buffer.writeln();
     buffer.write('''
-</section>
+    </section>
 
-''');
+    ''');
     buffer.write(
         __deduplicated_lib_templates_html__accessor_setter_html_partial_documentation_3(
             context1));
-    buffer.writeln();
+    buffer.write('\n    ');
     buffer.write(
         __deduplicated_lib_templates_html__accessor_setter_html_partial_source_code_4(
             context1));
     buffer.writeln();
     buffer.write('''
-</section>''');
+  </section>''');
   }
   buffer.writeln();
 

--- a/lib/templates/html/_accessor_getter.html
+++ b/lib/templates/html/_accessor_getter.html
@@ -1,14 +1,14 @@
-{{#getter}}
-<section id="getter">
+{{ #getter }}
+  <section id="getter">
 
-<section class="multi-line-signature">
-  {{ >annotations }}
-  <span class="returntype">{{{ modelType.returnType.linkedName }}}</span>
-  {{ >name_summary }}
-  {{ >attributes }}
-</section>
+    <section class="multi-line-signature">
+      {{ >annotations }}
+      <span class="returntype">{{{ modelType.returnType.linkedName }}}</span>
+      {{ >name_summary }}
+      {{ >attributes }}
+    </section>
 
-{{>documentation}}
-{{>source_code}}
-</section>
-{{/getter}}
+    {{ >documentation }}
+    {{ >source_code }}
+  </section>
+{{ /getter }}

--- a/lib/templates/html/_accessor_setter.html
+++ b/lib/templates/html/_accessor_setter.html
@@ -1,14 +1,14 @@
-{{#setter}}
-<section id="setter">
+{{ #setter }}
+  <section id="setter">
 
-<section class="multi-line-signature">
-  {{ >annotations }}
-  <span class="returntype">void</span>
-  {{ >name_summary }}<span class="signature">(<wbr>{{{ linkedParamsNoMetadata }}})</span>
-  {{ >attributes }}
-</section>
+    <section class="multi-line-signature">
+      {{ >annotations }}
+      <span class="returntype">void</span>
+      {{ >name_summary }}<span class="signature">(<wbr>{{{ linkedParamsNoMetadata }}})</span>
+      {{ >attributes }}
+    </section>
 
-{{>documentation}}
-{{>source_code}}
-</section>
-{{/setter}}
+    {{ >documentation }}
+    {{ >source_code }}
+  </section>
+{{ /setter }}

--- a/lib/templates/html/_callable.html
+++ b/lib/templates/html/_callable.html
@@ -1,10 +1,10 @@
-<dt id="{{htmlId}}" class="callable{{ #isInherited }} inherited{{ /isInherited}}">
-  <span class="name{{#isDeprecated}} deprecated{{/isDeprecated}}">{{{linkedName}}}</span>{{{linkedGenericParameters}}}<span class="signature">(<wbr>{{{ linkedParamsNoMetadata }}})
+<dt id="{{ htmlId }}" class="callable{{ #isInherited }} inherited{{ /isInherited}}">
+  <span class="name{{ #isDeprecated }} deprecated{{ /isDeprecated }}">{{{ linkedName }}}</span>{{{ linkedGenericParameters }}}<span class="signature">(<wbr>{{{ linkedParamsNoMetadata }}})
     <span class="returntype parameter">&#8594; {{{ modelType.returnType.linkedName }}}</span>
   </span>
-  {{>categorization}}
+  {{ >categorization }}
 </dt>
-<dd{{ #isInherited }} class="inherited"{{ /isInherited}}>
+<dd{{ #isInherited }} class="inherited"{{ /isInherited }}>
   {{{ oneLineDoc }}}
   {{ >attributes }}
 </dd>

--- a/lib/templates/html/_callable_multiline.html
+++ b/lib/templates/html/_callable_multiline.html
@@ -1,4 +1,4 @@
 {{ >annotations }}
 
 <span class="returntype">{{{ modelType.returnType.linkedName }}}</span>
-{{>name_summary}}{{{genericParameters}}}(<wbr>{{#hasParameters}}{{{linkedParamsLines}}}{{/hasParameters}})
+{{ >name_summary }}{{{ genericParameters }}}(<wbr>{{ #hasParameters }}{{{ linkedParamsLines }}}{{ /hasParameters }})

--- a/lib/templates/html/_extension.html
+++ b/lib/templates/html/_extension.html
@@ -1,7 +1,7 @@
-<dt id="{{htmlId}}">
-    <span class="name {{#isDeprecated}}deprecated{{/isDeprecated}}">{{{linkedName}}}</span> {{>categorization}}
+<dt id="{{ htmlId }}">
+  <span class="name {{ #isDeprecated }}deprecated{{ /isDeprecated }}">{{{ linkedName }}}</span> {{ >categorization }}
 </dt>
 <dd>
-    {{{ oneLineDoc }}}
+  {{{ oneLineDoc }}}
 </dd>
 

--- a/lib/templates/html/_property.html
+++ b/lib/templates/html/_property.html
@@ -1,8 +1,9 @@
-<dt id="{{htmlId}}" class="property{{ #isInherited }} inherited{{ /isInherited}}">
-  <span class="name">{{{linkedName}}}</span>
-  <span class="signature">{{{ arrow }}} {{{ modelType.linkedName }}}</span> {{>categorization}}
+<dt id="{{ htmlId }}" class="property{{ #isInherited }} inherited{{ /isInherited}}">
+  <span class="name">{{{ linkedName }}}</span>
+  <span class="signature">{{{ arrow }}} {{{ modelType.linkedName }}}</span>
+  {{ >categorization }}
 </dt>
-<dd{{ #isInherited }} class="inherited"{{ /isInherited}}>
+<dd{{ #isInherited }} class="inherited"{{ /isInherited }}>
   {{{ oneLineDoc }}}
   {{ >attributes }}
 </dd>

--- a/lib/templates/html/class.html
+++ b/lib/templates/html/class.html
@@ -1,77 +1,77 @@
-{{>head}}
+{{ >head }}
 
-  <div
-      id="dartdoc-main-content"
-      class="main-content"
-      data-above-sidebar="{{ aboveSidebarPath }}"
-      data-below-sidebar="{{ belowSidebarPath }}">
-    {{#self}}
-      <div>{{>source_link}}<h1><span class="kind-class">{{{nameWithGenerics}}}</span> {{kind}} {{>feature_set}} {{>categorization}}</h1></div>
-    {{/self}}
+<div
+    id="dartdoc-main-content"
+    class="main-content"
+    data-above-sidebar="{{ aboveSidebarPath }}"
+    data-below-sidebar="{{ belowSidebarPath }}">
+  {{ #self }}
+    <div>{{ >source_link }}<h1><span class="kind-class">{{{ nameWithGenerics }}}</span> {{ kind }} {{ >feature_set }} {{ >categorization }}</h1></div>
+  {{ /self }}
 
-    {{#clazz}}
-    {{>documentation}}
+  {{ #clazz }}
+    {{ >documentation }}
 
-    {{#hasModifiers}}
+    {{ #hasModifiers }}
     <section>
       <dl class="dl-horizontal">
         {{ >super_chain }}
         {{ >interfaces }}
         {{ >mixed_in_types }}
 
-        {{#hasPublicImplementors}}
-        <dt>Implementers</dt>
-        <dd><ul class="comma-separated clazz-relationships">
-          {{#publicImplementorsSorted}}
-          <li>{{{linkedName}}}</li>
-          {{/publicImplementorsSorted}}
-        </ul></dd>
-        {{/hasPublicImplementors}}
+        {{ #hasPublicImplementors }}
+          <dt>Implementers</dt>
+          <dd><ul class="comma-separated clazz-relationships">
+            {{ #publicImplementorsSorted }}
+              <li>{{{ linkedName }}}</li>
+            {{ /publicImplementorsSorted }}
+          </ul></dd>
+        {{ /hasPublicImplementors }}
 
-        {{#hasPotentiallyApplicableExtensions}}
-        <dt>Available Extensions</dt>
-        <dd><ul class="comma-separated clazz-relationships">
-          {{#potentiallyApplicableExtensionsSorted}}
-          <li>{{{linkedName}}}</li>
-          {{/potentiallyApplicableExtensionsSorted}}
-        </ul></dd>
-        {{/hasPotentiallyApplicableExtensions}}
+        {{ #hasPotentiallyApplicableExtensions }}
+          <dt>Available Extensions</dt>
+          <dd><ul class="comma-separated clazz-relationships">
+            {{ #potentiallyApplicableExtensionsSorted }}
+              <li>{{{ linkedName }}}</li>
+            {{ /potentiallyApplicableExtensionsSorted }}
+          </ul></dd>
+        {{ /hasPotentiallyApplicableExtensions }}
 
         {{ >container_annotations }}
       </dl>
     </section>
-    {{/hasModifiers}}
+    {{ /hasModifiers }}
 
     {{ >constructors }}
 
-    {{#hasPublicInstanceFields}}
+    {{ #hasPublicInstanceFields }}
     <section class="summary offset-anchor{{ #publicInheritedInstanceFields }} inherited{{ /publicInheritedInstanceFields }}" id="instance-properties">
       <h2>Properties</h2>
 
       <dl class="properties">
-        {{#publicInstanceFieldsSorted}}
-        {{>property}}
-        {{/publicInstanceFieldsSorted}}
+        {{ #publicInstanceFieldsSorted }}
+        {{ >property }}
+        {{ /publicInstanceFieldsSorted }}
       </dl>
     </section>
-    {{/hasPublicInstanceFields}}
+    {{ /hasPublicInstanceFields }}
 
     {{ >instance_methods }}
     {{ >instance_operators }}
     {{ >static_properties }}
     {{ >static_methods }}
     {{ >static_constants }}
-    {{/clazz}}
+  {{ /clazz }}
 
   </div> <!-- /.main-content -->
 
   <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
-    {{>search_sidebar}}
-    <h5>{{parent.name}} {{parent.kind}}</h5>
+    {{ >search_sidebar }}
+    <h5>{{ parent.name }} {{ parent.kind }}</h5>
     <div id="dartdoc-sidebar-left-content"></div>
   </div>
 
   <div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">
   </div><!--/.sidebar-offcanvas-->
 
-{{>footer}}
+{{ >footer }}

--- a/lib/templates/html/enum.html
+++ b/lib/templates/html/enum.html
@@ -1,62 +1,62 @@
 {{>head}}
 
-  <div
-      id="dartdoc-main-content"
-      class="main-content"
-      data-above-sidebar="{{ aboveSidebarPath }}"
-      data-below-sidebar="{{ belowSidebarPath }}">
-    {{ #self }}
-      <div>{{ >source_link }}
-        <h1>
-          <span class="kind-enum">{{{ nameWithGenerics }}}</span>
-          {{ kind }} {{ >feature_set }} {{ >categorization }}
-        </h1>
-      </div>
-    {{ /self }}
+<div
+    id="dartdoc-main-content"
+    class="main-content"
+    data-above-sidebar="{{ aboveSidebarPath }}"
+    data-below-sidebar="{{ belowSidebarPath }}">
+  {{ #self }}
+    <div>{{ >source_link }}
+      <h1>
+        <span class="kind-enum">{{{ nameWithGenerics }}}</span>
+        {{ kind }} {{ >feature_set }} {{ >categorization }}
+      </h1>
+    </div>
+  {{ /self }}
 
-    {{ #eNum }}
+  {{ #eNum }}
     {{ >documentation }}
 
     {{ #hasModifiers }}
-    <section>
-      <dl class="dl-horizontal">
-        {{ >super_chain }}
-        {{ >interfaces }}
-        {{ >mixed_in_types }}
-        {{ >container_annotations }}
-      </dl>
-    </section>
+      <section>
+        <dl class="dl-horizontal">
+          {{ >super_chain }}
+          {{ >interfaces }}
+          {{ >mixed_in_types }}
+          {{ >container_annotations }}
+        </dl>
+      </section>
     {{ /hasModifiers }}
 
     {{ >constructors }}
 
     {{ #hasPublicEnumValues }}
-    <section class="summary offset-anchor" id="values">
-      <h2>Values</h2>
+      <section class="summary offset-anchor" id="values">
+        <h2>Values</h2>
 
-      <dl class="properties">
-        {{ #publicEnumValues }}
-          {{ >constant }}
-        {{ /publicEnumValues }}
-      </dl>
-    </section>
+        <dl class="properties">
+          {{ #publicEnumValues }}
+            {{ >constant }}
+          {{ /publicEnumValues }}
+        </dl>
+      </section>
     {{ /hasPublicEnumValues }}
 
     {{ #hasPublicInstanceFields }}
-    <section
-        class="
-          summary
-          offset-anchor
-          {{ #publicInheritedInstanceFields }}inherited{{ /publicInheritedInstanceFields }}"
-        id="instance-properties">
-      <h2>Properties</h2>
+      <section
+          class="
+            summary
+            offset-anchor
+            {{ #publicInheritedInstanceFields }}inherited{{ /publicInheritedInstanceFields }}"
+          id="instance-properties">
+        <h2>Properties</h2>
 
-      <dl class="properties">
-        {{ #publicInstanceFieldsSorted }}
-        {{ >property }}
-        {{ /publicInstanceFieldsSorted }}
-      </dl>
-    </section>
+        <dl class="properties">
+          {{ #publicInstanceFieldsSorted }}
+          {{ >property }}
+          {{ /publicInstanceFieldsSorted }}
+        </dl>
+      </section>
     {{ /hasPublicInstanceFields }}
 
     {{ >instance_methods }}
@@ -64,16 +64,16 @@
     {{ >static_properties }}
     {{ >static_methods }}
     {{ >static_constants }}
-    {{ /eNum }}
-  </div><!-- /.main-content -->
+  {{ /eNum }}
+</div><!-- /.main-content -->
 
-  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
-    {{ >search_sidebar}}
-    <h5>{{ parent.name }} {{ parent.kind }}</h5>
-    <div id="dartdoc-sidebar-left-content"></div>
-  </div>
+<div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
+  {{ >search_sidebar }}
+  <h5>{{ parent.name }} {{ parent.kind }}</h5>
+  <div id="dartdoc-sidebar-left-content"></div>
+</div>
 
-  <div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">
-  </div><!-- /.sidebar-offcanvas -->
+<div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">
+</div><!-- /.sidebar-offcanvas -->
 
 {{ >footer }}

--- a/lib/templates/html/extension_type.html
+++ b/lib/templates/html/extension_type.html
@@ -4,12 +4,12 @@
     class="main-content"
     data-above-sidebar="{{ aboveSidebarPath }}"
     data-below-sidebar="{{ belowSidebarPath }}">
-    {{ #self }}
+  {{ #self }}
     <div>{{ >source_link }}<h1><span class="kind-class">{{{ nameWithGenerics }}}</span>
       {{ kind }} {{ >feature_set }} {{ >categorization }}</h1></div>
-    {{ /self }}
+  {{ /self }}
 
-    {{ #extensionType }}
+  {{ #extensionType }}
     {{ >documentation }}
     <section>
       <dl class="dl-horizontal">
@@ -18,7 +18,7 @@
           <ul class="comma-separated clazz-relationships">
             {{ #representationType }}
               <li>{{{ linkedName }}}</li>
-          {{ /representationType }}
+            {{ /representationType }}
           </ul>
         </dd>
         {{ >interfaces }}
@@ -29,15 +29,15 @@
     {{ >constructors }}
 
     {{ #hasPublicInstanceFields }}
-    <section class="summary offset-anchor" id="instance-properties">
+      <section class="summary offset-anchor" id="instance-properties">
         <h2>Properties</h2>
 
         <dl class="properties">
-            {{ #publicInstanceFieldsSorted }}
+          {{ #publicInstanceFieldsSorted }}
             {{ >property }}
-            {{ /publicInstanceFieldsSorted }}
+          {{ /publicInstanceFieldsSorted }}
         </dl>
-    </section>
+      </section>
     {{ /hasPublicInstanceFields }}
 
     {{ >instance_methods }}
@@ -46,11 +46,12 @@
     {{ >static_methods }}
     {{ >static_constants }}
 
+  {{ /extensionType }}
 </div><!-- /.main-content -->
 
 <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
-    {{ >search_sidebar }}
-    <h5>{{ parent.name }} {{ parent.kind }}</h5>
+  {{ >search_sidebar }}
+  <h5>{{ parent.name }} {{ parent.kind }}</h5>
 </div>
 
 <div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">

--- a/lib/templates/html/mixin.html
+++ b/lib/templates/html/mixin.html
@@ -1,75 +1,75 @@
 {{>head}}
 
-  <div
-      id="dartdoc-main-content"
-      class="main-content"
-      data-above-sidebar="{{ aboveSidebarPath }}"
-      data-below-sidebar="{{ belowSidebarPath }}">
-    {{#self}}
-      <div>{{>source_link}}<h1><span class="kind-mixin">{{{nameWithGenerics}}}</span> {{kind}} {{>feature_set}} {{>categorization}}</h1></div>
-    {{/self}}
+<div
+    id="dartdoc-main-content"
+    class="main-content"
+    data-above-sidebar="{{ aboveSidebarPath }}"
+    data-below-sidebar="{{ belowSidebarPath }}">
+  {{ #self }}
+    <div>{{ >source_link }}<h1><span class="kind-mixin">{{{ nameWithGenerics }}}</span> {{ kind }} {{ >feature_set }} {{ >categorization }}</h1></div>
+  {{ /self }}
 
-    {{#mixin}}
-    {{>documentation}}
+  {{ #mixin }}
+  {{ >documentation }}
 
-    {{#hasModifiers}}
+  {{ #hasModifiers }}
     <section>
       <dl class="dl-horizontal">
-        {{#hasPublicSuperclassConstraints}}
-        <dt>Superclass Constraints</dt>
-        <dd><ul class="comma-separated dark mixin-relationships">
-          {{#publicSuperclassConstraints}}
-          <li>{{{linkedName}}}</li>
-          {{/publicSuperclassConstraints}}
-        </ul></dd>
-        {{/hasPublicSuperclassConstraints}}
+        {{ #hasPublicSuperclassConstraints }}
+          <dt>Superclass Constraints</dt>
+          <dd><ul class="comma-separated dark mixin-relationships">
+            {{ #publicSuperclassConstraints }}
+              <li>{{{ linkedName }}}</li>
+            {{ /publicSuperclassConstraints }}
+          </ul></dd>
+        {{ /hasPublicSuperclassConstraints }}
 
         {{ >super_chain }}
         {{ >interfaces }}
 
-        {{#hasPublicImplementors}}
-        <dt>Mixin Applications</dt>
-        <dd>
-          <ul class="comma-separated mixin-relationships">
-            {{#publicImplementorsSorted}}
-            <li>{{{linkedName}}}</li>
-            {{/publicImplementorsSorted}}
-          </ul>
-        </dd>
-        {{/hasPublicImplementors}}
+        {{ #hasPublicImplementors }}
+          <dt>Mixin Applications</dt>
+          <dd>
+            <ul class="comma-separated mixin-relationships">
+              {{ #publicImplementorsSorted }}
+              <li>{{{ linkedName }}}</li>
+              {{ /publicImplementorsSorted }}
+            </ul>
+          </dd>
+        {{ /hasPublicImplementors }}
 
         {{ >annotations }}
       </dl>
     </section>
-    {{/hasModifiers}}
+  {{ /hasModifiers }}
 
-    {{#hasPublicInstanceFields}}
+  {{ #hasPublicInstanceFields }}
     <section class="summary offset-anchor{{ #publicInheritedInstanceFields }} inherited{{ /publicInheritedInstanceFields }}" id="instance-properties">
       <h2>Properties</h2>
 
       <dl class="properties">
-        {{#publicInstanceFields}}
-        {{>property}}
-        {{/publicInstanceFields}}
+        {{ #publicInstanceFields }}
+          {{ >property }}
+        {{ /publicInstanceFields }}
       </dl>
     </section>
-    {{/hasPublicInstanceFields}}
+    {{ /hasPublicInstanceFields }}
 
     {{ >instance_methods }}
     {{ >instance_operators }}
     {{ >static_properties }}
     {{ >static_methods }}
     {{ >static_constants }}
-    {{/mixin}}
-  </div> <!-- /.main-content -->
+  {{ /mixin }}
+</div> <!-- /.main-content -->
 
-  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
-    {{>search_sidebar}}
-    <h5>{{parent.name}} {{parent.kind}}</h5>
-    <div id="dartdoc-sidebar-left-content"></div>
-  </div>
+<div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
+  {{>search_sidebar}}
+  <h5>{{parent.name}} {{parent.kind}}</h5>
+  <div id="dartdoc-sidebar-left-content"></div>
+</div>
 
-  <div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">
-  </div><!--/.sidebar-offcanvas-->
+<div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">
+</div><!--/.sidebar-offcanvas-->
 
-{{>footer}}
+{{ >footer }}

--- a/lib/templates/html/property.html
+++ b/lib/templates/html/property.html
@@ -1,45 +1,45 @@
-{{>head}}
+{{ >head }}
 
-  <div
-      id="dartdoc-main-content"
-      class="main-content"
-      data-above-sidebar="{{ aboveSidebarPath }}"
-      data-below-sidebar="{{ belowSidebarPath }}">
-    {{#self}}
-      <div>{{>source_link}}<h1><span class="kind-property">{{name}}</span> {{kind}} {{>feature_set}}</h1></div>
-    {{/self}}
+<div
+    id="dartdoc-main-content"
+    class="main-content"
+    data-above-sidebar="{{ aboveSidebarPath }}"
+    data-below-sidebar="{{ belowSidebarPath }}">
+  {{ #self }}
+    <div>{{ >source_link }}<h1><span class="kind-property">{{ name }}</span> {{ kind }} {{ >feature_set }}</h1></div>
+  {{ /self }}
 
-    {{#self}}
-      {{#hasNoGetterSetter}}
-        <section class="multi-line-signature">
-          {{ >annotations }}
-          {{{ modelType.linkedName }}}
-          {{ >name_summary }}
-          {{ >attributes }}
-        </section>
-        {{>documentation}}
-        {{>source_code}}
-      {{/hasNoGetterSetter}}
+  {{ #self }}
+    {{ #hasNoGetterSetter }}
+      <section class="multi-line-signature">
+        {{ >annotations }}
+        {{{ modelType.linkedName }}}
+        {{ >name_summary }}
+        {{ >attributes }}
+      </section>
+      {{ >documentation }}
+      {{ >source_code }}
+    {{ /hasNoGetterSetter }}
 
-      {{#hasGetterOrSetter}}
-        {{#hasGetter}}
-        {{>accessor_getter}}
-        {{/hasGetter}}
+    {{ #hasGetterOrSetter }}
+      {{ #hasGetter }}
+        {{ >accessor_getter }}
+      {{ /hasGetter }}
 
-        {{#hasSetter}}
-        {{>accessor_setter}}
-        {{/hasSetter}}
-      {{/hasGetterOrSetter}}
-    {{/self}}
-  </div> <!-- /.main-content -->
+      {{ #hasSetter }}
+        {{ >accessor_setter }}
+      {{ /hasSetter }}
+    {{ /hasGetterOrSetter }}
+  {{ /self }}
+</div> <!-- /.main-content -->
 
-  <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
-    {{>search_sidebar}}
-    <h5>{{parent.name}} {{parent.kind}}</h5>
-    <div id="dartdoc-sidebar-left-content"></div>
-  </div><!--/.sidebar-offcanvas-->
+<div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
+  {{ >search_sidebar }}
+  <h5>{{ parent.name }} {{ parent.kind }}</h5>
+  <div id="dartdoc-sidebar-left-content"></div>
+</div><!--/.sidebar-offcanvas-->
 
-  <div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">
-  </div><!--/.sidebar-offcanvas-->
+<div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">
+</div><!--/.sidebar-offcanvas-->
 
-{{>footer}}
+{{ >footer }}


### PR DESCRIPTION
I've been trying to standardize on this style. Two things:

* Indent all HTML and block-like Mustache tags 2 spaces. This style does affect the indentation of the output HTML, but it should not be so many bytes as to matter.
* Write all Mustache tags with an opening space and a closing space, just next to the `{`/`}` delimiters. E.g. `{{ #getter }}` and `{{{ linkedGenericParameters }}}`. This style does not affect the outputted HTML.

Here I am just touching files that I might need to update for https://github.com/dart-lang/dartdoc/issues/2021.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
