### PR TITLE
Refactor extension type template tests to use test_reflective_loader

### DIFF
--- a/lib/src/model_utils.dart
+++ b/lib/src/model_utils.dart
@@ -9,11 +9,15 @@ import 'package:analyzer/file_system/file_system.dart';
 import 'package:dartdoc/src/failure.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:glob/glob.dart';
+import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path;
 
 final _driveLetterMatcher = RegExp(r'^\w:\\');
 
 final Map<String, String> _fileContents = <String, String>{};
+
+@visibleForTesting
+void clearFileContentsCache() => _fileContents.clear();
 
 /// This will handle matching globs, including on Windows.
 ///

--- a/test/src/test_descriptor_utils.dart
+++ b/test/src/test_descriptor_utils.dart
@@ -5,6 +5,7 @@
 import 'dart:convert';
 
 import 'package:analyzer/file_system/memory_file_system.dart';
+import 'package:dartdoc/src/model_utils.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
 import 'package:yaml/yaml.dart' as yaml;
 
@@ -84,6 +85,7 @@ Future<String> createPackage(
       ],
     ),
   ]);
+  clearFileContentsCache();
   if (resourceProvider == null) {
     await packageDir.create();
     return packageDir.io.path;


### PR DESCRIPTION
`test/templates/class_test.dart` was the first template test to use our OO-style tests, and it helps create isolated test cases. You can see the existing `test/templates/extension_type_test.dart` delcares one gigantic test library for extension type tests, which is hard to maintain. This change might add a lot of lines to that test, as each test case now must declare its own test library with an extension type, but this is so much more maintainable.

Declaring multiple libraries means we now need to clear the file content cache that we use to read source code.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
