### PR TITLE
Combine two field/getter pairs into simple final fields

### DIFF
--- a/lib/src/model/extension.dart
+++ b/lib/src/model/extension.dart
@@ -65,7 +65,7 @@ class Extension extends Container implements EnclosedElement {
 
   @override
   late final List<Field> declaredFields = element.fields.map((field) {
-    Accessor? getter, setter;
+    ContainerAccessor? getter, setter;
     final fieldGetter = field.getter;
     if (fieldGetter != null) {
       getter = ContainerAccessor(fieldGetter, library, packageGraph);

--- a/lib/src/model/extension_type.dart
+++ b/lib/src/model/extension_type.dart
@@ -40,7 +40,7 @@ class ExtensionType extends InheritingContainer with Constructable {
 
   @override
   late final List<Field> declaredFields = element.fields.map((field) {
-    Accessor? getter, setter;
+    ContainerAccessor? getter, setter;
     final fieldGetter = field.getter;
     if (fieldGetter != null) {
       getter = ContainerAccessor(fieldGetter, library, packageGraph);

--- a/lib/src/model/field.dart
+++ b/lib/src/model/field.dart
@@ -31,39 +31,30 @@ class Field extends ModelElement
     super.library,
     super.packageGraph,
     this.getter,
-    this.setter, {
-    this.isInherited = false,
-    Container? enclosingElement,
-  })  : enclosingElement = isInherited
-            ? enclosingElement!
-            : ModelElement.for_(element.enclosingElement, library, packageGraph)
+    this.setter,
+  )   : isInherited = false,
+        enclosingElement =
+            ModelElement.for_(element.enclosingElement, library, packageGraph)
                 as Container,
         assert(getter != null || setter != null) {
     getter?.enclosingCombo = this;
     setter?.enclosingCombo = this;
   }
 
-  factory Field.inherited(
-    FieldElement element,
-    Container enclosingContainer,
-    Library library,
-    PackageGraph packageGraph,
-    Accessor? getter,
-    Accessor? setter,
-  ) {
-    var newField = Field(
-      element,
-      library,
-      packageGraph,
-      getter as ContainerAccessor?,
-      setter as ContainerAccessor?,
-      isInherited: true,
-      enclosingElement: enclosingContainer,
-    );
-    // Can't set `_isInherited` to true if this is the defining element, because
+  Field.inherited(
+    this.element,
+    this.enclosingElement,
+    super.library,
+    super.packageGraph,
+    this.getter,
+    this.setter,
+  )   : isInherited = true,
+        assert(getter != null || setter != null) {
+    // Can't set `isInherited` to true if this is the defining element, because
     // that would mean it isn't inherited.
-    assert(newField.enclosingElement != newField.definingEnclosingContainer);
-    return newField;
+    assert(enclosingElement != definingEnclosingContainer);
+    getter?.enclosingCombo = this;
+    setter?.enclosingCombo = this;
   }
 
   @override

--- a/lib/src/model/field.dart
+++ b/lib/src/model/field.dart
@@ -14,32 +14,53 @@ class Field extends ModelElement
   @override
   final FieldElement element;
 
-  bool _isInherited = false;
-  late final Container _enclosingContainer;
   @override
   final ContainerAccessor? getter;
+
   @override
   final ContainerAccessor? setter;
 
+  @override
+  final bool isInherited;
+
+  @override
+  final Container enclosingElement;
+
   Field(
-      this.element, super.library, super.packageGraph, this.getter, this.setter)
-      : assert(getter != null || setter != null) {
+    this.element,
+    super.library,
+    super.packageGraph,
+    this.getter,
+    this.setter, {
+    this.isInherited = false,
+    Container? enclosingElement,
+  })  : enclosingElement = isInherited
+            ? enclosingElement!
+            : ModelElement.for_(element.enclosingElement, library, packageGraph)
+                as Container,
+        assert(getter != null || setter != null) {
     getter?.enclosingCombo = this;
     setter?.enclosingCombo = this;
   }
 
   factory Field.inherited(
-      FieldElement element,
-      Container enclosingContainer,
-      Library library,
-      PackageGraph packageGraph,
-      Accessor? getter,
-      Accessor? setter) {
-    var newField = Field(element, library, packageGraph,
-        getter as ContainerAccessor?, setter as ContainerAccessor?);
-    newField._isInherited = true;
-    newField._enclosingContainer = enclosingContainer;
-    // Can't set _isInherited to true if this is the defining element, because
+    FieldElement element,
+    Container enclosingContainer,
+    Library library,
+    PackageGraph packageGraph,
+    Accessor? getter,
+    Accessor? setter,
+  ) {
+    var newField = Field(
+      element,
+      library,
+      packageGraph,
+      getter as ContainerAccessor?,
+      setter as ContainerAccessor?,
+      isInherited: true,
+      enclosingElement: enclosingContainer,
+    );
+    // Can't set `_isInherited` to true if this is the defining element, because
     // that would mean it isn't inherited.
     assert(newField.enclosingElement != newField.definingEnclosingContainer);
     return newField;
@@ -66,11 +87,6 @@ class Field extends ModelElement
   }
 
   @override
-  Container get enclosingElement => isInherited
-      ? _enclosingContainer
-      : getModelFor(element.enclosingElement, library) as Container;
-
-  @override
   String get filePath =>
       '${enclosingElement.library.dirName}/${enclosingElement.name}/${fileStructure.fileName}';
 
@@ -84,8 +100,8 @@ class Field extends ModelElement
   @override
   bool get isConst => element.isConst;
 
-  /// Returns true if the FieldElement is covariant, or if the first parameter
-  /// for the setter is covariant.
+  /// Whether the [FieldElement] is covariant, or the first parameter for the
+  /// setter is covariant.
   @override
   bool get isCovariant => setter?.isCovariant == true || element.isCovariant;
 
@@ -101,9 +117,6 @@ class Field extends ModelElement
 
   @override
   bool get isLate => isFinal && element.isLate;
-
-  @override
-  bool get isInherited => _isInherited;
 
   bool get isStatic => element.isStatic;
 

--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -160,9 +160,14 @@ abstract class ModelElement extends Canonicalization
         }
       } else {
         // EnumFields can't be inherited, so this case is simpler.
-        // TODO(srawlins): Correct this? Is this dead?
         newModelElement = Field.inherited(
-            e, enclosingContainer, library, packageGraph, getter, setter);
+          e,
+          enclosingContainer,
+          library,
+          packageGraph,
+          getter as ContainerAccessor?,
+          setter as ContainerAccessor?,
+        );
       }
     } else if (e is TopLevelVariableElement) {
       assert(getter != null || setter != null);


### PR DESCRIPTION
These two field/getter pairs can just be set in the constructor. Easy peasy.

Also, `Field.inherited` changes from a factory constructor to a regular constructor, which simplifies each constructor.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
