### PR TITLE
Simplify InheritingContainer.allModelElements and _inheritedElements

### DIFF
--- a/lib/src/model/mixin.dart
+++ b/lib/src/model/mixin.dart
@@ -29,14 +29,12 @@ class Mixin extends InheritingContainer with TypeImplementing {
   @override
   late final List<InheritingContainer> inheritanceChain = [
     this,
-
-    // Mix-in interfaces come before other interfaces.
     ...superclassConstraints.modelElements.expandInheritanceChain,
 
     for (var container in superChain.modelElements)
       ...container.inheritanceChain,
 
-    // Interfaces need to come last, because classes in the superChain might
+    // Interfaces need to come last, because classes in the `superChain` might
     // implement them even when they aren't mentioned.
     ...interfaceElements.expandInheritanceChain,
   ];


### PR DESCRIPTION
I could _not_ wrap my head around the interactions between `InheritingContainer._allModelElements`, which seemed to fill a cache, then do work, then clear the cache, and `InheritingContainer._inheritedElements`. `_inheritedElements` and `_inheritedElementsCache` seemed like a clear instance of a `late final` field before null safety (before `late`), but then the cache invalidation in `_allModelElements` kind of nullifies that theory...

Anyways, it can all be simpler:

* `_allModelElements` can just be the list.
* `_inheritedElementsCache` is no more; `_inheritedElements` is now a late final.
* I cannot fathom why `inheritanceChainElements` was initialized in the for loop... so its now initialized outside the for loop. 🤷 
* Iterating over `someMap.keys` and immediately calling back into the map and null-asserting the result is too much work. We can instead iterate over the entries (hopefully performant...) and destructure the result.
* Add more comments for the next archaeologist.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
