### PR TITLE
In PackageBuilder._discoverLibraries, initialize newFiles outside loop.

### DIFF
--- a/lib/src/model/package_builder.dart
+++ b/lib/src/model/package_builder.dart
@@ -229,10 +229,10 @@ class PubPackageBuilder implements PackageBuilder {
     // a set of files (starting with the ones passed into the function), resolve
     // them, add them to the package graph via `addLibrary`, and then discover
     // which additional files need to be processed in the next loop. This
-    // discovery depends on various options (TODO: which?), but the basic idea
-    // is to take a file we've just processed, and add all of the files which
-    // that file references via imports or exports, and add them to the set of
-    // files to be processed.
+    // discovery depends on various options (TODO: which?). The basic idea is
+    // to take a file we've just processed, and add all of the files which that
+    // file references (via imports, augmentation imports, exports, and parts),
+    // and add them to the set of files to be processed.
     //
     // This loop may execute a few times. We know to stop looping when we have
     // added zero new files to process. This is tracked with `filesInLastPass`
@@ -247,9 +247,11 @@ class PubPackageBuilder implements PackageBuilder {
     if (!addingSpecials) {
       progressBarStart(files.length);
     }
+    // The set of files that are discovered while iterating in the below
+    // do-while loop, which are then added to `files`, as they are found.
+    var newFiles = <String>{};
     do {
       filesInLastPass = filesInCurrentPass;
-      var newFiles = <String>{};
       if (!addingSpecials) {
         progressBarUpdateTickCount(files.length);
       }


### PR DESCRIPTION
I noticed with print debugging that `addFilesReferencedBy` was being called way too many times for a given library. It turns out this is because it was being called on different Sets, when really it should mostly be operating on one Set. That one Set is `newFiles`. It was initialized in the do-while loop, but it can be initialized before the do-while loop.

I checked the logic to make sure this change is a no-op.

I also timed documenting flutter. This change seems to reduce the time-to-document by ~100 seconds, but that is only with one before and one after, so I promise nothing.

- Thanks for your contribution! Please replace this text with a description of what this PR is changing or adding and why, list any relevant issues, and review the contribution guidelines below.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
