### PR TITLE
Rewrite Library.allOriginalModelElementNames.

### DIFF
--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -8241,18 +8241,6 @@ class _Renderer_Library extends RendererBase<Library> {
                         parent: r));
                   },
                 ),
-                'allOriginalModelElementNames': Property(
-                  getValue: (CT_ c) => c.allOriginalModelElementNames,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(
-                          c, remainingNames, 'List<String>'),
-                  renderIterable: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    return c.allOriginalModelElementNames.map((e) =>
-                        _render_String(e, ast, r.template, sink, parent: r));
-                  },
-                ),
                 'belowSidebarPath': Property(
                   getValue: (CT_ c) => c.belowSidebarPath,
                   renderVariable:


### PR DESCRIPTION
* This method was public, but only used privately. :(
* This method returned a List, but only one method is ever called on the List: `contains`. So, change to a Set.
* This method used `allModelElements`, but that collection contains way too many things; it contains things like methods of classes, but in this case we are only concerned with direct library members.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
