### PR TITLE
Deprecate the 'include-externals' option.

### DIFF
--- a/lib/src/dartdoc.dart
+++ b/lib/src/dartdoc.dart
@@ -188,6 +188,14 @@ class Dartdoc {
     runtimeStats.startPerfTask('buildPackageGraph');
     var packageGraph = await packageBuilder.buildPackageGraph();
     runtimeStats.endPerfTask();
+    if (packageBuilder.includeExternalsWasSpecified) {
+      packageGraph.defaultPackage.warn(
+        PackageWarning.deprecated,
+        message:
+            "The '--include-externals' option is deprecated, and will soon be "
+            'removed.',
+      );
+    }
     var libs = packageGraph.libraryCount;
     logInfo("Initialized dartdoc with $libs librar${libs == 1 ? 'y' : 'ies'}");
 


### PR DESCRIPTION
I cannot see that this is used anywhere. We also have no tests for it. The documentation is minimal. It was added 8 years ago! How time flies!

I suspect this was put in place for Flutter, and Flutter switched to using the newer `--auto-include-dependencies` option.

I want to remove it because the implementation looks slow. In `PackageBuilder._includedExternalsFrom`, we instantiate a new `DartdocOptionContext` for every file analyzed. Maybe twice...

- Thanks for your contribution! Please replace this text with a description of what this PR is changing or adding and why, list any relevant issues, and review the contribution guidelines below.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
