### PR TITLE
Do not crash in the presence of macro applications.

### DIFF
--- a/lib/src/model/method.dart
+++ b/lib/src/model/method.dart
@@ -113,7 +113,8 @@ class Method extends ModelElement
       return null;
     }
     var parent = element.enclosingElement as InterfaceElement;
-    for (var t in parent.allSupertypes) {
+    var parentDeclaration = parent.augmented?.declaration ?? parent;
+    for (var t in parentDeclaration.allSupertypes) {
       Element? e = t.getMethod(element.name);
       if (e != null) {
         assert(

--- a/lib/src/model/package_builder.dart
+++ b/lib/src/model/package_builder.dart
@@ -136,8 +136,7 @@ class PubPackageBuilder implements PackageBuilder {
 
   late final Map<String, List<Folder>> _packageMap;
 
-  late final AnalysisContextCollection _contextCollection =
-      AnalysisContextCollectionImpl(
+  late final _contextCollection = AnalysisContextCollectionImpl(
     includedPaths: [_config.inputDir],
     // TODO(jcollins-g): should we pass excluded directories here instead of
     // handling it ourselves?
@@ -464,6 +463,8 @@ class PubPackageBuilder implements PackageBuilder {
       specialFiles.difference(files),
       addingSpecials: true,
     );
+    // Shutdown macro support.
+    await _contextCollection.dispose();
   }
 
   /// Throws an exception if any configured-to-be-included files were not found

--- a/lib/src/model/package_builder.dart
+++ b/lib/src/model/package_builder.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 
-import 'package:analyzer/dart/analysis/analysis_context_collection.dart';
 import 'package:analyzer/dart/analysis/context_root.dart';
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/ast/ast.dart';

--- a/lib/src/model/source_code_mixin.dart
+++ b/lib/src/model/source_code_mixin.dart
@@ -13,12 +13,28 @@ mixin SourceCode implements Documentable {
 
   Element? get element;
 
-  bool get hasSourceCode => config.includeSource && sourceCode.isNotEmpty;
+  bool get hasSourceCode =>
+      config.includeSource && !element.isAugmentation && sourceCode.isNotEmpty;
 
   Library? get library;
 
   String get sourceCode {
     var modelNode = this.modelNode;
     return modelNode == null ? '' : modelNode.sourceCode;
+  }
+}
+
+extension on Element? {
+  /// Whether `this` is an agumentation method or property.
+  ///
+  /// This property should only be referenced for elements whose source code we
+  /// may wish to refer to.
+  bool get isAugmentation {
+    final self = this;
+    return switch (self) {
+      ExecutableElement() => self.augmentationTarget != null,
+      PropertyInducingElement() => self.augmentationTarget != null,
+      _ => false,
+    };
   }
 }

--- a/lib/src/model/source_code_mixin.dart
+++ b/lib/src/model/source_code_mixin.dart
@@ -25,7 +25,7 @@ mixin SourceCode implements Documentable {
 }
 
 extension on Element? {
-  /// Whether `this` is an agumentation method or property.
+  /// Whether `this` is an augmentation method or property.
   ///
   /// This property should only be referenced for elements whose source code we
   /// may wish to refer to.


### PR DESCRIPTION
Fixes https://github.com/dart-lang/dartdoc/issues/3653

* Dispose of an AnalysisContextCollectionImpl.
* Before getting class hierarchy, navigate to possible augmentation declaration.
* Do not attempt to access source code of augmentation elements.

I cannot add tests yet because dartdoc needs to depend on a pinned version of the analyzer which matches the SDK in which the tests are run. We could do this if dartdoc was in the SDK repo, and we will more likely start when the macro API stuff is moved to a `dart:` library.


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
