### PR TITLE
Improve some exception messaging and comments

### DIFF
--- a/lib/src/tool_runner.dart
+++ b/lib/src/tool_runner.dart
@@ -98,12 +98,18 @@ class ToolRunner {
       var result =
           await Process.run(commandPath, args, environment: environment);
       if (result.exitCode != 0) {
-        toolErrorCallback('Tool "$name" returned non-zero exit code '
-            '(${result.exitCode}) when run as "${commandString()}" from '
-            '${pathContext.current}\n'
-            'Input to $name was:\n'
-            '$content\n'
-            'Stderr output was:\n${result.stderr}\n');
+        var envString =
+            environment.entries.map((e) => '${e.key}: ${e.value}').join(', ');
+        toolErrorCallback(
+          'Tool "$name" returned non-zero exit code '
+          '(${result.exitCode}) when run as "${commandString()}".\n'
+          '  Working directory: "${pathContext.current}"\n'
+          '  Env: $envString\n'
+          '  Input to $name was:\n'
+          '    $content\n'
+          '  Stderr output was:\n'
+          '    ${result.stderr}\n',
+        );
         return '';
       } else {
         return result.stdout as String;

--- a/lib/src/warnings.dart
+++ b/lib/src/warnings.dart
@@ -218,7 +218,7 @@ enum PackageWarning implements Comparable<PackageWarning> {
   ),
   duplicateFile(
     'duplicate-file',
-    'failed to write file at: {0}',
+    'file already written at "{0}"',
     shortHelp:
         'Dartdoc is trying to write to a duplicate filename based on the names '
         'of Dart symbols.',

--- a/tool/src/flutter_repo.dart
+++ b/tool/src/flutter_repo.dart
@@ -55,7 +55,7 @@ class FlutterRepo {
     return FlutterRepo._(flutterPath, env, cacheDart, launcher);
   }
 
-  /// Copies an existing, initialized flutter repo.
+  /// Copies an existing, initialized flutter repo to [flutterPath].
   static Future<FlutterRepo> copyFromExistingFlutterRepo(
       FlutterRepo originalRepo, String flutterPath, Map<String, String> env,
       [String? label]) async {


### PR DESCRIPTION
I've been fighting some exceptions, maybe with a badly configured flutter checkout or something, and made these little changes while working through it.

* The 'duplicate-file' warning did not specify at all _why_ it failed to write.
* The environment variables might be important to include in the messaging, on a failed process call, in case they contain interesting things like maybe `FLUTTER_ROOT`.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
