### PR TITLE
Display an extension's extended type in a few places.

### DIFF
--- a/lib/src/generator/template_data.dart
+++ b/lib/src/generator/template_data.dart
@@ -60,6 +60,10 @@ abstract class TemplateDataBase {
     return navLinksWithGenerics.last;
   }
 
+  bool get isParentExtension => parent is Extension;
+
+  Extension get parentAsExtension => parent as Extension;
+
   bool get hasHomepage => false;
 
   String? get homepage => null;

--- a/lib/src/generator/templates.aot_renderers_for_html.dart
+++ b/lib/src/generator/templates.aot_renderers_for_html.dart
@@ -758,7 +758,7 @@ String renderExtension<T extends Extension>(ExtensionTemplateData<T> context0) {
   if (context2.hasPublicInstanceFields) {
     buffer.writeln();
     buffer.write('''
-    <section class="summary offset-anchor" id="instance-properties">
+      <section class="summary offset-anchor" id="instance-properties">
         <h2>Properties</h2>
 
         <dl class="properties">''');
@@ -770,7 +770,7 @@ String renderExtension<T extends Extension>(ExtensionTemplateData<T> context0) {
     buffer.writeln();
     buffer.write('''
         </dl>
-    </section>''');
+      </section>''');
   }
   buffer.write('\n\n    ');
   buffer.write(_renderExtension_partial_instance_methods_7(context2));
@@ -782,17 +782,18 @@ String renderExtension<T extends Extension>(ExtensionTemplateData<T> context0) {
   buffer.write(_renderExtension_partial_static_methods_10(context2));
   buffer.write('\n    ');
   buffer.write(_renderExtension_partial_static_constants_11(context2));
+  var context6 = context0.extension;
   buffer.writeln();
   buffer.write('''
 
 </div> <!-- /.main-content -->
 
 <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
-    ''');
+  ''');
   buffer.write(_renderExtension_partial_search_sidebar_12(context0));
   buffer.writeln();
   buffer.write('''
-    <h5>''');
+  <h5>''');
   buffer.writeEscaped(context0.parent!.name);
   buffer.write(' ');
   buffer.writeEscaped(context0.parent!.kind.toString());
@@ -805,6 +806,7 @@ String renderExtension<T extends Extension>(ExtensionTemplateData<T> context0) {
 
 ''');
   buffer.write(_renderExtension_partial_footer_13(context0));
+  buffer.writeln();
   buffer.writeln();
   buffer.writeln();
 
@@ -1142,29 +1144,29 @@ String renderLibrary(LibraryTemplateData context0) {
   buffer.writeln();
   buffer.write('''
 
-  <div
-      id="dartdoc-main-content"
-      class="main-content"
-      data-above-sidebar="''');
+<div
+    id="dartdoc-main-content"
+    class="main-content"
+    data-above-sidebar="''');
   buffer.writeEscaped(context0.aboveSidebarPath);
   buffer.write('''"
-      data-below-sidebar="''');
+    data-below-sidebar="''');
   buffer.writeEscaped(context0.belowSidebarPath);
   buffer.write('''">
-      ''');
+  ''');
   var context1 = context0.self;
   buffer.writeln();
   buffer.write('''
-      <div>
-        ''');
+    <div>
+      ''');
   buffer.write(_renderLibrary_partial_source_link_1(context1));
   buffer.writeln();
   buffer.write('''
-        <h1>
-          <span class="kind-library">''');
+      <h1>
+        <span class="kind-library">''');
   buffer.write(context1.displayName);
   buffer.write('''</span>
-          ''');
+        ''');
   buffer.writeEscaped(context1.kind.toString());
   buffer.write(' ');
   buffer.write(_renderLibrary_partial_feature_set_2(context1));
@@ -1172,8 +1174,8 @@ String renderLibrary(LibraryTemplateData context0) {
   buffer.write(_renderLibrary_partial_categorization_3(context1));
   buffer.writeln();
   buffer.write('''
-        </h1>
-      </div>''');
+      </h1>
+    </div>''');
   buffer.writeln();
   var context2 = context0.library;
   buffer.write('\n    ');
@@ -1190,7 +1192,7 @@ String renderLibrary(LibraryTemplateData context0) {
     var context4 = context3.library;
     var context5 = context4.publicClassesSorted;
     for (var context6 in context5) {
-      buffer.write('\n        ');
+      buffer.write('\n          ');
       buffer.write(_renderLibrary_partial_container_5(context6));
     }
     buffer.writeln();
@@ -1210,7 +1212,7 @@ String renderLibrary(LibraryTemplateData context0) {
     var context8 = context7.library;
     var context9 = context8.publicEnumsSorted;
     for (var context10 in context9) {
-      buffer.write('\n        ');
+      buffer.write('\n          ');
       buffer.write(_renderLibrary_partial_container_5(context10));
     }
     buffer.writeln();
@@ -1230,7 +1232,7 @@ String renderLibrary(LibraryTemplateData context0) {
     var context12 = context11.library;
     var context13 = context12.publicMixinsSorted;
     for (var context14 in context13) {
-      buffer.write('\n        ');
+      buffer.write('\n          ');
       buffer.write(_renderLibrary_partial_container_5(context14));
     }
     buffer.writeln();
@@ -1250,7 +1252,7 @@ String renderLibrary(LibraryTemplateData context0) {
     var context16 = context15.library;
     var context17 = context16.publicExtensionTypesSorted;
     for (var context18 in context17) {
-      buffer.write('\n        ');
+      buffer.write('\n          ');
       buffer.write(_renderLibrary_partial_extension_type_6(context18));
     }
     buffer.writeln();
@@ -1270,7 +1272,7 @@ String renderLibrary(LibraryTemplateData context0) {
     var context20 = context19.library;
     var context21 = context20.publicExtensionsSorted;
     for (var context22 in context21) {
-      buffer.write('\n        ');
+      buffer.write('\n          ');
       buffer.write(_renderLibrary_partial_extension_7(context22));
     }
     buffer.writeln();
@@ -1290,7 +1292,7 @@ String renderLibrary(LibraryTemplateData context0) {
     var context24 = context23.library;
     var context25 = context24.publicConstantsSorted;
     for (var context26 in context25) {
-      buffer.write('\n        ');
+      buffer.write('\n          ');
       buffer.write(_renderLibrary_partial_constant_8(context26));
     }
     buffer.writeln();
@@ -1310,7 +1312,7 @@ String renderLibrary(LibraryTemplateData context0) {
     var context28 = context27.library;
     var context29 = context28.publicPropertiesSorted;
     for (var context30 in context29) {
-      buffer.write('\n        ');
+      buffer.write('\n          ');
       buffer.write(_renderLibrary_partial_property_9(context30));
     }
     buffer.writeln();
@@ -1330,7 +1332,7 @@ String renderLibrary(LibraryTemplateData context0) {
     var context32 = context31.library;
     var context33 = context32.publicFunctionsSorted;
     for (var context34 in context33) {
-      buffer.write('\n        ');
+      buffer.write('\n          ');
       buffer.write(_renderLibrary_partial_callable_10(context34));
     }
     buffer.writeln();
@@ -1370,7 +1372,7 @@ String renderLibrary(LibraryTemplateData context0) {
     var context40 = context39.library;
     var context41 = context40.publicExceptionsSorted;
     for (var context42 in context41) {
-      buffer.write('\n        ');
+      buffer.write('\n          ');
       buffer.write(_renderLibrary_partial_container_5(context42));
     }
     buffer.writeln();
@@ -1420,19 +1422,19 @@ String renderMethod(MethodTemplateData context0) {
   buffer.writeln();
   buffer.write('''
 
-  <div
-      id="dartdoc-main-content"
-      class="main-content"
-      data-above-sidebar="''');
+<div
+    id="dartdoc-main-content"
+    class="main-content"
+    data-above-sidebar="''');
   buffer.writeEscaped(context0.aboveSidebarPath);
   buffer.write('''"
-      data-below-sidebar="''');
+    data-below-sidebar="''');
   buffer.writeEscaped(context0.belowSidebarPath);
   buffer.write('''">''');
   var context1 = context0.self;
   buffer.writeln();
   buffer.write('''
-      <div>''');
+    <div>''');
   buffer.write(_renderMethod_partial_source_link_1(context1));
   buffer.write('''<h1><span class="kind-method">''');
   buffer.write(context1.nameWithGenerics);
@@ -1465,18 +1467,33 @@ String renderMethod(MethodTemplateData context0) {
   <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
     ''');
   buffer.write(_renderMethod_partial_search_sidebar_7(context0));
+  if (context0.isParentExtension) {
+    buffer.writeln();
+    buffer.write('''
+    <h5>''');
+    buffer.writeEscaped(context0.parent!.name);
+    buffer.write(' ');
+    buffer.writeEscaped(context0.parent!.kind.toString());
+    buffer.write(''' on ''');
+    buffer.write(context0.parentAsExtension.extendedType.linkedName);
+    buffer.write('''</h5>''');
+  }
+  if (!context0.isParentExtension) {
+    buffer.writeln();
+    buffer.write('''
+    <h5>''');
+    buffer.writeEscaped(context0.parent!.name);
+    buffer.write(' ');
+    buffer.writeEscaped(context0.parent!.kind.toString());
+    buffer.write('''</h5>''');
+  }
   buffer.writeln();
   buffer.write('''
-    <h5>''');
-  buffer.writeEscaped(context0.parent!.name);
-  buffer.write(' ');
-  buffer.writeEscaped(context0.parent!.kind.toString());
-  buffer.write('''</h5>
     <div id="dartdoc-sidebar-left-content"></div>
   </div><!--/.sidebar-offcanvas-->
 
   <div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">
-  </div><!--/.sidebar-offcanvas-->
+</div><!--/.sidebar-offcanvas-->
 
 ''');
   buffer.write(_renderMethod_partial_footer_8(context0));
@@ -1699,13 +1716,28 @@ String renderProperty(PropertyTemplateData context0) {
 <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
   ''');
   buffer.write(_renderProperty_partial_search_sidebar_10(context0));
+  if (context0.isParentExtension) {
+    buffer.writeln();
+    buffer.write('''
+  <h5>''');
+    buffer.writeEscaped(context0.parent!.name);
+    buffer.write(' ');
+    buffer.writeEscaped(context0.parent!.kind.toString());
+    buffer.write(''' on ''');
+    buffer.write(context0.parentAsExtension.extendedType.linkedName);
+    buffer.write('''</h5>''');
+  }
+  if (!context0.isParentExtension) {
+    buffer.writeln();
+    buffer.write('''
+  <h5>''');
+    buffer.writeEscaped(context0.parent!.name);
+    buffer.write(' ');
+    buffer.writeEscaped(context0.parent!.kind.toString());
+    buffer.write('''</h5>''');
+  }
   buffer.writeln();
   buffer.write('''
-  <h5>''');
-  buffer.writeEscaped(context0.parent!.name);
-  buffer.write(' ');
-  buffer.writeEscaped(context0.parent!.kind.toString());
-  buffer.write('''</h5>
   <div id="dartdoc-sidebar-left-content"></div>
 </div><!--/.sidebar-offcanvas-->
 
@@ -3717,7 +3749,10 @@ String _deduplicated_lib_templates__extension_html(Extension context0) {
   }
   buffer.write('''">''');
   buffer.write(context0.linkedName);
-  buffer.write('''</span> ''');
+  buffer.write('''</span>
+  on ''');
+  buffer.write(context0.extendedType.linkedName);
+  buffer.write('\n  ');
   buffer.write(
       __deduplicated_lib_templates__extension_html_partial_categorization_0(
           context0));

--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -13842,6 +13842,13 @@ class _Renderer_TemplateDataBase extends RendererBase<TemplateDataBase> {
                       self.renderSimpleVariable(c, remainingNames, 'bool'),
                   getBool: (CT_ c) => c.includeVersion,
                 ),
+                'isParentExtension': Property(
+                  getValue: (CT_ c) => c.isParentExtension,
+                  renderVariable: (CT_ c, Property<CT_> self,
+                          List<String> remainingNames) =>
+                      self.renderSimpleVariable(c, remainingNames, 'bool'),
+                  getBool: (CT_ c) => c.isParentExtension,
+                ),
                 'layoutTitle': Property(
                   getValue: (CT_ c) => c.layoutTitle,
                   renderVariable:
@@ -13942,6 +13949,29 @@ class _Renderer_TemplateDataBase extends RendererBase<TemplateDataBase> {
                   renderValue: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
                     _render_Documentable(c.parent!, ast, r.template, sink,
+                        parent: r);
+                  },
+                ),
+                'parentAsExtension': Property(
+                  getValue: (CT_ c) => c.parentAsExtension,
+                  renderVariable:
+                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
+                    if (remainingNames.isEmpty) {
+                      return self.getValue(c).toString();
+                    }
+                    var name = remainingNames.first;
+                    var nextProperty =
+                        _Renderer_Extension.propertyMap().getValue(name);
+                    return nextProperty.renderVariable(
+                        self.getValue(c) as Extension,
+                        nextProperty,
+                        [...remainingNames.skip(1)]);
+                  },
+                  isNullValue: (CT_ c) => false,
+                  renderValue: (CT_ c, RendererBase<CT_> r,
+                      List<MustachioNode> ast, StringSink sink) {
+                    _render_Extension(
+                        c.parentAsExtension, ast, r.template, sink,
                         parent: r);
                   },
                 ),

--- a/lib/templates/_extension.html
+++ b/lib/templates/_extension.html
@@ -1,5 +1,7 @@
 <dt id="{{ htmlId }}">
-  <span class="name {{ #isDeprecated }}deprecated{{ /isDeprecated }}">{{{ linkedName }}}</span> {{ >categorization }}
+  <span class="name {{ #isDeprecated }}deprecated{{ /isDeprecated }}">{{{ linkedName }}}</span>
+  on {{{ extendedType.linkedName }}}
+  {{ >categorization }}
 </dt>
 <dd>
   {{{ oneLineDoc }}}

--- a/lib/templates/extension.html
+++ b/lib/templates/extension.html
@@ -1,15 +1,15 @@
-{{>head}}
+{{ >head }}
 <div
     id="dartdoc-main-content"
     class="main-content"
     data-above-sidebar="{{ aboveSidebarPath }}"
     data-below-sidebar="{{ belowSidebarPath }}">
-    {{#self}}
-    <div>{{>source_link}}<h1><span class="kind-class">{{{nameWithGenerics}}}</span> {{kind}} {{>feature_set}} {{>categorization}}</h1></div>
-    {{/self}}
+  {{ #self }}
+    <div>{{ >source_link }}<h1><span class="kind-class">{{{ nameWithGenerics }}}</span> {{ kind }} {{ >feature_set }} {{ >categorization }}</h1></div>
+  {{ /self }}
 
-    {{#extension}}
-    {{>documentation}}
+  {{ #extension }}
+    {{ >documentation }}
     <section>
       <dl class="dl-horizontal">
         <dt>on</dt>
@@ -24,33 +24,34 @@
       {{ >container_annotations }}
     </section>
 
-    {{#hasPublicInstanceFields}}
-    <section class="summary offset-anchor" id="instance-properties">
+    {{ #hasPublicInstanceFields }}
+      <section class="summary offset-anchor" id="instance-properties">
         <h2>Properties</h2>
 
         <dl class="properties">
-            {{#publicInstanceFieldsSorted}}
-            {{>property}}
-            {{/publicInstanceFieldsSorted}}
+          {{ #publicInstanceFieldsSorted }}
+            {{ >property }}
+          {{ /publicInstanceFieldsSorted }}
         </dl>
-    </section>
-    {{/hasPublicInstanceFields}}
+      </section>
+    {{ /hasPublicInstanceFields }}
 
     {{ >instance_methods }}
     {{ >instance_operators }}
     {{ >static_properties }}
     {{ >static_methods }}
     {{ >static_constants }}
+  {{ #extension }}
 
 </div> <!-- /.main-content -->
 
 <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
-    {{>search_sidebar}}
-    <h5>{{parent.name}} {{parent.kind}}</h5>
+  {{ >search_sidebar }}
+  <h5>{{ parent.name }} {{ parent.kind }}</h5>
   <div id="dartdoc-sidebar-left-content"></div>
 </div>
 
 <div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">
 </div><!--/.sidebar-offcanvas-->
 
-{{>footer}}
+{{ >footer }}

--- a/lib/templates/library.html
+++ b/lib/templates/library.html
@@ -1,155 +1,155 @@
-{{>head}}
+{{ >head }}
 
-  <div
-      id="dartdoc-main-content"
-      class="main-content"
-      data-above-sidebar="{{ aboveSidebarPath }}"
-      data-below-sidebar="{{ belowSidebarPath }}">
-      {{ !-- TODO(srawlins): Add annotations. }}
-    {{ #self }}
-      <div>
-        {{ >source_link }}
-        <h1>
-          <span class="kind-library">{{{ displayName }}}</span>
-          {{ kind }} {{ >feature_set }} {{ >categorization }}
-        </h1>
-      </div>
-    {{ /self }}
+<div
+    id="dartdoc-main-content"
+    class="main-content"
+    data-above-sidebar="{{ aboveSidebarPath }}"
+    data-below-sidebar="{{ belowSidebarPath }}">
+  {{ !-- TODO(srawlins): Add annotations. }}
+  {{ #self }}
+    <div>
+      {{ >source_link }}
+      <h1>
+        <span class="kind-library">{{{ displayName }}}</span>
+        {{ kind }} {{ >feature_set }} {{ >categorization }}
+      </h1>
+    </div>
+  {{ /self }}
 
-    {{#library}}
-    {{>documentation}}
-    {{/library}}
+  {{ #library }}
+    {{ >documentation }}
+  {{ /library }}
 
-    {{#library.hasPublicClasses}}
+  {{ #library.hasPublicClasses }}
     <section class="summary offset-anchor" id="classes">
       <h2>Classes</h2>
 
       <dl>
-        {{#library.publicClassesSorted}}
-        {{>container}}
-        {{/library.publicClassesSorted}}
+        {{ #library.publicClassesSorted }}
+          {{ >container }}
+        {{ /library.publicClassesSorted }}
       </dl>
     </section>
-    {{/library.hasPublicClasses}}
+  {{ /library.hasPublicClasses }}
 
-    {{#library.hasPublicEnums}}
+  {{ #library.hasPublicEnums }}
     <section class="summary offset-anchor" id="enums">
       <h2>Enums</h2>
 
       <dl>
-        {{#library.publicEnumsSorted}}
-        {{>container}}
-        {{/library.publicEnumsSorted}}
+        {{ #library.publicEnumsSorted }}
+          {{ >container }}
+        {{ /library.publicEnumsSorted }}
       </dl>
     </section>
-    {{/library.hasPublicEnums}}
+  {{ /library.hasPublicEnums }}
 
-    {{#library.hasPublicMixins}}
+  {{ #library.hasPublicMixins }}
     <section class="summary offset-anchor" id="mixins">
       <h2>Mixins</h2>
 
       <dl>
-        {{#library.publicMixinsSorted}}
-        {{>container}}
-        {{/library.publicMixinsSorted}}
+        {{ #library.publicMixinsSorted }}
+          {{ >container }}
+        {{ /library.publicMixinsSorted }}
       </dl>
     </section>
-    {{/library.hasPublicMixins}}
+  {{ /library.hasPublicMixins }}
 
-    {{ #library.hasPublicExtensionTypes }}
+  {{ #library.hasPublicExtensionTypes }}
     <section class="summary offset-anchor" id="extension-types">
       <h2>Extension Types</h2>
 
       <dl>
         {{ #library.publicExtensionTypesSorted }}
-        {{ >extension_type }}
+          {{ >extension_type }}
         {{ /library.publicExtensionTypesSorted }}
       </dl>
     </section>
-    {{ /library.hasPublicExtensionTypes }}
+  {{ /library.hasPublicExtensionTypes }}
 
-    {{#library.hasPublicExtensions}}
+  {{ #library.hasPublicExtensions }}
     <section class="summary offset-anchor" id="extensions">
       <h2>Extensions</h2>
 
       <dl>
-        {{#library.publicExtensionsSorted}}
-        {{>extension}}
-        {{/library.publicExtensionsSorted}}
+        {{ #library.publicExtensionsSorted }}
+          {{ >extension }}
+        {{ /library.publicExtensionsSorted }}
       </dl>
     </section>
-    {{/library.hasPublicExtensions}}
+  {{ /library.hasPublicExtensions }}
 
-    {{#library.hasPublicConstants}}
+  {{ #library.hasPublicConstants }}
     <section class="summary offset-anchor" id="constants">
       <h2>Constants</h2>
 
       <dl class="properties">
-        {{#library.publicConstantsSorted}}
-        {{>constant}}
-        {{/library.publicConstantsSorted}}
+        {{ #library.publicConstantsSorted }}
+          {{ >constant }}
+        {{ /library.publicConstantsSorted }}
       </dl>
     </section>
-    {{/library.hasPublicConstants}}
+  {{ /library.hasPublicConstants }}
 
-    {{#library.hasPublicProperties}}
+  {{ #library.hasPublicProperties }}
     <section class="summary offset-anchor" id="properties">
       <h2>Properties</h2>
 
       <dl class="properties">
-        {{#library.publicPropertiesSorted}}
-        {{>property}}
-        {{/library.publicPropertiesSorted}}
+        {{ #library.publicPropertiesSorted }}
+          {{ >property }}
+        {{ /library.publicPropertiesSorted }}
       </dl>
     </section>
-    {{/library.hasPublicProperties}}
+  {{ /library.hasPublicProperties }}
 
-    {{#library.hasPublicFunctions}}
+  {{ #library.hasPublicFunctions }}
     <section class="summary offset-anchor" id="functions">
       <h2>Functions</h2>
 
       <dl class="callables">
-        {{#library.publicFunctionsSorted}}
-        {{>callable}}
-        {{/library.publicFunctionsSorted}}
+        {{ #library.publicFunctionsSorted }}
+          {{ >callable }}
+        {{ /library.publicFunctionsSorted }}
       </dl>
     </section>
-    {{/library.hasPublicFunctions}}
+  {{ /library.hasPublicFunctions }}
 
-    {{#library.hasPublicTypedefs}}
+  {{ #library.hasPublicTypedefs }}
     <section class="summary offset-anchor" id="typedefs">
       <h2>Typedefs</h2>
 
       <dl>
-        {{#library.publicTypedefsSorted}}
-          {{>typedef}}
-        {{/library.publicTypedefsSorted}}
+        {{ #library.publicTypedefsSorted }}
+          {{ >typedef }}
+        {{ /library.publicTypedefsSorted }}
       </dl>
     </section>
-    {{/library.hasPublicTypedefs}}
+  {{ /library.hasPublicTypedefs }}
 
-    {{#library.hasPublicExceptions}}
+  {{ #library.hasPublicExceptions }}
     <section class="summary offset-anchor" id="exceptions">
       <h2>Exceptions / Errors</h2>
 
       <dl>
-        {{#library.publicExceptionsSorted}}
-        {{>container}}
-        {{/library.publicExceptionsSorted}}
+        {{ #library.publicExceptionsSorted }}
+          {{ >container }}
+        {{ /library.publicExceptionsSorted }}
       </dl>
     </section>
-    {{/library.hasPublicExceptions}}
+  {{ /library.hasPublicExceptions }}
 
   </div> <!-- /.main-content -->
 
   <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
-    {{>search_sidebar}}
-    <h5><span class="package-name">{{parent.name}}</span> <span class="package-kind">{{parent.kind}}</span></h5>
-    {{>packages}}
+    {{ >search_sidebar }}
+    <h5><span class="package-name">{{ parent.name }}</span> <span class="package-kind">{{ parent.kind }}</span></h5>
+    {{ >packages }}
   </div>
 
   <div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">
-    <h5>{{self.name}} {{self.kind}}</h5>
+    <h5>{{ self.name }} {{ self.kind }}</h5>
   </div><!--/sidebar-offcanvas-right-->
 
-{{>footer}}
+{{ >footer }}

--- a/lib/templates/method.html
+++ b/lib/templates/method.html
@@ -1,33 +1,38 @@
-{{>head}}
+{{ >head }}
 
-  <div
-      id="dartdoc-main-content"
-      class="main-content"
-      data-above-sidebar="{{ aboveSidebarPath }}"
-      data-below-sidebar="{{ belowSidebarPath }}">
-    {{#self}}
-      <div>{{>source_link}}<h1><span class="kind-method">{{{nameWithGenerics}}}</span> {{fullkind}} {{>feature_set}}</h1></div>
-    {{/self}}
+<div
+    id="dartdoc-main-content"
+    class="main-content"
+    data-above-sidebar="{{ aboveSidebarPath }}"
+    data-below-sidebar="{{ belowSidebarPath }}">
+  {{ #self }}
+    <div>{{ >source_link }}<h1><span class="kind-method">{{{ nameWithGenerics }}}</span> {{ fullkind }} {{ >feature_set }}</h1></div>
+  {{ /self }}
 
-    {{#method}}
+  {{ #method }}
     <section class="multi-line-signature">
       {{ >callable_multiline }}
       {{ >attributes }}
     </section>
-    {{>documentation}}
+    {{ >documentation }}
 
-    {{>source_code}}
+    {{ >source_code }}
 
-    {{/method}}
+  {{ /method }}
   </div> <!-- /.main-content -->
 
   <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
-    {{>search_sidebar}}
-    <h5>{{parent.name}} {{parent.kind}}</h5>
+    {{ >search_sidebar }}
+    {{ #isParentExtension }}
+    <h5>{{ parent.name }} {{ parent.kind }} on {{{ parentAsExtension.extendedType.linkedName }}}</h5>
+    {{ /isParentExtension }}
+    {{ ^isParentExtension }}
+    <h5>{{ parent.name }} {{ parent.kind }}</h5>
+    {{ /isParentExtension }}
     <div id="dartdoc-sidebar-left-content"></div>
   </div><!--/.sidebar-offcanvas-->
 
   <div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">
-  </div><!--/.sidebar-offcanvas-->
+</div><!--/.sidebar-offcanvas-->
 
-{{>footer}}
+{{ >footer }}

--- a/lib/templates/property.html
+++ b/lib/templates/property.html
@@ -35,7 +35,12 @@
 
 <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
   {{ >search_sidebar }}
+  {{ #isParentExtension }}
+  <h5>{{ parent.name }} {{ parent.kind }} on {{{ parentAsExtension.extendedType.linkedName }}}</h5>
+  {{ /isParentExtension }}
+  {{ ^isParentExtension }}
   <h5>{{ parent.name }} {{ parent.kind }}</h5>
+  {{ /isParentExtension }}
   <div id="dartdoc-sidebar-left-content"></div>
 </div><!--/.sidebar-offcanvas-->
 


### PR DESCRIPTION
* With the extension's name on a library's page
* With the extension's name in a method or property's sidebar

It's pretty straightforward. One imperfection is we need to add some getters to TemplateData, to help understand whether the parent of a method or property is an extension. This could be made simpler (maybe?) if we added an "is" mustache syntax, like `{{ parent is Extension }}`.

Fixes https://github.com/dart-lang/dartdoc/issues/3650 and work towards https://github.com/dart-lang/dartdoc/issues/2021

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
