### PR TITLE
Make a few optimizations

### DIFF
--- a/lib/src/model/inheriting_container.dart
+++ b/lib/src/model/inheriting_container.dart
@@ -104,10 +104,15 @@ abstract class InheritingContainer extends Container
               packageGraph.rendererFactory.languageFeatureRenderer)
           .toList();
 
-  late final List<ModelElement> _allModelElements = [
-    ...super.allModelElements,
-    ...typeParameters,
-  ];
+  late final List<ModelElement> _allModelElements = () {
+    _inheritedElementsCache = _inheritedElements;
+    var result = [
+      ...super.allModelElements,
+      ...typeParameters,
+    ];
+    _inheritedElementsCache = null;
+    return result;
+  }();
 
   Iterable<Method> get inheritedMethods {
     var methodNames = declaredMethods.map((m) => m.element.name).toSet();
@@ -144,7 +149,9 @@ abstract class InheritingContainer extends Container
   late final List<DefinedElementType> publicSuperChain =
       model_utils.filterNonPublic(superChain).toList(growable: false);
 
+  List<ExecutableElement>? _inheritedElementsCache;
   List<ExecutableElement> get _inheritedElements {
+    if (_inheritedElementsCache != null) return _inheritedElementsCache!;
     if (element is ClassElement && (element as ClassElement).isDartCoreObject) {
       return const <ExecutableElement>[];
     }
@@ -193,7 +200,7 @@ abstract class InheritingContainer extends Container
   }
 
   /// All fields defined on this container, _including inherited fields_.
-  List<Field> get allFields {
+  late List<Field> allFields = () {
     var inheritedAccessorElements = {
       ..._inheritedElements.whereType<PropertyAccessorElement>()
     };
@@ -243,7 +250,7 @@ abstract class InheritingContainer extends Container
     });
 
     return fields;
-  }
+  }();
 
   @override
   late final List<Method> declaredMethods = element.methods

--- a/lib/src/model/package.dart
+++ b/lib/src/model/package.dart
@@ -175,7 +175,7 @@ class Package extends LibraryContainer
 
   /// Returns the location of documentation for this package, for linkToRemote
   /// and canonicalization decision making.
-  DocumentLocation get documentedWhere {
+  late DocumentLocation documentedWhere = () {
     if (isLocal && isPublic) {
       return DocumentLocation.local;
     }
@@ -186,7 +186,7 @@ class Package extends LibraryContainer
       return DocumentLocation.remote;
     }
     return DocumentLocation.missing;
-  }
+  }();
 
   @override
   String get enclosingName => packageGraph.defaultPackageName;


### PR DESCRIPTION
This:

  * Make 'allFields' a late field instead
  * Cache _inheritedElements in allModelElements call
  * Make documentedWhere a late field

Measusred on top of (and compared to) https://github.com/dart-lang/dartdoc/pull/3659 (I couldn't figure out how to actually do a stacked thing on github):

Very small, JIT:
```
Difference at 95.0% confidence
        -2052.67 +/- 417.162
        -13.7812% +/- 2.80075%
        (Student's t, pooled s = 184.048)
```

Very small, AOT:
```
Difference at 95.0% confidence
        -1370.33 +/- 214.258
        -20.2832% +/- 3.17138%
        (Student's t, pooled s = 94.5287)
```

Flutter, JIT:
```
Difference at 95.0% confidence
        -5111.33 +/- 2168.41
        -6.57446% +/- 2.78912%
        (Student's t, pooled s = 956.682)
```

Flutter, AOT:
```
Difference at 95.0% confidence
        -3224.33 +/- 599.597
        -5.33441% +/- 0.991988%
        (Student's t, pooled s = 264.537)
```

So it seems better across the board, but comparably less so for a big application (flutter in this case) --- which makes sense because most of the time is spent in the "generator.generate" (name from the "Runtime performance" when running with -v) where these changes is optimizing the "initializePackageGraph" part...