### PR TITLE
Remove CallableElementType.

### DIFF
--- a/lib/src/element_type.dart
+++ b/lib/src/element_type.dart
@@ -406,27 +406,6 @@ mixin Rendered implements ElementType {
   ElementTypeRenderer<ElementType> get _renderer;
 }
 
-/// A callable type that may or may not be backed by a declaration using the
-/// generic function syntax.
-class CallableElementType extends DefinedElementType with Rendered, Callable {
-  CallableElementType._(
-      FunctionType super.t, super.library, super.packageGraph, super.element)
-      : super._();
-
-  @override
-  String get name => super.name.isNotEmpty ? super.name : 'Function';
-
-  @override
-  ElementTypeRenderer<CallableElementType> get _renderer =>
-      const CallableElementTypeRendererHtml();
-
-  @override
-  late final List<ElementType> typeArguments = type.alias?.typeArguments
-          .map((f) => modelBuilder.typeFrom(f, library))
-          .toList(growable: false) ??
-      const [];
-}
-
 extension on DartType {
   /// The dartdoc nullability suffix for this type in [library].
   String nullabilitySuffixWithin(Library library) {

--- a/lib/src/render/element_type_renderer.dart
+++ b/lib/src/render/element_type_renderer.dart
@@ -176,37 +176,3 @@ class AliasedElementTypeRendererHtml
         elementType.aliasArguments,
       );
 }
-
-class CallableElementTypeRendererHtml
-    extends ElementTypeRenderer<CallableElementType> {
-  const CallableElementTypeRendererHtml();
-
-  @override
-  String renderLinkedName(CallableElementType elementType) {
-    var buffer = StringBuffer()
-      ..write(elementType.nameWithGenerics)
-      ..write('(')
-      ..write(const ParameterRendererHtml()
-          .renderLinkedParams(elementType.modelElement.parameters,
-              showNames: false)
-          .trim())
-      ..write(') → ')
-      ..write(elementType.returnType.linkedName);
-    return wrapNullabilityParens(elementType, buffer.toString());
-  }
-
-  @override
-  String renderNameWithGenerics(CallableElementType elementType) {
-    var buffer = StringBuffer()..write(elementType.name);
-    if (elementType.typeArguments.isNotEmpty &&
-        !elementType.typeArguments.every((t) => t.name == 'dynamic')) {
-      buffer
-        ..write('&lt;')
-        ..writeAll(
-            elementType.typeArguments.map((t) => t.nameWithGenerics), ', ')
-        ..write('>');
-    }
-    buffer.write(elementType.nullabilitySuffix);
-    return buffer.toString();
-  }
-}

--- a/lib/src/render/parameter_renderer.dart
+++ b/lib/src/render/parameter_renderer.dart
@@ -65,7 +65,7 @@ abstract class ParameterRenderer {
   String required(String required);
 
   String renderLinkedParams(List<Parameter> parameters,
-      {bool showMetadata = true, bool showNames = true}) {
+      {bool showMetadata = true}) {
     var positionalParams = parameters
         .where((Parameter p) => p.isRequiredPositional)
         .toList(growable: false);
@@ -77,27 +77,33 @@ abstract class ParameterRenderer {
 
     var buffer = StringBuffer();
     if (positionalParams.isNotEmpty) {
-      _renderLinkedParameterSublist(positionalParams, buffer,
-          trailingComma:
-              optionalPositionalParams.isNotEmpty || namedParams.isNotEmpty,
-          showMetadata: showMetadata,
-          showNames: showNames);
+      _renderLinkedParameterSublist(
+        positionalParams,
+        buffer,
+        trailingComma:
+            optionalPositionalParams.isNotEmpty || namedParams.isNotEmpty,
+        showMetadata: showMetadata,
+      );
     }
     if (optionalPositionalParams.isNotEmpty) {
-      _renderLinkedParameterSublist(optionalPositionalParams, buffer,
-          trailingComma: namedParams.isNotEmpty,
-          openBracket: '[',
-          closeBracket: ']',
-          showMetadata: showMetadata,
-          showNames: showNames);
+      _renderLinkedParameterSublist(
+        optionalPositionalParams,
+        buffer,
+        trailingComma: namedParams.isNotEmpty,
+        openBracket: '[',
+        closeBracket: ']',
+        showMetadata: showMetadata,
+      );
     }
     if (namedParams.isNotEmpty) {
-      _renderLinkedParameterSublist(namedParams, buffer,
-          trailingComma: false,
-          openBracket: '{',
-          closeBracket: '}',
-          showMetadata: showMetadata,
-          showNames: showNames);
+      _renderLinkedParameterSublist(
+        namedParams,
+        buffer,
+        trailingComma: false,
+        openBracket: '{',
+        closeBracket: '}',
+        showMetadata: showMetadata,
+      );
     }
     return orderedList(buffer.toString());
   }
@@ -109,7 +115,6 @@ abstract class ParameterRenderer {
     String openBracket = '',
     String closeBracket = '',
     bool showMetadata = true,
-    bool showNames = true,
   }) {
     for (var p in parameters) {
       var prefix = '';
@@ -128,7 +133,6 @@ abstract class ParameterRenderer {
         prefix: prefix,
         suffix: suffix,
         showMetadata: showMetadata,
-        showNames: showNames,
       );
       buffer.write(listItem(parameter(renderedParameter, p.htmlId)));
     }
@@ -139,7 +143,6 @@ abstract class ParameterRenderer {
     required String prefix,
     required String suffix,
     bool showMetadata = true,
-    bool showNames = true,
   }) {
     final buffer = StringBuffer(prefix);
     final modelType = param.modelType;
@@ -160,17 +163,12 @@ abstract class ParameterRenderer {
           ? modelType.linkedName
           : modelType.returnType.linkedName;
       buffer.write(typeName(returnTypeName));
-      if (showNames) {
-        buffer.write(' ${parameterName(param.name)}');
-      } else {
-        buffer.write(' ${parameterName(modelType.name)}');
-      }
+      buffer.write(' ${parameterName(param.name)}');
       if (!modelType.isTypedef && modelType is DefinedElementType) {
         buffer.write('(');
         buffer.write(renderLinkedParams(
           (modelType as DefinedElementType).modelElement.parameters,
           showMetadata: showMetadata,
-          showNames: showNames,
         ));
         buffer.write(')');
         buffer.write(modelType.nullabilitySuffix);
@@ -180,7 +178,6 @@ abstract class ParameterRenderer {
         buffer.write(renderLinkedParams(
           modelType.parameters,
           showMetadata: showMetadata,
-          showNames: showNames,
         ));
         buffer.write(')');
         buffer.write(modelType.nullabilitySuffix);
@@ -189,11 +186,11 @@ abstract class ParameterRenderer {
       final linkedTypeName = modelType.linkedName;
       if (linkedTypeName.isNotEmpty) {
         buffer.write(typeName(linkedTypeName));
-        if (showNames && param.name.isNotEmpty) {
+        if (param.name.isNotEmpty) {
           buffer.write(' ');
         }
       }
-      if (showNames && param.name.isNotEmpty) {
+      if (param.name.isNotEmpty) {
         buffer.write(parameterName(param.name));
       }
     }

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -4379,7 +4379,7 @@ String? topLevelFunction(int param1, bool param2, Cool coolBeans,
     test('a function requiring a Future<void> parameter', () {
       expect(
           ParameterRendererHtml().renderLinkedParams(aVoidParameter.parameters,
-              showMetadata: true, showNames: true),
+              showMetadata: true),
           equals(
               '<span class="parameter" id="aVoidParameter-param-p1"><span class="type-annotation">Future<span class="signature">&lt;<wbr><span class="type-parameter">void</span>&gt;</span></span> <span class="parameter-name">p1</span></span>'));
     });


### PR DESCRIPTION
Was looking at a bug and realized we don't use this code.

Removed `CallableElementType` which ended up removing the renderer.
`showNames` in the `ParameterRenderer` was only being set to false in this one place, so that's completely unused now too.

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
