### PR TITLE
Move the `filterNonDocumented` and `filterNonPublic` functions as extension getters

### DIFF
--- a/lib/src/generator/empty_generator.dart
+++ b/lib/src/generator/empty_generator.dart
@@ -18,13 +18,14 @@ class EmptyGenerator implements Generator {
       packageGraph.defaultPackage,
       ...packageGraph.localPackages
     }) {
-      for (var category in filterNonDocumented(package.categories)) {
+      for (var category in package.categories.whereDocumented) {
         logProgress(category.documentationAsHtml);
       }
 
-      for (var lib in filterNonDocumented(package.libraries)) {
-        filterNonDocumented(lib.allModelElements)
-            .forEach((m) => logProgress(m.documentationAsHtml));
+      for (var lib in package.libraries.whereDocumented) {
+        for (var e in lib.allModelElements.whereDocumented) {
+          logProgress(e.documentationAsHtml);
+        }
       }
     }
     return Future.value();

--- a/lib/src/generator/generator_frontend.dart
+++ b/lib/src/generator/generator_frontend.dart
@@ -79,7 +79,7 @@ class GeneratorFrontEnd implements Generator {
     var multiplePackages = packageGraph.localPackages.length > 1;
 
     void generateConstants(Container container) {
-      for (var constant in filterNonDocumented(container.constantFields)) {
+      for (var constant in container.constantFields.whereDocumented) {
         if (!constant.isCanonical) continue;
         indexAccumulator.add(constant);
         _generatorBackend.generateProperty(
@@ -88,7 +88,7 @@ class GeneratorFrontEnd implements Generator {
     }
 
     void generateConstructors(Constructable constructable) {
-      for (var constructor in filterNonDocumented(constructable.constructors)) {
+      for (var constructor in constructable.constructors.whereDocumented) {
         if (!constructor.isCanonical) continue;
         indexAccumulator.add(constructor);
         _generatorBackend.generateConstructor(
@@ -97,7 +97,7 @@ class GeneratorFrontEnd implements Generator {
     }
 
     void generateInstanceMethods(Container container) {
-      for (var method in filterNonDocumented(container.instanceMethods)) {
+      for (var method in container.instanceMethods.whereDocumented) {
         if (!method.isCanonical) continue;
         indexAccumulator.add(method);
         _generatorBackend.generateMethod(
@@ -106,7 +106,7 @@ class GeneratorFrontEnd implements Generator {
     }
 
     void generateInstanceOperators(Container container) {
-      for (var operator in filterNonDocumented(container.instanceOperators)) {
+      for (var operator in container.instanceOperators.whereDocumented) {
         if (!operator.isCanonical) continue;
         indexAccumulator.add(operator);
         _generatorBackend.generateMethod(
@@ -115,7 +115,7 @@ class GeneratorFrontEnd implements Generator {
     }
 
     void generateInstanceProperty(Container container) {
-      for (var property in filterNonDocumented(container.instanceFields)) {
+      for (var property in container.instanceFields.whereDocumented) {
         if (!property.isCanonical) continue;
         indexAccumulator.add(property);
         _generatorBackend.generateProperty(
@@ -124,7 +124,7 @@ class GeneratorFrontEnd implements Generator {
     }
 
     void generateStaticMethods(Container container) {
-      for (var method in filterNonDocumented(container.staticMethods)) {
+      for (var method in container.staticMethods.whereDocumented) {
         if (!method.isCanonical) continue;
         indexAccumulator.add(method);
         _generatorBackend.generateMethod(
@@ -133,8 +133,7 @@ class GeneratorFrontEnd implements Generator {
     }
 
     void generateStaticProperty(Container container) {
-      for (var property
-          in filterNonDocumented(container.variableStaticFields)) {
+      for (var property in container.variableStaticFields.whereDocumented) {
         if (!property.isCanonical) continue;
         indexAccumulator.add(property);
         _generatorBackend.generateProperty(
@@ -146,14 +145,14 @@ class GeneratorFrontEnd implements Generator {
       if (multiplePackages) {
         logInfo('Generating docs for package ${package.name}...');
       }
-      for (var category in filterNonDocumented(package.categories)) {
+      for (var category in package.categories.whereDocumented) {
         logInfo('Generating docs for category ${category.name} from '
             '${category.package.fullyQualifiedName}...');
         indexAccumulator.add(category);
         _generatorBackend.generateCategory(packageGraph, category);
       }
 
-      for (var lib in filterNonDocumented(package.libraries)) {
+      for (var lib in package.libraries.whereDocumented) {
         if (!multiplePackages) {
           logInfo('Generating docs for library ${lib.breadcrumbName} from '
               '${lib.element.source.uri}...');
@@ -164,7 +163,7 @@ class GeneratorFrontEnd implements Generator {
         indexAccumulator.add(lib);
         _generatorBackend.generateLibrary(packageGraph, lib);
 
-        for (var class_ in filterNonDocumented(lib.allClasses)) {
+        for (var class_ in lib.allClasses.whereDocumented) {
           indexAccumulator.add(class_);
           _generatorBackend.generateClass(packageGraph, lib, class_);
 
@@ -177,7 +176,7 @@ class GeneratorFrontEnd implements Generator {
           generateStaticProperty(class_);
         }
 
-        for (var extension in filterNonDocumented(lib.extensions)) {
+        for (var extension in lib.extensions.whereDocumented) {
           indexAccumulator.add(extension);
           _generatorBackend.generateExtension(packageGraph, lib, extension);
 
@@ -189,7 +188,7 @@ class GeneratorFrontEnd implements Generator {
           generateStaticProperty(extension);
         }
 
-        for (var extensionType in filterNonDocumented(lib.extensionTypes)) {
+        for (var extensionType in lib.extensionTypes.whereDocumented) {
           indexAccumulator.add(extensionType);
           _generatorBackend.generateExtensionType(
               packageGraph, lib, extensionType);
@@ -203,7 +202,7 @@ class GeneratorFrontEnd implements Generator {
           generateStaticProperty(extensionType);
         }
 
-        for (var mixin in filterNonDocumented(lib.mixins)) {
+        for (var mixin in lib.mixins.whereDocumented) {
           indexAccumulator.add(mixin);
           _generatorBackend.generateMixin(packageGraph, lib, mixin);
 
@@ -215,7 +214,7 @@ class GeneratorFrontEnd implements Generator {
           generateStaticProperty(mixin);
         }
 
-        for (var enum_ in filterNonDocumented(lib.enums)) {
+        for (var enum_ in lib.enums.whereDocumented) {
           indexAccumulator.add(enum_);
           _generatorBackend.generateEnum(packageGraph, lib, enum_);
 
@@ -228,24 +227,24 @@ class GeneratorFrontEnd implements Generator {
           generateStaticProperty(enum_);
         }
 
-        for (var constant in filterNonDocumented(lib.constants)) {
+        for (var constant in lib.constants.whereDocumented) {
           indexAccumulator.add(constant);
           _generatorBackend.generateTopLevelProperty(
               packageGraph, lib, constant);
         }
 
-        for (var property in filterNonDocumented(lib.properties)) {
+        for (var property in lib.properties.whereDocumented) {
           indexAccumulator.add(property);
           _generatorBackend.generateTopLevelProperty(
               packageGraph, lib, property);
         }
 
-        for (var function in filterNonDocumented(lib.functions)) {
+        for (var function in lib.functions.whereDocumented) {
           indexAccumulator.add(function);
           _generatorBackend.generateFunction(packageGraph, lib, function);
         }
 
-        for (var typeDef in filterNonDocumented(lib.typedefs)) {
+        for (var typeDef in lib.typedefs.whereDocumented) {
           indexAccumulator.add(typeDef);
           _generatorBackend.generateTypeDef(packageGraph, lib, typeDef);
         }

--- a/lib/src/generator/templates.aot_renderers_for_html.dart
+++ b/lib/src/generator/templates.aot_renderers_for_html.dart
@@ -1584,7 +1584,7 @@ String renderMixin(MixinTemplateData context0) {
       <h2>Properties</h2>
 
       <dl class="properties">''');
-    var context7 = context2.publicInstanceFields;
+    var context7 = context2.publicInstanceFieldsSorted;
     for (var context8 in context7) {
       buffer.write('\n          ');
       buffer.write(_renderMixin_partial_property_8(context8));

--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -3124,18 +3124,6 @@ class _Renderer_Container extends RendererBase<Container> {
                       self.renderSimpleVariable(c, remainingNames, 'bool'),
                   getBool: (CT_ c) => c.isMixin,
                 ),
-                'publicConstantFields': Property(
-                  getValue: (CT_ c) => c.publicConstantFields,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(
-                          c, remainingNames, 'Iterable<Field>'),
-                  renderIterable: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    return c.publicConstantFields.map((e) =>
-                        _render_Field(e, ast, r.template, sink, parent: r));
-                  },
-                ),
                 'publicConstantFieldsSorted': Property(
                   getValue: (CT_ c) => c.publicConstantFieldsSorted,
                   renderVariable: (CT_ c, Property<CT_> self,
@@ -3194,18 +3182,6 @@ class _Renderer_Container extends RendererBase<Container> {
                       self.renderSimpleVariable(c, remainingNames, 'bool'),
                   getBool: (CT_ c) => c.publicInheritedInstanceOperators,
                 ),
-                'publicInstanceFields': Property(
-                  getValue: (CT_ c) => c.publicInstanceFields,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(
-                          c, remainingNames, 'Iterable<Field>'),
-                  renderIterable: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    return c.publicInstanceFields.map((e) =>
-                        _render_Field(e, ast, r.template, sink, parent: r));
-                  },
-                ),
                 'publicInstanceFieldsSorted': Property(
                   getValue: (CT_ c) => c.publicInstanceFieldsSorted,
                   renderVariable: (CT_ c, Property<CT_> self,
@@ -3218,18 +3194,6 @@ class _Renderer_Container extends RendererBase<Container> {
                         _render_Field(e, ast, r.template, sink, parent: r));
                   },
                 ),
-                'publicInstanceMethods': Property(
-                  getValue: (CT_ c) => c.publicInstanceMethods,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(
-                          c, remainingNames, 'Iterable<Method>'),
-                  renderIterable: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    return c.publicInstanceMethods.map((e) =>
-                        _render_Method(e, ast, r.template, sink, parent: r));
-                  },
-                ),
                 'publicInstanceMethodsSorted': Property(
                   getValue: (CT_ c) => c.publicInstanceMethodsSorted,
                   renderVariable: (CT_ c, Property<CT_> self,
@@ -3240,18 +3204,6 @@ class _Renderer_Container extends RendererBase<Container> {
                       List<MustachioNode> ast, StringSink sink) {
                     return c.publicInstanceMethodsSorted.map((e) =>
                         _render_Method(e, ast, r.template, sink, parent: r));
-                  },
-                ),
-                'publicInstanceOperators': Property(
-                  getValue: (CT_ c) => c.publicInstanceOperators,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(
-                          c, remainingNames, 'Iterable<Operator>'),
-                  renderIterable: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    return c.publicInstanceOperators.map((e) =>
-                        _render_Operator(e, ast, r.template, sink, parent: r));
                   },
                 ),
                 'publicInstanceOperatorsSorted': Property(
@@ -7771,19 +7723,6 @@ class _Renderer_InheritingContainer extends RendererBase<InheritingContainer> {
                             parent: r));
                   },
                 ),
-                'publicSuperChain': Property(
-                  getValue: (CT_ c) => c.publicSuperChain,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(
-                          c, remainingNames, 'List<DefinedElementType>'),
-                  renderIterable: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    return c.publicSuperChain.map((e) =>
-                        _render_DefinedElementType(e, ast, r.template, sink,
-                            parent: r));
-                  },
-                ),
                 'publicSuperChainReversed': Property(
                   getValue: (CT_ c) => c.publicSuperChainReversed,
                   renderVariable: (CT_ c, Property<CT_> self,
@@ -8877,18 +8816,6 @@ class _Renderer_LibraryContainer extends RendererBase<LibraryContainer> {
                   renderIterable: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
                     return c.libraries.map((e) =>
-                        _render_Library(e, ast, r.template, sink, parent: r));
-                  },
-                ),
-                'publicLibraries': Property(
-                  getValue: (CT_ c) => c.publicLibraries,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(
-                          c, remainingNames, 'Iterable<Library>'),
-                  renderIterable: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    return c.publicLibraries.map((e) =>
                         _render_Library(e, ast, r.template, sink, parent: r));
                   },
                 ),
@@ -11534,6 +11461,13 @@ class _Renderer_Nameable extends RendererBase<Nameable> {
                         parent: r);
                   },
                 ),
+                'isPublic': Property(
+                  getValue: (CT_ c) => c.isPublic,
+                  renderVariable: (CT_ c, Property<CT_> self,
+                          List<String> remainingNames) =>
+                      self.renderSimpleVariable(c, remainingNames, 'bool'),
+                  getBool: (CT_ c) => c.isPublic,
+                ),
                 'name': Property(
                   getValue: (CT_ c) => c.name,
                   renderVariable:
@@ -12024,18 +11958,6 @@ class _Renderer_Package extends RendererBase<Package> {
                     return c.documentationFrom.map((e) => renderSimple(
                         e, ast, r.template, sink,
                         parent: r, getters: _invisibleGetters['Locatable']!));
-                  },
-                ),
-                'documentedCategories': Property(
-                  getValue: (CT_ c) => c.documentedCategories,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(
-                          c, remainingNames, 'Iterable<Category>'),
-                  renderIterable: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    return c.documentedCategories.map((e) =>
-                        _render_Category(e, ast, r.template, sink, parent: r));
                   },
                 ),
                 'documentedCategoriesSorted': Property(
@@ -14313,11 +14235,11 @@ class _Renderer_TopLevelContainer extends RendererBase<TopLevelContainer> {
                           List<String> remainingNames) =>
                       self.renderSimpleVariable(
                           c, remainingNames, 'Iterable<ModelFunction>'),
-                  isNullValue: (CT_ c) => c.functions == null,
-                  renderValue: (CT_ c, RendererBase<CT_> r,
+                  renderIterable: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
-                    renderSimple(c.functions, ast, r.template, sink,
-                        parent: r, getters: _invisibleGetters['Iterable']!);
+                    return c.functions.map((e) => _render_ModelFunction(
+                        e, ast, r.template, sink,
+                        parent: r));
                   },
                 ),
                 'hasPublicClasses': Property(
@@ -14415,18 +14337,6 @@ class _Renderer_TopLevelContainer extends RendererBase<TopLevelContainer> {
                         parent: r));
                   },
                 ),
-                'publicClasses': Property(
-                  getValue: (CT_ c) => c.publicClasses,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(
-                          c, remainingNames, 'Iterable<Class>'),
-                  renderIterable: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    return c.publicClasses.map((e) =>
-                        _render_Class(e, ast, r.template, sink, parent: r));
-                  },
-                ),
                 'publicClassesSorted': Property(
                   getValue: (CT_ c) => c.publicClassesSorted,
                   renderVariable: (CT_ c, Property<CT_> self,
@@ -14437,19 +14347,6 @@ class _Renderer_TopLevelContainer extends RendererBase<TopLevelContainer> {
                       List<MustachioNode> ast, StringSink sink) {
                     return c.publicClassesSorted.map((e) =>
                         _render_Container(e, ast, r.template, sink, parent: r));
-                  },
-                ),
-                'publicConstants': Property(
-                  getValue: (CT_ c) => c.publicConstants,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(
-                          c, remainingNames, 'Iterable<TopLevelVariable>'),
-                  renderIterable: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    return c.publicConstants.map((e) =>
-                        _render_TopLevelVariable(e, ast, r.template, sink,
-                            parent: r));
                   },
                 ),
                 'publicConstantsSorted': Property(
@@ -14463,18 +14360,6 @@ class _Renderer_TopLevelContainer extends RendererBase<TopLevelContainer> {
                     return c.publicConstantsSorted.map((e) =>
                         _render_TopLevelVariable(e, ast, r.template, sink,
                             parent: r));
-                  },
-                ),
-                'publicEnums': Property(
-                  getValue: (CT_ c) => c.publicEnums,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(
-                          c, remainingNames, 'Iterable<Enum>'),
-                  renderIterable: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    return c.publicEnums.map((e) =>
-                        _render_Enum(e, ast, r.template, sink, parent: r));
                   },
                 ),
                 'publicEnumsSorted': Property(
@@ -14501,19 +14386,6 @@ class _Renderer_TopLevelContainer extends RendererBase<TopLevelContainer> {
                         _render_Class(e, ast, r.template, sink, parent: r));
                   },
                 ),
-                'publicExtensionTypes': Property(
-                  getValue: (CT_ c) => c.publicExtensionTypes,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(
-                          c, remainingNames, 'Iterable<ExtensionType>'),
-                  renderIterable: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    return c.publicExtensionTypes.map((e) =>
-                        _render_ExtensionType(e, ast, r.template, sink,
-                            parent: r));
-                  },
-                ),
                 'publicExtensionTypesSorted': Property(
                   getValue: (CT_ c) => c.publicExtensionTypesSorted,
                   renderVariable: (CT_ c, Property<CT_> self,
@@ -14527,18 +14399,6 @@ class _Renderer_TopLevelContainer extends RendererBase<TopLevelContainer> {
                             parent: r));
                   },
                 ),
-                'publicExtensions': Property(
-                  getValue: (CT_ c) => c.publicExtensions,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(
-                          c, remainingNames, 'Iterable<Extension>'),
-                  renderIterable: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    return c.publicExtensions.map((e) =>
-                        _render_Extension(e, ast, r.template, sink, parent: r));
-                  },
-                ),
                 'publicExtensionsSorted': Property(
                   getValue: (CT_ c) => c.publicExtensionsSorted,
                   renderVariable: (CT_ c, Property<CT_> self,
@@ -14549,19 +14409,6 @@ class _Renderer_TopLevelContainer extends RendererBase<TopLevelContainer> {
                       List<MustachioNode> ast, StringSink sink) {
                     return c.publicExtensionsSorted.map((e) =>
                         _render_Extension(e, ast, r.template, sink, parent: r));
-                  },
-                ),
-                'publicFunctions': Property(
-                  getValue: (CT_ c) => c.publicFunctions,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(
-                          c, remainingNames, 'Iterable<ModelFunctionTyped>'),
-                  renderIterable: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    return c.publicFunctions.map((e) =>
-                        _render_ModelFunctionTyped(e, ast, r.template, sink,
-                            parent: r));
                   },
                 ),
                 'publicFunctionsSorted': Property(
@@ -14577,18 +14424,6 @@ class _Renderer_TopLevelContainer extends RendererBase<TopLevelContainer> {
                             parent: r));
                   },
                 ),
-                'publicMixins': Property(
-                  getValue: (CT_ c) => c.publicMixins,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(
-                          c, remainingNames, 'Iterable<Mixin>'),
-                  renderIterable: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    return c.publicMixins.map((e) =>
-                        _render_Mixin(e, ast, r.template, sink, parent: r));
-                  },
-                ),
                 'publicMixinsSorted': Property(
                   getValue: (CT_ c) => c.publicMixinsSorted,
                   renderVariable: (CT_ c, Property<CT_> self,
@@ -14599,19 +14434,6 @@ class _Renderer_TopLevelContainer extends RendererBase<TopLevelContainer> {
                       List<MustachioNode> ast, StringSink sink) {
                     return c.publicMixinsSorted.map((e) =>
                         _render_Mixin(e, ast, r.template, sink, parent: r));
-                  },
-                ),
-                'publicProperties': Property(
-                  getValue: (CT_ c) => c.publicProperties,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(
-                          c, remainingNames, 'Iterable<TopLevelVariable>'),
-                  renderIterable: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    return c.publicProperties.map((e) =>
-                        _render_TopLevelVariable(e, ast, r.template, sink,
-                            parent: r));
                   },
                 ),
                 'publicPropertiesSorted': Property(
@@ -14625,18 +14447,6 @@ class _Renderer_TopLevelContainer extends RendererBase<TopLevelContainer> {
                     return c.publicPropertiesSorted.map((e) =>
                         _render_TopLevelVariable(e, ast, r.template, sink,
                             parent: r));
-                  },
-                ),
-                'publicTypedefs': Property(
-                  getValue: (CT_ c) => c.publicTypedefs,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(
-                          c, remainingNames, 'Iterable<Typedef>'),
-                  renderIterable: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    return c.publicTypedefs.map((e) =>
-                        _render_Typedef(e, ast, r.template, sink, parent: r));
                   },
                 ),
                 'publicTypedefsSorted': Property(
@@ -16826,7 +16636,6 @@ const _invisibleGetters = {
     'defaultPackage',
     'defaultPackageName',
     'displayName',
-    'documentedExtensions',
     'extensions',
     'hasEmbedderSdk',
     'hasFooterVersion',

--- a/lib/src/model/container.dart
+++ b/lib/src/model/container.dart
@@ -95,14 +95,10 @@ abstract class Container extends ModelElement
   List<Constructor> get publicConstructorsSorted => const [];
 
   @nonVirtual
-  bool get hasPublicInstanceMethods =>
-      model_utils.filterNonPublic(instanceMethods).isNotEmpty;
-
-  Iterable<Method> get publicInstanceMethods =>
-      model_utils.filterNonPublic(instanceMethods);
+  bool get hasPublicInstanceMethods => instanceMethods.any((e) => e.isPublic);
 
   late final List<Method> publicInstanceMethodsSorted =
-      publicInstanceMethods.toList(growable: false)..sort();
+      instanceMethods.wherePublic.toList(growable: false)..sort();
 
   @nonVirtual
   late final List<Operator> declaredOperators =
@@ -115,14 +111,10 @@ abstract class Container extends ModelElement
 
   @nonVirtual
   bool get hasPublicInstanceOperators =>
-      publicInstanceOperatorsSorted.isNotEmpty;
-
-  @nonVirtual
-  Iterable<Operator> get publicInstanceOperators =>
-      model_utils.filterNonPublic(instanceOperators);
+      instanceOperators.any((e) => e.isPublic);
 
   late final List<Operator> publicInstanceOperatorsSorted =
-      publicInstanceOperators.toList(growable: false)..sort();
+      instanceOperators.wherePublic.toList(growable: false)..sort();
 
   /// Fields fully declared in this [Container].
   Iterable<Field> get declaredFields;
@@ -134,24 +126,17 @@ abstract class Container extends ModelElement
   bool get hasInstanceFields => instanceFields.isNotEmpty;
 
   @nonVirtual
-  Iterable<Field> get publicInstanceFields =>
-      model_utils.filterNonPublic(instanceFields);
-
-  @nonVirtual
-  bool get hasPublicInstanceFields => publicInstanceFields.isNotEmpty;
+  bool get hasPublicInstanceFields => instanceFields.any((e) => e.isPublic);
 
   late final List<Field> publicInstanceFieldsSorted =
-      publicInstanceFields.toList(growable: false)..sort(byName);
+      instanceFields.wherePublic.toList(growable: false)..sort(byName);
 
   Iterable<Field> get constantFields => declaredFields.where((f) => f.isConst);
 
-  Iterable<Field> get publicConstantFields =>
-      model_utils.filterNonPublic(constantFields);
-
-  bool get hasPublicConstantFields => publicConstantFields.isNotEmpty;
+  bool get hasPublicConstantFields => constantFields.any((e) => e.isPublic);
 
   late final List<Field> publicConstantFieldsSorted =
-      publicConstantFields.toList(growable: false)..sort(byName);
+      constantFields.wherePublic.toList(growable: false)..sort(byName);
 
   /// The total list of public enum values.
   ///
@@ -207,10 +192,10 @@ abstract class Container extends ModelElement
     return member as T;
   }
 
-  bool get hasPublicStaticFields => publicStaticFieldsSorted.isNotEmpty;
+  bool get hasPublicStaticFields => staticFields.any((e) => e.isPublic);
 
   late final List<Field> publicStaticFieldsSorted =
-      model_utils.filterNonPublic(staticFields).toList(growable: false)..sort();
+      staticFields.wherePublic.toList(growable: false)..sort();
 
   Iterable<Field> get staticFields => declaredFields.where((f) => f.isStatic);
 
@@ -218,23 +203,18 @@ abstract class Container extends ModelElement
       staticFields.where((f) => !f.isConst);
 
   bool get hasPublicVariableStaticFields =>
-      publicVariableStaticFieldsSorted.isNotEmpty;
+      variableStaticFields.any((e) => e.isPublic);
 
-  late final List<Field> publicVariableStaticFieldsSorted = model_utils
-      .filterNonPublic(variableStaticFields)
-      .toList(growable: false)
-    ..sort();
+  late final List<Field> publicVariableStaticFieldsSorted =
+      variableStaticFields.wherePublic.toList(growable: false)..sort();
 
   Iterable<Method> get staticMethods =>
       declaredMethods.where((m) => m.isStatic);
 
-  bool get hasPublicStaticMethods =>
-      model_utils.filterNonPublic(publicStaticMethodsSorted).isNotEmpty;
+  bool get hasPublicStaticMethods => staticMethods.any((e) => e.isPublic);
 
-  late final List<Method> publicStaticMethodsSorted = model_utils
-      .filterNonPublic(staticMethods)
-      .toList(growable: false)
-    ..sort();
+  late final List<Method> publicStaticMethodsSorted =
+      staticMethods.wherePublic.toList(growable: false)..sort();
 
   /// For subclasses to add items after the main pass but before the
   /// parameter-global.

--- a/lib/src/model/enum.dart
+++ b/lib/src/model/enum.dart
@@ -45,12 +45,12 @@ class Enum extends InheritingContainer
       declaredFields.where((f) => f is! EnumField && f.isConst);
 
   @override
-  late final List<Field> publicEnumValues = model_utils
-      .filterNonPublic(allFields.whereType<EnumField>())
-      .toList(growable: false);
+  late final List<Field> publicEnumValues =
+      allFields.whereType<EnumField>().wherePublic.toList(growable: false);
 
   @override
-  bool get hasPublicEnumValues => publicEnumValues.isNotEmpty;
+  bool get hasPublicEnumValues =>
+      allFields.whereType<EnumField>().any((e) => e.isPublic);
 
   @override
   bool get isAbstract => false;

--- a/lib/src/model/library_container.dart
+++ b/lib/src/model/library_container.dart
@@ -15,13 +15,10 @@ abstract mixin class LibraryContainer
     implements Nameable, Comparable<LibraryContainer>, Documentable {
   final List<Library> libraries = [];
 
-  Iterable<Library> get publicLibraries =>
-      model_utils.filterNonPublic(libraries);
-
   late final List<Library> publicLibrariesSorted =
-      publicLibraries.sorted(byName);
+      libraries.wherePublic.sorted(byName);
 
-  bool get hasPublicLibraries => publicLibraries.isNotEmpty;
+  bool get hasPublicLibraries => libraries.any((e) => e.isPublic);
 
   /// The name of the container or object that this LibraryContainer is a part
   /// of.  Used for sorting in [containerOrder].

--- a/lib/src/model/mixin.dart
+++ b/lib/src/model/mixin.dart
@@ -76,7 +76,7 @@ class Mixin extends InheritingContainer with TypeImplementing {
   Kind get kind => Kind.mixin;
 
   Iterable<ParameterizedElementType> get publicSuperclassConstraints =>
-      model_utils.filterNonPublic(superclassConstraints);
+      superclassConstraints.wherePublic;
 
   @override
   String get relationshipsClass => 'mixin-relationships';

--- a/lib/src/model/nameable.dart
+++ b/lib/src/model/nameable.dart
@@ -11,11 +11,12 @@ import 'package:dartdoc/src/model/container.dart';
 import 'package:dartdoc/src/model/library.dart';
 import 'package:dartdoc/src/model/model_element.dart';
 import 'package:dartdoc/src/model/package_graph.dart';
+import 'package:dartdoc/src/model/privacy.dart';
 
 import 'locatable.dart';
 
 /// Something that has a name.
-mixin Nameable {
+mixin Nameable implements Privacy {
   String get name;
 
   String get fullyQualifiedName => name;
@@ -34,6 +35,9 @@ mixin Nameable {
   // TODO(jcollins-g): This should really be the same as 'name', but isn't
   // because of accessors and operators.
   late final String namePart = fullyQualifiedName.split('.').last;
+
+  @override
+  bool get isPublic => name.isNotEmpty && !name.startsWith('_');
 
   @override
   String toString() => name;

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -308,9 +308,6 @@ class PackageGraph with CommentReferable, Nameable {
     return _implementers;
   }
 
-  Iterable<Extension> get documentedExtensions =>
-      utils.filterNonDocumented(extensions).toList(growable: false);
-
   Iterable<Extension> get extensions {
     assert(allExtensionsAdded);
     return _extensions;
@@ -645,7 +642,7 @@ class PackageGraph with CommentReferable, Nameable {
 
   late final Set<Library> publicLibraries = () {
     assert(allLibrariesAdded);
-    return utils.filterNonPublic(libraries).toSet();
+    return libraries.wherePublic.toSet();
   }();
 
   late final List<Library> _localLibraries = () {
@@ -656,7 +653,7 @@ class PackageGraph with CommentReferable, Nameable {
 
   late final Set<Library> localPublicLibraries = () {
     assert(allLibrariesAdded);
-    return utils.filterNonPublic(_localLibraries).toSet();
+    return _localLibraries.wherePublic.toSet();
   }();
 
   /// The String name representing the `Object` type.
@@ -1000,15 +997,15 @@ class PackageGraph with CommentReferable, Nameable {
     children.addEntriesIfAbsent(sortedDocumentedPackages
         .expand((p) => p.publicLibrariesSorted)
         .expand((l) => [
-              ...l.publicConstants,
-              ...l.publicFunctions,
-              ...l.publicProperties,
-              ...l.publicTypedefs,
-              ...l.publicExtensions,
-              ...l.publicExtensionTypes,
-              ...l.publicClasses,
-              ...l.publicEnums,
-              ...l.publicMixins
+              ...l.constants.wherePublic,
+              ...l.functions.wherePublic,
+              ...l.properties.wherePublic,
+              ...l.typedefs.wherePublic,
+              ...l.extensions.wherePublic,
+              ...l.extensionTypes.wherePublic,
+              ...l.classes.wherePublic,
+              ...l.enums.wherePublic,
+              ...l.mixins.wherePublic,
             ])
         .generateEntries());
 

--- a/lib/src/model/privacy.dart
+++ b/lib/src/model/privacy.dart
@@ -3,6 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Classes implementing this have a public/private distinction.
-abstract /*interface*/ class Privacy {
+abstract interface class Privacy {
   bool get isPublic;
 }

--- a/lib/src/model/top_level_container.dart
+++ b/lib/src/model/top_level_container.dart
@@ -28,86 +28,60 @@ mixin TopLevelContainer implements Nameable {
 
   Iterable<TopLevelVariable> get properties;
 
-  Iterable<ModelFunction>? get functions;
+  Iterable<ModelFunction> get functions;
 
   Iterable<Typedef> get typedefs;
 
-  bool get hasPublicClasses => publicClasses.isNotEmpty;
+  bool get hasPublicClasses => classes.any((e) => e.isPublic);
 
-  bool get hasPublicExtensions => publicExtensions.isNotEmpty;
+  bool get hasPublicExtensions => extensions.any((e) => e.isPublic);
 
-  bool get hasPublicExtensionTypes => publicExtensionTypes.isNotEmpty;
+  bool get hasPublicExtensionTypes => extensionTypes.any((e) => e.isPublic);
 
-  bool get hasPublicConstants => publicConstants.isNotEmpty;
+  bool get hasPublicConstants => constants.any((e) => e.isPublic);
 
-  bool get hasPublicEnums => publicEnums.isNotEmpty;
+  bool get hasPublicEnums => enums.any((e) => e.isPublic);
 
-  bool get hasPublicExceptions => _publicExceptions.isNotEmpty;
+  bool get hasPublicExceptions => exceptions.any((e) => e.isPublic);
 
-  bool get hasPublicFunctions => publicFunctions.isNotEmpty;
+  bool get hasPublicFunctions => functions.any((e) => e.isPublic);
 
-  bool get hasPublicMixins => publicMixins.isNotEmpty;
+  bool get hasPublicMixins => mixins.any((e) => e.isPublic);
 
-  bool get hasPublicProperties => publicProperties.isNotEmpty;
+  bool get hasPublicProperties => properties.any((e) => e.isPublic);
 
-  bool get hasPublicTypedefs => publicTypedefs.isNotEmpty;
-
-  Iterable<Class> get publicClasses => model_utils.filterNonPublic(classes);
+  bool get hasPublicTypedefs => typedefs.any((e) => e.isPublic);
 
   // TODO(jcollins-g):  Setting this type parameter to `Container` magically
   // fixes a number of type problems in the AOT compiler, but I am mystified as
   // to why that should be the case.
   late final List<Container> publicClassesSorted =
-      publicClasses.toList(growable: false)..sort();
-
-  Iterable<Extension> get publicExtensions =>
-      model_utils.filterNonPublic(extensions);
+      classes.wherePublic.toList(growable: false)..sort();
 
   late final List<Extension> publicExtensionsSorted =
-      publicExtensions.toList(growable: false)..sort();
-
-  Iterable<ExtensionType> get publicExtensionTypes =>
-      model_utils.filterNonPublic(extensionTypes);
+      extensions.wherePublic.toList(growable: false)..sort();
 
   late final List<ExtensionType> publicExtensionTypesSorted =
-      publicExtensionTypes.toList(growable: false)..sort();
-
-  Iterable<TopLevelVariable> get publicConstants =>
-      model_utils.filterNonPublic(constants);
+      extensionTypes.wherePublic.toList(growable: false)..sort();
 
   Iterable<TopLevelVariable> get publicConstantsSorted =>
-      publicConstants.toList(growable: false)..sort();
+      constants.wherePublic.toList(growable: false)..sort();
 
-  Iterable<Enum> get publicEnums => model_utils.filterNonPublic(enums);
-
-  late final List<Enum> publicEnumsSorted = publicEnums.toList(growable: false)
-    ..sort();
-
-  Iterable<Class> get _publicExceptions =>
-      model_utils.filterNonPublic(exceptions);
+  late final List<Enum> publicEnumsSorted =
+      enums.wherePublic.toList(growable: false)..sort();
 
   late final List<Class> publicExceptionsSorted =
-      _publicExceptions.toList(growable: false)..sort();
-
-  Iterable<ModelFunctionTyped> get publicFunctions =>
-      model_utils.filterNonPublic(functions!);
+      exceptions.wherePublic.toList(growable: false)..sort();
 
   late final List<ModelFunctionTyped> publicFunctionsSorted =
-      publicFunctions.toList(growable: false)..sort();
-
-  Iterable<Mixin> get publicMixins => model_utils.filterNonPublic(mixins);
+      functions.wherePublic.toList(growable: false)..sort();
 
   late final List<Mixin> publicMixinsSorted =
-      publicMixins.toList(growable: false)..sort();
-
-  Iterable<TopLevelVariable> get publicProperties =>
-      model_utils.filterNonPublic(properties);
+      mixins.wherePublic.toList(growable: false)..sort();
 
   late final List<TopLevelVariable> publicPropertiesSorted =
-      publicProperties.toList(growable: false)..sort();
-
-  Iterable<Typedef> get publicTypedefs => model_utils.filterNonPublic(typedefs);
+      properties.wherePublic.toList(growable: false)..sort();
 
   late final List<Typedef> publicTypedefsSorted =
-      publicTypedefs.toList(growable: false)..sort();
+      typedefs.wherePublic.toList(growable: false)..sort();
 }

--- a/lib/src/model_utils.dart
+++ b/lib/src/model_utils.dart
@@ -52,15 +52,6 @@ Iterable<T> filterHasCanonical<T extends ModelElement>(
   return maybeHasCanonicalItems.where((me) => me.canonicalModelElement != null);
 }
 
-/// Selects [items] which are documented.
-Iterable<T> filterNonDocumented<T extends Documentable>(Iterable<T> items) =>
-    items.where((me) => me.isDocumented);
-
-/// Returns an iterable containing only public elements from [privacyItems].
-Iterable<T> filterNonPublic<T extends Privacy>(Iterable<T> privacyItems) {
-  return privacyItems.where((me) => me.isPublic);
-}
-
 /// Finds canonical classes for all classes in the iterable, if possible.
 /// If a canonical class can not be found, returns the original class.
 Iterable<InheritingContainer> findCanonicalFor(
@@ -102,3 +93,13 @@ bool hasPrivateName(Element e) {
 }
 
 bool hasPublicName(Element e) => !hasPrivateName(e);
+
+extension IterableOfDocumentableExtension<E extends Documentable>
+    on Iterable<E> {
+  /// The public items which are documented.
+  Iterable<E> get whereDocumented => where((e) => e.isDocumented).wherePublic;
+}
+
+extension IterableOfNameableExtension<E extends Privacy> on Iterable<E> {
+  Iterable<E> get wherePublic => where((e) => e.isPublic);
+}

--- a/lib/templates/mixin.html
+++ b/lib/templates/mixin.html
@@ -48,9 +48,9 @@
       <h2>Properties</h2>
 
       <dl class="properties">
-        {{ #publicInstanceFields }}
+        {{ #publicInstanceFieldsSorted }}
           {{ >property }}
-        {{ /publicInstanceFields }}
+        {{ /publicInstanceFieldsSorted }}
       </dl>
     </section>
     {{ /hasPublicInstanceFields }}

--- a/test/end2end/dartdoc_test.dart
+++ b/test/end2end/dartdoc_test.dart
@@ -12,6 +12,7 @@ import 'package:dartdoc/src/io_utils.dart';
 import 'package:dartdoc/src/logging.dart';
 import 'package:dartdoc/src/model/documentable.dart';
 import 'package:dartdoc/src/model/package_builder.dart';
+import 'package:dartdoc/src/model_utils.dart';
 import 'package:dartdoc/src/package_config_provider.dart';
 import 'package:dartdoc/src/package_meta.dart';
 import 'package:dartdoc/src/warnings.dart';
@@ -135,7 +136,7 @@ void main() {
         expect(p.packageMeta.getReadmeContents(), isNotNull);
         // Total number of public libraries in test_package.
         // +2 since we are not manually excluding anything.
-        expect(packageGraph.defaultPackage.publicLibraries,
+        expect(packageGraph.defaultPackage.libraries.wherePublic.wherePublic,
             hasLength(kTestPackagePublicLibraries + 2));
         expect(packageGraph.localPackages.length, equals(1));
       });
@@ -183,7 +184,7 @@ void main() {
           dartPackage.libraries.firstWhere((lib) => lib.name == 'dart:bear');
       expect(
           dartBear.allClasses.map((cls) => cls.name).contains('Bear'), isTrue);
-      expect(dartPackage.publicLibraries, hasLength(3));
+      expect(dartPackage.libraries.wherePublic, hasLength(3));
     });
 
     test('rel canonical prefix does not include base href', () async {

--- a/test/end2end/model_special_cases_test.dart
+++ b/test/end2end/model_special_cases_test.dart
@@ -12,6 +12,7 @@ library;
 import 'package:async/async.dart';
 import 'package:dartdoc/src/matching_link_result.dart';
 import 'package:dartdoc/src/model/model.dart';
+import 'package:dartdoc/src/model_utils.dart';
 import 'package:dartdoc/src/package_config_provider.dart';
 import 'package:dartdoc/src/package_meta.dart';
 import 'package:dartdoc/src/special_elements.dart';
@@ -360,9 +361,11 @@ void main() {
         () {
       var IAmAClassWithCategories = ginormousPackageGraph.localPackages
           .firstWhere((Package p) => p.name == 'test_package_imported')
-          .publicLibraries
+          .libraries
+          .wherePublic
           .firstWhere((Library l) => l.name == 'categoriesExported')
-          .publicClasses
+          .classes
+          .wherePublic
           .firstWhere((Class c) => c.name == 'IAmAClassWithCategories');
       expect(IAmAClassWithCategories.hasCategoryNames, isTrue);
       expect(IAmAClassWithCategories.categories, hasLength(1));
@@ -376,9 +379,11 @@ void main() {
     test('Verify that reexported classes pick up categories', () {
       var IAmAClassWithCategoriesReexport = ginormousPackageGraph.localPackages
           .firstWhere((Package p) => p.name == 'test_package')
-          .publicLibraries
+          .libraries
+          .wherePublic
           .firstWhere((Library l) => l.name == 'fake')
-          .publicClasses
+          .classes
+          .wherePublic
           .firstWhere((Class c) => c.name == 'IAmAClassWithCategories');
       expect(IAmAClassWithCategoriesReexport.hasCategoryNames, isTrue);
       expect(IAmAClassWithCategoriesReexport.categories, hasLength(1));
@@ -393,11 +398,12 @@ void main() {
     test('Verify that multiple categories work correctly', () {
       var fakeLibrary = ginormousPackageGraph.localPackages
           .firstWhere((Package p) => p.name == 'test_package')
-          .publicLibraries
+          .libraries
+          .wherePublic
           .firstWhere((Library l) => l.name == 'fake');
-      var BaseForDocComments = fakeLibrary.publicClasses
+      var BaseForDocComments = fakeLibrary.classes.wherePublic
           .firstWhere((Class c) => c.name == 'BaseForDocComments');
-      var SubForDocComments = fakeLibrary.publicClasses
+      var SubForDocComments = fakeLibrary.classes.wherePublic
           .firstWhere((Class c) => c.name == 'SubForDocComments');
       expect(BaseForDocComments.hasCategoryNames, isTrue);
       // Display both, with the correct order and display name.
@@ -428,7 +434,7 @@ void main() {
           sdkAsPackageGraph.libraries.singleWhere((l) => l.name == 'dart:html');
       var eventTarget =
           htmlLibrary.allClasses.singleWhere((c) => c.name == 'EventTarget');
-      var hashCode = eventTarget.publicInstanceFields
+      var hashCode = eventTarget.instanceFields.wherePublic
           .singleWhere((f) => f.name == 'hashCode');
       var objectModelElement =
           sdkAsPackageGraph.specialClasses[SpecialClass.object];

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -14,6 +14,7 @@ import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/matching_link_result.dart';
 import 'package:dartdoc/src/model/attribute.dart';
 import 'package:dartdoc/src/model/model.dart';
+import 'package:dartdoc/src/model_utils.dart';
 import 'package:dartdoc/src/package_config_provider.dart';
 import 'package:dartdoc/src/package_meta.dart';
 import 'package:dartdoc/src/render/parameter_renderer.dart';
@@ -306,14 +307,14 @@ void main() async {
           .firstWhere((c) => c.name == 'B');
       c = nullSafetyClassMemberDeclarations.allClasses
           .firstWhere((c) => c.name == 'C');
-      oddAsyncFunction = nullableElements.publicFunctions
-          .firstWhere((f) => f.name == 'oddAsyncFunction') as ModelFunction;
-      anotherOddFunction = nullableElements.publicFunctions
-          .firstWhere((f) => f.name == 'oddAsyncFunction') as ModelFunction;
-      neverReturns = nullableElements.publicFunctions
-          .firstWhere((f) => f.name == 'neverReturns') as ModelFunction;
-      almostNeverReturns = nullableElements.publicFunctions
-          .firstWhere((f) => f.name == 'almostNeverReturns') as ModelFunction;
+      oddAsyncFunction = nullableElements.functions.wherePublic
+          .firstWhere((f) => f.name == 'oddAsyncFunction');
+      anotherOddFunction = nullableElements.functions.wherePublic
+          .firstWhere((f) => f.name == 'oddAsyncFunction');
+      neverReturns = nullableElements.functions.wherePublic
+          .firstWhere((f) => f.name == 'neverReturns');
+      almostNeverReturns = nullableElements.functions.wherePublic
+          .firstWhere((f) => f.name == 'almostNeverReturns');
     });
 
     test('Never types are allowed to have nullability markers', () {
@@ -420,7 +421,7 @@ void main() async {
     });
 
     test('Late final top level variables', () {
-      var initializeMe = lateFinalWithoutInitializer.publicProperties
+      var initializeMe = lateFinalWithoutInitializer.properties.wherePublic
           .firstWhere((v) => v.name == 'initializeMe');
       expect(initializeMe.modelType.name, equals('String'));
       expect(initializeMe.isLate, isTrue);
@@ -441,9 +442,9 @@ void main() async {
     test('simple nullable elements are detected and rendered correctly', () {
       var nullableMembers = nullableElements.allClasses
           .firstWhere((c) => c.name == 'NullableMembers');
-      var methodWithNullables = nullableMembers.publicInstanceMethods
+      var methodWithNullables = nullableMembers.instanceMethods.wherePublic
           .firstWhere((f) => f.name == 'methodWithNullables');
-      var operatorStar = nullableMembers.publicInstanceOperators
+      var operatorStar = nullableMembers.instanceOperators.wherePublic
           .firstWhere((f) => f.name == 'operator *');
       expect(
           methodWithNullables.linkedParams,
@@ -759,7 +760,7 @@ void main() async {
     test('Verify that libraries without categories get handled', () {
       expect(
           packageGraph
-              .localPackages.first.defaultCategory.publicLibraries.length,
+              .localPackages.first.defaultCategory.libraries.wherePublic.length,
           // Only 5 libraries have categories, the rest belong in default.
           equals(kTestPackagePublicLibraries - 5));
     });
@@ -1629,7 +1630,8 @@ void main() async {
         () {
       var notAMethodFromPrivateClass = fakeLibrary.allClasses
           .firstWhere((Class c) => c.name == 'ReferringClass')
-          .publicInstanceMethods
+          .instanceMethods
+          .wherePublic
           .firstWhere((Method m) => m.name == 'notAMethodFromPrivateClass');
       expect(
           notAMethodFromPrivateClass.documentationAsHtml,
@@ -1751,7 +1753,7 @@ void main() async {
     test(
         'ExecutableElements from private classes and from public interfaces (#1561)',
         () {
-      var MIEEMixinWithOverride = fakeLibrary.publicClasses
+      var MIEEMixinWithOverride = fakeLibrary.classes.wherePublic
           .firstWhere((c) => c.name == 'MIEEMixinWithOverride');
       var problematicOperator = MIEEMixinWithOverride.inheritedOperators
           .firstWhere((o) => o.name == 'operator []=');
@@ -1771,11 +1773,11 @@ void main() async {
         overrideByModifierClass;
 
     setUpAll(() {
-      var classes = fakeLibrary.publicClasses;
+      var classes = fakeLibrary.classes.wherePublic;
       GenericClass = classes.firstWhere((c) => c.name == 'GenericClass');
       ModifierClass = classes.firstWhere((c) => c.name == 'ModifierClass');
-      GenericMixin =
-          fakeLibrary.publicMixins.firstWhere((m) => m.name == 'GenericMixin');
+      GenericMixin = fakeLibrary.mixins.wherePublic
+          .firstWhere((m) => m.name == 'GenericMixin');
       TypeInferenceMixedIn =
           classes.firstWhere((c) => c.name == 'TypeInferenceMixedIn');
       overrideByEverything = TypeInferenceMixedIn.instanceFields
@@ -1789,9 +1791,9 @@ void main() async {
     });
 
     test('computes interfaces and implementors correctly', () {
-      var ThingToImplementInMixin = fakeLibrary.publicClasses
+      var ThingToImplementInMixin = fakeLibrary.classes.wherePublic
           .firstWhere((c) => c.name == 'ThingToImplementInMixin');
-      var MixedInImplementation = fakeLibrary.publicClasses
+      var MixedInImplementation = fakeLibrary.classes.wherePublic
           .firstWhere((c) => c.name == 'MixedInImplementation');
       var MixInImplementation =
           fakeLibrary.mixins.firstWhere((m) => m.name == 'MixInImplementation');
@@ -1923,7 +1925,7 @@ void main() async {
     late final Class ExtendingClass, CatString;
 
     setUpAll(() {
-      classes = exLibrary.publicClasses.toList();
+      classes = exLibrary.classes.wherePublic.toList();
       Apple = classes.firstWhere((c) => c.name == 'Apple');
       B = classes.firstWhere((c) => c.name == 'B');
       Cat = classes.firstWhere((c) => c.name == 'Cat');
@@ -2013,29 +2015,37 @@ void main() async {
     });
 
     test('get constants', () {
-      expect(Apple.publicConstantFields, hasLength(1));
-      expect(Apple.publicConstantFields.first.kind, equals(Kind.constant));
+      expect(Apple.constantFields.wherePublic, hasLength(1));
+      expect(
+        Apple.constantFields.wherePublic.first.kind,
+        equals(Kind.constant),
+      );
     });
 
     test('get instance fields', () {
-      expect(Apple.publicInstanceFields.where((f) => !f.isInherited),
-          hasLength(3));
-      expect(Apple.publicInstanceFields.first.kind, equals(Kind.property));
+      expect(
+        Apple.instanceFields.wherePublic.where((f) => !f.isInherited),
+        hasLength(3),
+      );
+      expect(
+        Apple.instanceFields.wherePublic.first.kind,
+        equals(Kind.property),
+      );
     });
 
     test('get inherited properties, including properties of Object', () {
-      expect(B.publicInheritedFields, hasLength(4));
+      expect(B.inheritedFields.wherePublic, hasLength(4));
     });
 
     test('get methods', () {
-      expect(Dog.publicInstanceMethods.where((m) => !m.isInherited),
+      expect(Dog.instanceMethods.wherePublic.where((m) => !m.isInherited),
           hasLength(16));
     });
 
     test('get operators', () {
-      expect(Dog.publicInstanceOperators, hasLength(2));
-      expect(Dog.publicInstanceOperators.first.name, 'operator ==');
-      expect(Dog.publicInstanceOperators.last.name, 'operator +');
+      expect(Dog.instanceOperators.wherePublic, hasLength(2));
+      expect(Dog.instanceOperators.wherePublic.first.name, 'operator ==');
+      expect(Dog.instanceOperators.wherePublic.last.name, 'operator +');
     });
 
     test('has non-inherited instance operators', () {
@@ -2047,15 +2057,15 @@ void main() async {
     });
 
     test('inherited methods, including from Object ', () {
-      expect(B.publicInheritedMethods, hasLength(7));
+      expect(B.inheritedMethods.wherePublic, hasLength(7));
       expect(B.hasPublicInheritedMethods, isTrue);
     });
 
     test('all instance methods', () {
-      var methods = B.publicInstanceMethods.where((m) => !m.isInherited);
+      var methods = B.instanceMethods.wherePublic.where((m) => !m.isInherited);
       expect(methods, isNotEmpty);
-      expect(B.publicInstanceMethods,
-          hasLength(methods.length + B.publicInheritedMethods.length));
+      expect(B.instanceMethods.wherePublic,
+          hasLength(methods.length + B.inheritedMethods.wherePublic.length));
     });
 
     test('inherited methods exist', () {
@@ -2074,14 +2084,18 @@ void main() async {
 
     test('F has a single instance method', () {
       expect(
-          F.publicInstanceMethods.where((m) => !m.isInherited), hasLength(1));
+        F.instanceMethods.wherePublic.where((m) => !m.isInherited),
+        hasLength(1),
+      );
       expect(
-          F.publicInstanceMethods.first.name, equals('methodWithGenericParam'));
+        F.instanceMethods.wherePublic.first.name,
+        equals('methodWithGenericParam'),
+      );
     });
 
     test('F has many inherited methods', () {
       expect(
-          F.publicInheritedMethods.map((im) => im.name),
+          F.inheritedMethods.wherePublic.map((im) => im.name),
           containsAll([
             'abstractMethod',
             'foo',
@@ -2106,13 +2120,16 @@ void main() async {
     });
 
     test('F has zero declared instance properties', () {
-      expect(F.publicInstanceFields.where((f) => !f.isInherited), hasLength(0));
+      expect(
+        F.instanceFields.wherePublic.where((f) => !f.isInherited),
+        hasLength(0),
+      );
     });
 
     test('F has a few inherited properties', () {
-      expect(F.publicInheritedFields, hasLength(10));
+      expect(F.inheritedFields.wherePublic, hasLength(10));
       expect(
-          F.publicInheritedFields.map((ip) => ip.name),
+          F.inheritedFields.wherePublic.map((ip) => ip.name),
           containsAll([
             'aFinalField',
             'aGetterReturningRandomThings',
@@ -2128,12 +2145,13 @@ void main() async {
     });
 
     test('SpecialList has zero instance methods', () {
-      expect(SpecialList.publicInstanceMethods.where((m) => !m.isInherited),
+      expect(
+          SpecialList.instanceMethods.wherePublic.where((m) => !m.isInherited),
           hasLength(0));
     });
 
     test('SpecialList has many inherited methods', () {
-      expect(SpecialList.publicInheritedMethods, hasLength(49));
+      expect(SpecialList.inheritedMethods.wherePublic, hasLength(49));
       var methods = SpecialList.publicInstanceMethodsSorted
           .where((m) => m.isInherited)
           .toList();
@@ -2157,11 +2175,15 @@ void main() async {
           ExtendingClass.superChain.first.modelElement.isPublic, equals(false));
       // And it should still show up in the publicSuperChain, because it is
       // exported.
-      expect(ExtendingClass.publicSuperChain.first.name, equals('BaseClass'));
       expect(
-          ExtendingClass
-              .publicSuperChain.first.modelElement.canonicalLibrary!.name,
-          equals('two_exports'));
+        ExtendingClass.superChain.wherePublic.first.name,
+        equals('BaseClass'),
+      );
+      expect(
+        ExtendingClass
+            .superChain.wherePublic.first.modelElement.canonicalLibrary!.name,
+        equals('two_exports'),
+      );
     });
 
     test(
@@ -2895,7 +2917,7 @@ void main() async {
           .firstWhere((m) => m.name == 'doStuff');
       staticFieldExtension = exLibrary.extensions
           .firstWhere((e) => e.name == 'StaticFieldExtension');
-      extensions = exLibrary.publicExtensions.toList();
+      extensions = exLibrary.extensions.wherePublic.toList();
       baseTest = fakeLibrary.classes.firstWhere((e) => e.name == 'BaseTest');
       bigAnotherExtended =
           fakeLibrary.classes.firstWhere((e) => e.name == 'BigAnotherExtended');
@@ -3076,11 +3098,11 @@ void main() async {
     });
 
     test('get methods', () {
-      expect(fancyList.publicInstanceMethods, hasLength(1));
+      expect(fancyList.instanceMethods.wherePublic, hasLength(1));
     });
 
     test('get operators', () {
-      expect(fancyList.publicInstanceOperators, hasLength(1));
+      expect(fancyList.instanceOperators.wherePublic, hasLength(1));
     });
 
     test('get static methods', () {
@@ -3088,11 +3110,11 @@ void main() async {
     });
 
     test('get properties', () {
-      expect(fancyList.publicInstanceFields, hasLength(1));
+      expect(fancyList.instanceFields.wherePublic, hasLength(1));
     });
 
     test('get constants', () {
-      expect(fancyList.publicConstantFields, hasLength(0));
+      expect(fancyList.constantFields.wherePublic, hasLength(0));
     });
 
     test('correctly finds all the extensions', () {
@@ -3618,7 +3640,7 @@ String? topLevelFunction(int param1, bool param2, Cool coolBeans,
     setUpAll(() {
       c = exLibrary.classes.firstWhere((c) => c.name == 'Apple');
       f1 = c.publicVariableStaticFieldsSorted.first; // n
-      f2 = c.publicInstanceFields.first;
+      f2 = c.instanceFields.wherePublic.first;
       constField = c.constantFields.first; // string
       LongFirstLine =
           fakeLibrary.classes.firstWhere((c) => c.name == 'LongFirstLine');
@@ -4092,13 +4114,13 @@ String? topLevelFunction(int param1, bool param2, Cool coolBeans,
     });
 
     test('@nodoc on simple property works', () {
-      var nodocSimple = fakeLibrary.publicProperties
+      var nodocSimple = fakeLibrary.properties.wherePublic
           .firstWhereOrNull((p) => p.name == 'simplePropertyHidden');
       expect(nodocSimple, isNull);
     });
 
     test('@nodoc on both hides both', () {
-      var nodocBoth = fakeLibrary.publicProperties
+      var nodocBoth = fakeLibrary.properties.wherePublic
           .firstWhereOrNull((p) => p.name == 'getterSetterNodocBoth');
       expect(nodocBoth, isNull);
     });
@@ -4133,7 +4155,7 @@ String? topLevelFunction(int param1, bool param2, Cool coolBeans,
     });
 
     test('found five properties', () {
-      expect(exLibrary.publicProperties, hasLength(7));
+      expect(exLibrary.properties.wherePublic, hasLength(7));
     });
 
     test('linked return type is a double', () {
@@ -4219,7 +4241,7 @@ String? topLevelFunction(int param1, bool param2, Cool coolBeans,
     });
 
     test('found all the constants', () {
-      expect(exLibrary.publicConstants, hasLength(9));
+      expect(exLibrary.constants.wherePublic, hasLength(9));
     });
 
     test('COLOR_GREEN is constant', () {
@@ -4387,7 +4409,7 @@ String? topLevelFunction(int param1, bool param2, Cool coolBeans,
           ExtendsFutureVoid.linkedName,
           equals(
               '<a href="${htmlBasePlaceholder}fake/ExtendsFutureVoid-class.html">ExtendsFutureVoid</a>'));
-      var FutureVoid = ExtendsFutureVoid.publicSuperChain
+      var FutureVoid = ExtendsFutureVoid.superChain.wherePublic
           .firstWhere((c) => c.name == 'Future');
       expect(
           FutureVoid.linkedName,
@@ -4594,8 +4616,8 @@ String? topLevelFunction(int param1, bool param2, Cool coolBeans,
           .singleWhere((m) => m.name == 'methodWithGenericParam');
       methodWithTypedefParam = c.instanceMethods
           .singleWhere((m) => m.name == 'methodWithTypedefParam');
-      doAComplicatedThing = fakeLibrary.publicFunctions
-          .firstWhere((m) => m.name == 'doAComplicatedThing') as ModelFunction;
+      doAComplicatedThing = fakeLibrary.functions.wherePublic
+          .firstWhere((m) => m.name == 'doAComplicatedThing');
     });
 
     test('covariant parameters render correctly', () {

--- a/test/enum_test.dart
+++ b/test/enum_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:dartdoc/src/model/model.dart';
+import 'package:dartdoc/src/model_utils.dart';
 import 'package:dartdoc/src/render/enum_field_renderer.dart';
 import 'package:test/test.dart';
 import 'package:test_reflective_loader/test_reflective_loader.dart';
@@ -551,7 +552,7 @@ class C {}
 
   void test_publicEnums() async {
     var library = await bootPackageWithLibrary('enum E { one, two, three }');
-    expect(library.publicEnums, isNotEmpty);
+    expect(library.enums.wherePublic, isNotEmpty);
   }
 
   void test_publicEnumValues() async {

--- a/test/extension_methods_test.dart
+++ b/test/extension_methods_test.dart
@@ -6,6 +6,7 @@ import 'package:dartdoc/src/markdown_processor.dart';
 import 'package:dartdoc/src/model/extension.dart';
 import 'package:dartdoc/src/model/method.dart';
 import 'package:dartdoc/src/model/model_element.dart';
+import 'package:dartdoc/src/model_utils.dart';
 import 'package:test/test.dart';
 import 'package:test_reflective_loader/test_reflective_loader.dart';
 
@@ -52,7 +53,7 @@ var aPublicFunction() {}
         reexportedContent, libraryContent,
         reexportPrivate: true, show: ['AClassNeedingExtending', 'AnExtension']);
     var aPublicFunction = library.functions.named('aPublicFunction');
-    var anExtension = library.package.publicLibraries
+    var anExtension = library.package.libraries.wherePublic
         .named('${libraryName}_lib')
         .extensions
         .named('AnExtension');
@@ -74,7 +75,7 @@ var aPublicFunction() {}
         reexportedContent, libraryContent,
         reexportPrivate: true, hide: ['AClassNotNeedingExtending']);
     var aPublicFunction = library.functions.named('aPublicFunction');
-    var anExtension = library.package.publicLibraries
+    var anExtension = library.package.libraries.wherePublic
         .named('${libraryName}_lib')
         .extensions
         .named('AnExtension');
@@ -96,7 +97,7 @@ var aPublicFunction() {}
         reexportedContent, libraryContent,
         reexportPrivate: true);
     var aPublicFunction = library.functions.named('aPublicFunction');
-    var anExtension = library.package.publicLibraries
+    var anExtension = library.package.libraries.wherePublic
         .named('${libraryName}_lib')
         .extensions
         .named('AnExtension');

--- a/test/parameter_test.dart
+++ b/test/parameter_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:dartdoc/src/model/model.dart';
+import 'package:dartdoc/src/model_utils.dart';
 import 'package:test/test.dart';
 import 'package:test_reflective_loader/test_reflective_loader.dart';
 
@@ -55,7 +56,7 @@ int one(int Function<T>(T)? f) {
   return 1;
 }
 ''');
-    var one = library.publicFunctions.firstWhere((c) => c.name == 'one');
+    var one = library.functions.wherePublic.firstWhere((c) => c.name == 'one');
     expect(one.linkedParams, matchesCompressed(r'''
         <span class="parameter" id="one-param-f">
           <span class="type-annotation">


### PR DESCRIPTION
`filterNonPublic` becomes an extension getter, `wherePublic`, and `filterNonDocumented` becomes an extension getter, `whereDocumented`.

Nameable now implements Privacy. Privacy is now an abstract interface class.

Changing all the call sites highlights a number of ModelElement getters that are superfluous. For example, `Container.publicInstanceMethods`. This was a getter that now boils down to `instanceMethods.wherePublic`, and it really is unneccessary to keep this; there are many such methods that are removed here:

* Container: `publicInstanceMethods`, `publicInstanceOperators`, `publicInstanceFields`, `publicConstantFields`,
* InheritingContainer: `publicSuperChain`, `publicInheritedFields`, `publicInheritedMethods`,
* LibraryContainer: `publicLibraries`,
* Package: `documentedCategories`,
* PackageGraph: `documentedExtensions`,
* TopLevelContainer: `publicClasses`, `publicExtensions`, `publicExtensionTypes`, `publicConstants`, `publicEnums`, `_publicExceptions`, `publicFunctions`, `publicMixins`, `publicProperties`, `publicTypedefs`.

Additionally, this change highlights some small inefficiency in some `hasX` methods. For example, `hasPublicInstanceMethods` used to enumerate all of the public instance methods, then ask if the list is empty. Now we can ask if `any` of the `instanceMethods` are `public`.

* Container: `hasPublicInstanceMethods`, `hasPublicInstanceOperators`, `hasPublicInstanceFields`, `hasPublicConstantFields`, `hasPublicVariableStaticFields`, `hasPublicStaticMethods`, `hasPublicEnumValues`,
* InheritingContainer: `hasPublicInheritedMethods`, `hasPublicSuperChainReversed`,
* MixedInTypes: `hasPublicMixedInTypes`,
* LibraryContainer: `hasPublicLibraries`,
* Package: `hasDocumentedCategories`,
* TopLevelContainer: `hasPublicClasses`, `hasPublicExtensions`, `hasPublicExtensionTypes`, `hasPublicConstants`, `hasPublicEnums`, `hasPublicExceptions`, `hasPublicFunctions`,`hasPublicMixins`, `hasPublicProperties`, `hasPublicTypedefs`.

Because the field `InheritingContaier.publicSuperChain` is removed, I change `superChain` from a getter to a field, sort of the point of caching.

- Thanks for your contribution! Please replace this text with a description of what this PR is changing or adding and why, list any relevant issues, and review the contribution guidelines below.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
