### PR TITLE
Convert many fields on Container and TopLevelContainer to getters

### DIFF
--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -14390,7 +14390,7 @@ class _Renderer_TopLevelContainer extends RendererBase<TopLevelContainer> {
                   renderVariable: (CT_ c, Property<CT_> self,
                           List<String> remainingNames) =>
                       self.renderSimpleVariable(
-                          c, remainingNames, 'Iterable<TopLevelVariable>'),
+                          c, remainingNames, 'List<TopLevelVariable>'),
                   renderIterable: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
                     return c.publicConstantsSorted.map((e) =>

--- a/lib/src/model/container.dart
+++ b/lib/src/model/container.dart
@@ -97,7 +97,7 @@ abstract class Container extends ModelElement
   @nonVirtual
   bool get hasPublicInstanceMethods => instanceMethods.any((e) => e.isPublic);
 
-  late final List<Method> publicInstanceMethodsSorted =
+  List<Method> get publicInstanceMethodsSorted =>
       instanceMethods.wherePublic.toList(growable: false)..sort();
 
   @nonVirtual
@@ -113,7 +113,7 @@ abstract class Container extends ModelElement
   bool get hasPublicInstanceOperators =>
       instanceOperators.any((e) => e.isPublic);
 
-  late final List<Operator> publicInstanceOperatorsSorted =
+  List<Operator> get publicInstanceOperatorsSorted =>
       instanceOperators.wherePublic.toList(growable: false)..sort();
 
   /// Fields fully declared in this [Container].
@@ -128,14 +128,14 @@ abstract class Container extends ModelElement
   @nonVirtual
   bool get hasPublicInstanceFields => instanceFields.any((e) => e.isPublic);
 
-  late final List<Field> publicInstanceFieldsSorted =
+  List<Field> get publicInstanceFieldsSorted =>
       instanceFields.wherePublic.toList(growable: false)..sort(byName);
 
   Iterable<Field> get constantFields => declaredFields.where((f) => f.isConst);
 
   bool get hasPublicConstantFields => constantFields.any((e) => e.isPublic);
 
-  late final List<Field> publicConstantFieldsSorted =
+  List<Field> get publicConstantFieldsSorted =>
       constantFields.wherePublic.toList(growable: false)..sort(byName);
 
   /// The total list of public enum values.
@@ -194,7 +194,7 @@ abstract class Container extends ModelElement
 
   bool get hasPublicStaticFields => staticFields.any((e) => e.isPublic);
 
-  late final List<Field> publicStaticFieldsSorted =
+  List<Field> get publicStaticFieldsSorted =>
       staticFields.wherePublic.toList(growable: false)..sort();
 
   Iterable<Field> get staticFields => declaredFields.where((f) => f.isStatic);
@@ -205,7 +205,7 @@ abstract class Container extends ModelElement
   bool get hasPublicVariableStaticFields =>
       variableStaticFields.any((e) => e.isPublic);
 
-  late final List<Field> publicVariableStaticFieldsSorted =
+  List<Field> get publicVariableStaticFieldsSorted =>
       variableStaticFields.wherePublic.toList(growable: false)..sort();
 
   Iterable<Method> get staticMethods =>
@@ -213,7 +213,7 @@ abstract class Container extends ModelElement
 
   bool get hasPublicStaticMethods => staticMethods.any((e) => e.isPublic);
 
-  late final List<Method> publicStaticMethodsSorted =
+  List<Method> get publicStaticMethodsSorted =>
       staticMethods.wherePublic.toList(growable: false)..sort();
 
   /// For subclasses to add items after the main pass but before the

--- a/lib/src/model/top_level_container.dart
+++ b/lib/src/model/top_level_container.dart
@@ -55,33 +55,33 @@ mixin TopLevelContainer implements Nameable {
   // TODO(jcollins-g):  Setting this type parameter to `Container` magically
   // fixes a number of type problems in the AOT compiler, but I am mystified as
   // to why that should be the case.
-  late final List<Container> publicClassesSorted =
+  List<Container> get publicClassesSorted =>
       classes.wherePublic.toList(growable: false)..sort();
 
-  late final List<Extension> publicExtensionsSorted =
+  List<Extension> get publicExtensionsSorted =>
       extensions.wherePublic.toList(growable: false)..sort();
 
-  late final List<ExtensionType> publicExtensionTypesSorted =
+  List<ExtensionType> get publicExtensionTypesSorted =>
       extensionTypes.wherePublic.toList(growable: false)..sort();
 
-  Iterable<TopLevelVariable> get publicConstantsSorted =>
+  List<TopLevelVariable> get publicConstantsSorted =>
       constants.wherePublic.toList(growable: false)..sort();
 
-  late final List<Enum> publicEnumsSorted =
+  List<Enum> get publicEnumsSorted =>
       enums.wherePublic.toList(growable: false)..sort();
 
-  late final List<Class> publicExceptionsSorted =
+  List<Class> get publicExceptionsSorted =>
       exceptions.wherePublic.toList(growable: false)..sort();
 
-  late final List<ModelFunctionTyped> publicFunctionsSorted =
+  List<ModelFunctionTyped> get publicFunctionsSorted =>
       functions.wherePublic.toList(growable: false)..sort();
 
-  late final List<Mixin> publicMixinsSorted =
+  List<Mixin> get publicMixinsSorted =>
       mixins.wherePublic.toList(growable: false)..sort();
 
-  late final List<TopLevelVariable> publicPropertiesSorted =
+  List<TopLevelVariable> get publicPropertiesSorted =>
       properties.wherePublic.toList(growable: false)..sort();
 
-  late final List<Typedef> publicTypedefsSorted =
+  List<Typedef> get publicTypedefsSorted =>
       typedefs.wherePublic.toList(growable: false)..sort();
 }


### PR DESCRIPTION
These were late, final, and public, my least favorite thing. The idea, historically, behind late final fields in dartdoc is caching. If a value is expensive to calculate, like a big list of things, and we have to access that value a few times, best to calculate it once.

But some late final fields are only accessed while rendering HTML, accessed from the rendered templates. And typically only accessed once. The '*Sorted' fields definitely fall into this bucket. So I made them all getters, and then benchmarked with the googleapis package, and found no significant change in time-to-document, or max RSS.


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
