### PR TITLE
Fix missing left sidebar on extension type pages

### DIFF
--- a/lib/src/generator/templates.aot_renderers_for_html.dart
+++ b/lib/src/generator/templates.aot_renderers_for_html.dart
@@ -918,6 +918,7 @@ String renderExtensionType<T extends ExtensionType>(
   buffer.write(' ');
   buffer.writeEscaped(context0.parent!.kind.toString());
   buffer.write('''</h5>
+  <div id="dartdoc-sidebar-left-content"></div>
 </div>
 
 <div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">

--- a/lib/templates/html/extension_type.html
+++ b/lib/templates/html/extension_type.html
@@ -52,6 +52,7 @@
 <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
   {{ >search_sidebar }}
   <h5>{{ parent.name }} {{ parent.kind }}</h5>
+  <div id="dartdoc-sidebar-left-content"></div>
 </div>
 
 <div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">


### PR DESCRIPTION
As seen on https://api.dart.dev/stable/dart-js_interop/JSObject-extension-type.html