### PR TITLE
Fix enum representationsto show correct (implicit) args, const

### DIFF
--- a/lib/src/model/getter_setter_combo.dart
+++ b/lib/src/model/getter_setter_combo.dart
@@ -133,7 +133,8 @@ mixin GetterSetterCombo on ModelElement {
       // For an enum value with an implicit constructor call (like
       // `enum E { one, two; }`), `constantInitializer.toString()` does not
       // include the implicit enum index argument (it is something like
-      // `const E()`). We must manually include it.
+      // `const E()`). We must manually include it. See
+      // https://github.com/dart-lang/sdk/issues/54988.
       initializerString =
           initializerString.replaceFirst('()', '(${self.index})');
     }

--- a/lib/src/model/getter_setter_combo.dart
+++ b/lib/src/model/getter_setter_combo.dart
@@ -73,15 +73,15 @@ mixin GetterSetterCombo on ModelElement {
       return original;
     }
     var target = modelBuilder.fromElement(staticElement) as Constructor;
-    if (target.enclosingElement is! Class) return original;
-    var targetClass = target.enclosingElement as Class;
-    // TODO(jcollins-g): this logic really should be integrated into Constructor,
-    // but that's not trivial because of linkedName's usage.
-    if (targetClass.name == target.name) {
+    var enclosingElement = target.enclosingElement;
+    if (enclosingElement is! Class) return original;
+    // TODO(jcollins-g): this logic really should be integrated into
+    // `Constructor`, but that's not trivial because of `linkedName`'s usage.
+    if (enclosingElement.name == target.name) {
       return original.replaceAll(constructorName, target.linkedName);
     }
-    return original.replaceAll('${targetClass.name}.${target.name}',
-        '${targetClass.linkedName}.${target.linkedName}');
+    return original.replaceAll('${enclosingElement.name}.${target.name}',
+        '${enclosingElement.linkedName}.${target.linkedName}');
   }
 
   @override
@@ -110,8 +110,37 @@ mixin GetterSetterCombo on ModelElement {
   String get constantValueTruncated =>
       linkifyConstantValue(truncateString(constantValueBase, 200));
 
-  late final String constantValueBase = const HtmlEscape(HtmlEscapeMode.unknown)
-      .convert(constantInitializer?.toString() ?? '');
+  late final String constantValueBase = () {
+    final constantInitializer = this.constantInitializer;
+    if (constantInitializer == null) {
+      return '';
+    }
+
+    var initializerString = constantInitializer.toString();
+
+    final self = this;
+    if (self is! EnumField ||
+        constantInitializer is! InstanceCreationExpression) {
+      return _htmlEscape.convert(initializerString);
+    }
+
+    initializerString = 'const $initializerString';
+
+    var isImplicitConstructorCall = constantInitializer
+            .constructorName.staticElement?.isDefaultConstructor ??
+        false;
+    if (isImplicitConstructorCall) {
+      // For an enum value with an implicit constructor call (like
+      // `enum E { one, two; }`), `constantInitializer.toString()` does not
+      // include the implicit enum index argument (it is something like
+      // `const E()`). We must manually include it.
+      initializerString =
+          initializerString.replaceFirst('()', '(${self.index})');
+    }
+    return _htmlEscape.convert(initializerString);
+  }();
+
+  static const _htmlEscape = HtmlEscape(HtmlEscapeMode.unknown);
 
   late final bool hasPublicGetter = hasGetter && getter!.isPublic;
 

--- a/test/enum_test.dart
+++ b/test/enum_test.dart
@@ -394,7 +394,19 @@ class C {}
     );
   }
 
-  void test_valuesHaveAConstantValueImplementation() async {
+  void test_constantValue_implicitConstructorCall() async {
+    var library = await bootPackageWithLibrary('''
+enum E { one, two }
+''');
+
+    var oneValue = library.enums.named('E').publicEnumValues.named('one');
+    expect(oneValue.constantValueTruncated, 'const E(0)');
+
+    var twoValue = library.enums.named('E').publicEnumValues.named('two');
+    expect(twoValue.constantValueTruncated, 'const E(1)');
+  }
+
+  void test_constantValue_explicitConstructorCall() async {
     var library = await bootPackageWithLibrary('''
 enum E {
   one.named(1),
@@ -402,23 +414,33 @@ enum E {
 
   final int x;
 
-  /// A named constructor.
   const E.named(this.x);
 }
-
-enum F { one, two }
 ''');
     var eOneValue = library.enums.named('E').publicEnumValues.named('one');
-    expect(eOneValue.constantValueTruncated, 'E.named(1)');
+    expect(eOneValue.constantValueTruncated, 'const E.named(1)');
 
     var eTwoValue = library.enums.named('E').publicEnumValues.named('two');
-    expect(eTwoValue.constantValueTruncated, 'E.named(2)');
+    expect(eTwoValue.constantValueTruncated, 'const E.named(2)');
+  }
 
-    var fOneValue = library.enums.named('F').publicEnumValues.named('one');
-    expect(fOneValue.constantValueTruncated, 'F()');
+  void test_constantValue_explicitConstructorCall_zeroConstructorArgs() async {
+    var library = await bootPackageWithLibrary('''
+enum E {
+  one.named1(),
+  two.named2();
 
-    var fTwoValue = library.enums.named('F').publicEnumValues.named('two');
-    expect(fTwoValue.constantValueTruncated, 'F()');
+  final int x;
+
+  const E.named1() : x = 1;
+  const E.named2() : x = 2;
+}
+''');
+    var eOneValue = library.enums.named('E').publicEnumValues.named('one');
+    expect(eOneValue.constantValueTruncated, 'const E.named1()');
+
+    var eTwoValue = library.enums.named('E').publicEnumValues.named('two');
+    expect(eTwoValue.constantValueTruncated, 'const E.named2()');
   }
 }
 

--- a/test/templates/enum_test.dart
+++ b/test/templates/enum_test.dart
@@ -19,7 +19,7 @@ void main() async {
   late List<String> enumWithDefaultConstructorLines;
   late List<String> enumWithDefaultConstructorRightSidebarLines;
 
-  group('enhanced enums', skip: !enhancedEnumsAllowed, () {
+  group('enums', () {
     setUpAll(() async {
       final packageMetaProvider = testPackageMetaProvider;
       final resourceProvider =
@@ -31,11 +31,6 @@ name: enums
 version: 0.0.1
 environment:
   sdk: '>=2.17.0-0 <3.0.0'
-''',
-        analysisOptions: '''
-analyzer:
-  enable-experiment:
-    - enhanced-enums
 ''',
         libFiles: [
           d.file('lib.dart', '''
@@ -194,7 +189,7 @@ enum EnumWithDefaultConstructor {
           matches('<span class="name ">one</span>'),
           matches('<p>Doc comment for <a href="../lib/E.html">one</a>.</p>'),
           matches(
-              r'<span class="signature"><code>E&lt;int&gt;.named\(1\)</code></span>'),
+              r'<span class="signature"><code>const E&lt;int&gt;.named\(1\)</code></span>'),
         ]),
       );
     });


### PR DESCRIPTION
When adding support for enhanced enums, I think I overlooked some validation of "old scool" enums-with-implicit-constructors. I discovered this when trying to move all tests to use Dart Language version 3.2.0 (next PR).

Unfortunately, the analyzer's `constantInitializer` property for such enum values is not really meant for re-constructing what a constant's source was, and it returns code like `E()` for the constant initializer for `E.one` given `enum E { one, two; }`. (It should implicitly use an index of 0, and show `E(0)`; see the [de-sugaring examples in the spec](https://github.com/dart-lang/language/blob/main/accepted/2.17/enhanced-enums/feature-specification.md#examples).) I filed https://github.com/dart-lang/sdk/issues/54988.

In this code, we also add the word `const` to enhanced enum values (with an explicit constructor); previously, only old-school enums had the keyword `const`. So now that's unified.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
