### PR TITLE
Deprecate --resources-dir option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 8.0.7-wip
 
 * Deprecate the `--nodoc` option. (#3690)
+* Deprecate the `--resources-dir` option. (#3696)
 
 ## 8.0.6
 

--- a/lib/src/dartdoc_options.dart
+++ b/lib/src/dartdoc_options.dart
@@ -1679,9 +1679,11 @@ List<DartdocOption> createDartdocOptions(
         help:
             'A list of package names to place first when grouping libraries in '
             'packages. Unmentioned packages are placed after these.'),
-    // TODO(srawlins): Deprecate this option.
+    // Deprecated. Use of this option is reported.
+    // TODO(kallentu): Remove this option.
     DartdocOptionArgOnly<String?>('resourcesDir', null, resourceProvider,
-        help: "An absolute path to dartdoc's resources directory.", hide: true),
+        help: "(deprecated) An absolute path to dartdoc's resources directory.",
+        hide: true),
     DartdocOptionArgOnly<bool>('sdkDocs', false, resourceProvider,
         help: 'Generate ONLY the docs for the Dart SDK.'),
     DartdocOptionArgSynth<String?>('sdkDir',

--- a/lib/src/generator/generator_frontend.dart
+++ b/lib/src/generator/generator_frontend.dart
@@ -27,6 +27,13 @@ class GeneratorFrontEnd implements Generator {
             'longer be supported.',
       );
     }
+    if (_generatorBackend.options.resourcesDir != null) {
+      packageGraph?.defaultPackage.warn(
+        PackageWarning.deprecated,
+        message: "The '--resources-dir' option is deprecated, and will soon be "
+            'removed.',
+      );
+    }
 
     var indexElements = packageGraph == null
         ? const <Indexable>[]


### PR DESCRIPTION
Deprecating alongside `--templates-dir`. Purge them all!

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
