### PR TITLE
Remove missingConstantConstructor warning.

### DIFF
--- a/lib/src/model/getter_setter_combo.dart
+++ b/lib/src/model/getter_setter_combo.dart
@@ -17,7 +17,6 @@ import 'package:dartdoc/src/model/attribute.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/utils.dart';
-import 'package:dartdoc/src/warnings.dart';
 import 'package:meta/meta.dart';
 
 /// Mixin for top-level variables and fields (aka properties).
@@ -68,10 +67,7 @@ mixin GetterSetterCombo on ModelElement {
     var creationExpression = constantInitializer as InstanceCreationExpression;
     var constructorName = creationExpression.constructorName.toString();
     Element? staticElement = creationExpression.constructorName.staticElement;
-    if (staticElement == null) {
-      warn(PackageWarning.missingConstantConstructor, message: constructorName);
-      return original;
-    }
+    if (staticElement == null) return original;
     var target = getModelForElement(staticElement) as Constructor;
     var enclosingElement = target.enclosingElement;
     if (enclosingElement is! Class) return original;

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -455,7 +455,6 @@ class PackageGraph with CommentReferable, Nameable {
       PackageWarning.toolError ||
       PackageWarning.deprecated ||
       PackageWarning.unresolvedExport ||
-      PackageWarning.missingConstantConstructor ||
       PackageWarning.missingExampleFile ||
       PackageWarning.missingCodeBlockLanguage =>
         kind.messageFor([message])

--- a/lib/src/warnings.dart
+++ b/lib/src/warnings.dart
@@ -285,21 +285,6 @@ enum PackageWarning implements Comparable<PackageWarning> {
     shortHelp: 'An export refers to a URI that cannot be resolved.',
     defaultWarningMode: PackageWarningMode.error,
   ),
-  missingConstantConstructor(
-    'missing-constant-constructor',
-    'constant constructor missing: {0}',
-    shortHelp:
-        'Dartdoc can not show the value of a constant because its constructor '
-        'could not be resolved.',
-    longHelp:
-        'To resolve a constant into its literal value, Dartdoc relies on the '
-        "analyzer to resolve the constructor. The analyzer didn't provide the "
-        "constructor for '$_namePlaceholder', which is usually due to an error "
-        'in the code. Use the analyzer to resolve the issue.',
-    // Defaults to ignore as this doesn't impact the docs severely but is
-    // useful for debugging package structure.
-    defaultWarningMode: PackageWarningMode.ignore,
-  ),
   missingExampleFile(
     'missing-example-file',
     'example file not found: {0}',


### PR DESCRIPTION
Don't warn on a missing constant constructor.
Cleaning up the warning because we most likely don't need it and the analyzer for sure reports this.

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
