### PR TITLE
Bump the version of the Dart SDK mocked in most tests

### DIFF
--- a/test/dartdoc_test_base.dart
+++ b/test/dartdoc_test_base.dart
@@ -36,10 +36,9 @@ abstract class DartdocTestBase {
 
   String get linkPrefix => '$placeholder$libraryName';
 
-  String get dartCoreUrlPrefix =>
-      'https://api.dart.dev/stable/2.16.0/dart-core';
+  String get dartCoreUrlPrefix => 'https://api.dart.dev/stable/3.2.0/dart-core';
 
-  String get sdkConstraint => '>=2.15.0 <3.0.0';
+  String get sdkConstraint => '>=3.2.0 <4.0.0';
 
   List<String> get experiments => [];
 

--- a/test/element_type_test.dart
+++ b/test/element_type_test.dart
@@ -18,9 +18,9 @@ void main() async {
   const linkPrefix = '$placeholder$libraryName';
 
   const intLink =
-      '<a href="https://api.dart.dev/stable/2.16.0/dart-core/int-class.html">int</a>';
+      '<a href="https://api.dart.dev/stable/3.2.0/dart-core/int-class.html">int</a>';
   const stringLink =
-      '<a href="https://api.dart.dev/stable/2.16.0/dart-core/String-class.html">String</a>';
+      '<a href="https://api.dart.dev/stable/3.2.0/dart-core/String-class.html">String</a>';
 
   final packageMetaProvider = testPackageMetaProvider;
   final resourceProvider =

--- a/test/enum_test.dart
+++ b/test/enum_test.dart
@@ -517,7 +517,7 @@ class C {}
     expect(
       cClass.documentationAsHtml,
       '<p>Reference to '
-      '<a href="https://api.dart.dev/stable/2.16.0/dart-core/Enum/index.html">E.index</a>.</p>',
+      '<a href="https://api.dart.dev/stable/3.2.0/dart-core/Enum/index.html">E.index</a>.</p>',
     );
   }
 
@@ -528,7 +528,7 @@ class C {}
     expect(eEnum.instanceFields.map((f) => f.name), contains('index'));
     expect(
       eEnum.instanceFields.named('index').linkedName,
-      '<a href="https://api.dart.dev/stable/2.16.0/dart-core/Enum/index.html">index</a>',
+      '<a href="https://api.dart.dev/stable/3.2.0/dart-core/Enum/index.html">index</a>',
     );
   }
 

--- a/test/src/test_descriptor_utils.dart
+++ b/test/src/test_descriptor_utils.dart
@@ -10,7 +10,7 @@ import 'package:yaml/yaml.dart' as yaml;
 
 export 'package:test_descriptor/test_descriptor.dart';
 
-String buildPubspecText({String sdkConstraint = '>=2.15.0 <3.0.0'}) => '''
+String buildPubspecText({String sdkConstraint = '>=3.2.0 <4.0.0'}) => '''
 name: test_package
 version: 0.0.1
 environment:
@@ -76,9 +76,9 @@ Future<String> createPackage(
   "packages": [
     $packagesInfo
   ],
-  "generated": "2021-09-14T20:36:04.604099Z",
+  "generated": "2024-02-14T20:36:04.604099Z",
   "generator": "pub",
-  "generatorVersion": "2.14.1"
+  "generatorVersion": "3.2.0"
 }
 ''')
       ],

--- a/test/src/utils.dart
+++ b/test/src/utils.dart
@@ -161,7 +161,7 @@ PackageMetaProvider get testPackageMetaProvider {
 ///
 /// Included is a "version" file and an "api_readme.md" file.
 void writeMockSdkFiles(Folder sdkFolder) {
-  sdkFolder.getChildAssumingFile('version').writeAsStringSync('2.16.0');
+  sdkFolder.getChildAssumingFile('version').writeAsStringSync('3.2.0');
   sdkFolder.getChildAssumingFile('api_readme.md').writeAsStringSync(
       'Welcome to the [Dart](https://dart.dev/) API reference documentation');
 


### PR DESCRIPTION
Just bumping these numbers to more recent versions.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
