### PR TITLE
Replace record keys in maps

### DIFF
--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -173,8 +173,8 @@ abstract class ModelElement extends Canonicalization
     }
 
     // Return the cached ModelElement if it exists.
-    var cachedModelElement = packageGraph
-        .allConstructedModelElements[(e, library, enclosingContainer)];
+    var cachedModelElement = packageGraph.allConstructedModelElements[
+        ConstructedModelElementsKey(e, library, enclosingContainer)];
     if (cachedModelElement != null) {
       return cachedModelElement;
     }
@@ -263,8 +263,8 @@ abstract class ModelElement extends Canonicalization
     }
 
     // Return the cached ModelElement if it exists.
-    var cachedModelElement = packageGraph
-        .allConstructedModelElements[(e, library, enclosingContainer)];
+    var cachedModelElement = packageGraph.allConstructedModelElements[
+        ConstructedModelElementsKey(e, library, enclosingContainer)];
     if (cachedModelElement != null) {
       return cachedModelElement;
     }
@@ -294,11 +294,12 @@ abstract class ModelElement extends Canonicalization
     //                   is fixed?
     if (library != Library.sentinel && newModelElement is! Parameter) {
       runtimeStats.incrementAccumulator('modelElementCacheInsertion');
-      var key = (e, library, enclosingContainer);
+      var key = ConstructedModelElementsKey(e, library, enclosingContainer);
       library.packageGraph.allConstructedModelElements[key] = newModelElement;
       if (newModelElement is Inheritable) {
         library.packageGraph.allInheritableElements
-            .putIfAbsent((e, library), () => {}).add(newModelElement);
+            .putIfAbsent(InheritableElementsKey(e, library), () => {})
+            .add(newModelElement);
       }
     }
   }

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -318,11 +318,12 @@ class PackageGraph with CommentReferable, Nameable, ModelBuilder {
 
   /// All [ModelElement]s constructed for this package; a superset of
   /// the elements gathered in [_gatherModelElements].
-  final Map<(Element element, Library library, Container? enclosingElement),
-      ModelElement> allConstructedModelElements = {};
+  final Map<ConstructedModelElementsKey, ModelElement>
+      allConstructedModelElements = {};
 
   /// Anything that might be inheritable, place here for later lookup.
-  final Map<(Element, Library), Set<ModelElement>> allInheritableElements = {};
+  final Map<InheritableElementsKey, Set<ModelElement>> allInheritableElements =
+      {};
 
   /// A mapping of the list of classes which implement each class.
   final Map<InheritingContainer, List<InheritingContainer>> _implementors =
@@ -800,18 +801,20 @@ class PackageGraph with CommentReferable, Nameable, ModelBuilder {
       {InheritingContainer? preferredClass}) {
     var candidates = <ModelElement>{};
     if (lib != null) {
-      var constructedWithKey = allConstructedModelElements[(e, lib, null)];
+      var constructedWithKey = allConstructedModelElements[
+          ConstructedModelElementsKey(e, lib, null)];
       if (constructedWithKey != null) {
         candidates.add(constructedWithKey);
       }
-      var constructedWithKeyWithClass =
-          allConstructedModelElements[(e, lib, preferredClass)];
+      var constructedWithKeyWithClass = allConstructedModelElements[
+          ConstructedModelElementsKey(e, lib, preferredClass)];
       if (constructedWithKeyWithClass != null) {
         candidates.add(constructedWithKeyWithClass);
       }
       if (candidates.isEmpty) {
         candidates = {
-          ...?allInheritableElements[(e, lib)]?.where((me) => me.isCanonical),
+          ...?allInheritableElements[InheritableElementsKey(e, lib)]
+              ?.where((me) => me.isCanonical),
         };
       }
     }
@@ -1003,4 +1006,31 @@ class PackageGraph with CommentReferable, Nameable, ModelBuilder {
 
   @override
   Iterable<CommentReferable> get referenceParents => const [];
+}
+
+class ConstructedModelElementsKey {
+  final Element element;
+  final Library library;
+  final Container? enclosingElement;
+
+  ConstructedModelElementsKey(
+      this.element, this.library, this.enclosingElement);
+
+  @override
+  late final int hashCode = Object.hash(element, library, enclosingElement);
+
+  @override
+  bool operator ==(Object other) {
+    if (other is! ConstructedModelElementsKey) return false;
+    return other.element == element &&
+        other.library == library &&
+        other.enclosingElement == enclosingElement;
+  }
+}
+
+class InheritableElementsKey {
+  final Element element;
+  final Library library;
+
+  InheritableElementsKey(this.element, this.library);
 }


### PR DESCRIPTION
Something weird is happening - for dart JIT - when using records as keys in maps. See also https://github.com/dart-lang/sdk/issues/54928 where I reported it as a bug.

This PR uses 2 classes instead.
The result - for a very small example - is:

```
Difference at 95.0% confidence
        -6286.33 +/- 969.339
        -29.6791% +/- 4.57645%
        (Student's t, pooled s = 427.663)
```

(from ~21 seconds to ~15 seconds)

and trying on flutter the result is

```
Difference at 95.0% confidence
        -46593 +/- 2604.32
        -37.4728% +/- 2.09454%
        (Student's t, pooled s = 1149)
```

(from ~124 seconds to ~78 seconds)

There is ~no difference for an AOT compile.