### PR TITLE
Simplify Annotation and Attribute classes

### DIFF
--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -425,20 +425,6 @@ class _Renderer_Annotation extends RendererBase<Annotation> {
           CT_,
           () => {
                 ..._Renderer_Attribute.propertyMap<CT_>(),
-                'annotation': Property(
-                  getValue: (CT_ c) => c.annotation,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(
-                          c, remainingNames, 'ElementAnnotation'),
-                  isNullValue: (CT_ c) => false,
-                  renderValue: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    renderSimple(c.annotation, ast, r.template, sink,
-                        parent: r,
-                        getters: _invisibleGetters['ElementAnnotation']!);
-                  },
-                ),
                 'cssClassName': Property(
                   getValue: (CT_ c) => c.cssClassName,
                   renderVariable:
@@ -479,28 +465,6 @@ class _Renderer_Annotation extends RendererBase<Annotation> {
                           List<String> remainingNames) =>
                       self.renderSimpleVariable(c, remainingNames, 'bool'),
                   getBool: (CT_ c) => c.isPublic,
-                ),
-                'library': Property(
-                  getValue: (CT_ c) => c.library,
-                  renderVariable:
-                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
-                    if (remainingNames.isEmpty) {
-                      return self.getValue(c).toString();
-                    }
-                    var name = remainingNames.first;
-                    var nextProperty =
-                        _Renderer_Library.propertyMap().getValue(name);
-                    return nextProperty.renderVariable(
-                        self.getValue(c) as Library,
-                        nextProperty,
-                        [...remainingNames.skip(1)]);
-                  },
-                  isNullValue: (CT_ c) => false,
-                  renderValue: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    _render_Library(c.library, ast, r.template, sink,
-                        parent: r);
-                  },
                 ),
                 'linkedName': Property(
                   getValue: (CT_ c) => c.linkedName,
@@ -544,63 +508,6 @@ class _Renderer_Annotation extends RendererBase<Annotation> {
                       List<MustachioNode> ast, StringSink sink) {
                     _render_String(
                         c.linkedNameWithParameters, ast, r.template, sink,
-                        parent: r);
-                  },
-                ),
-                'modelType': Property(
-                  getValue: (CT_ c) => c.modelType,
-                  renderVariable:
-                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
-                    if (remainingNames.isEmpty) {
-                      return self.getValue(c).toString();
-                    }
-                    var name = remainingNames.first;
-                    var nextProperty =
-                        _Renderer_ElementType.propertyMap().getValue(name);
-                    return nextProperty.renderVariable(
-                        self.getValue(c) as ElementType,
-                        nextProperty,
-                        [...remainingNames.skip(1)]);
-                  },
-                  isNullValue: (CT_ c) => false,
-                  renderValue: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    _render_ElementType(c.modelType, ast, r.template, sink,
-                        parent: r);
-                  },
-                ),
-                'packageGraph': Property(
-                  getValue: (CT_ c) => c.packageGraph,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(
-                          c, remainingNames, 'PackageGraph'),
-                  isNullValue: (CT_ c) => false,
-                  renderValue: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    renderSimple(c.packageGraph, ast, r.template, sink,
-                        parent: r, getters: _invisibleGetters['PackageGraph']!);
-                  },
-                ),
-                'parameterText': Property(
-                  getValue: (CT_ c) => c.parameterText,
-                  renderVariable:
-                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
-                    if (remainingNames.isEmpty) {
-                      return self.getValue(c).toString();
-                    }
-                    var name = remainingNames.first;
-                    var nextProperty =
-                        _Renderer_String.propertyMap().getValue(name);
-                    return nextProperty.renderVariable(
-                        self.getValue(c) as String,
-                        nextProperty,
-                        [...remainingNames.skip(1)]);
-                  },
-                  isNullValue: (CT_ c) => false,
-                  renderValue: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    _render_String(c.parameterText, ast, r.template, sink,
                         parent: r);
                   },
                 ),
@@ -16194,39 +16101,6 @@ const _invisibleGetters = {
     'session',
     'sinceSdkVersion',
     'source'
-  },
-  'ElementAnnotation': {
-    'constantEvaluationErrors',
-    'element',
-    'hashCode',
-    'isAlwaysThrows',
-    'isDeprecated',
-    'isDoNotStore',
-    'isFactory',
-    'isImmutable',
-    'isInternal',
-    'isIsTest',
-    'isIsTestGroup',
-    'isJS',
-    'isLiteral',
-    'isMustBeOverridden',
-    'isMustCallSuper',
-    'isNonVirtual',
-    'isOptionalTypeArgs',
-    'isOverride',
-    'isProtected',
-    'isProxy',
-    'isRedeclare',
-    'isReopen',
-    'isRequired',
-    'isSealed',
-    'isTarget',
-    'isUseResult',
-    'isVisibleForOverriding',
-    'isVisibleForTemplate',
-    'isVisibleForTesting',
-    'isVisibleOutsideTemplate',
-    'runtimeType'
   },
   'EnumElement': {
     'augmentation',

--- a/lib/src/model/annotation.dart
+++ b/lib/src/model/annotation.dart
@@ -14,49 +14,50 @@ import 'package:dartdoc/src/model/package_graph.dart';
 
 /// Represents a Dart annotation, attached to an element in the source code with
 /// `@`.
-class Annotation extends Attribute {
-  final ElementAnnotation annotation;
-  final Library library;
+final class Annotation extends Attribute {
+  final ElementAnnotation _annotation;
 
-  final PackageGraph packageGraph;
+  final Library _library;
 
-  Annotation(this.annotation, this.library, this.packageGraph)
-      : super(annotation.element!.name!);
+  final PackageGraph _packageGraph;
 
-  @override
-  late final String linkedNameWithParameters =
-      '@$linkedName${HtmlEscape().convert(parameterText)}';
+  Annotation(this._annotation, this._library, this._packageGraph)
+      : super(_annotation.element!.name!);
 
   @override
-  String get linkedName => annotation.element is PropertyAccessorElement
-      ? packageGraph.getModelForElement(annotation.element!).linkedName
-      // TODO(jcollins-g): consider linking to constructor instead of type?
-      : modelType.linkedName;
-
-  late final ElementType modelType = switch (annotation.element) {
-    ConstructorElement(:var returnType) =>
-      packageGraph.getTypeFor(returnType, library),
-    PropertyAccessorElement(:var variable) =>
-      (packageGraph.getModelForElement(variable) as GetterSetterCombo)
-          .modelType,
-    _ => throw StateError(
-        'non-callable element used as annotation?: ${annotation.element}')
-  };
-
-  // TODO(srawlins): Attempt to revive constructor arguments in an annotation,
-  // akin to source_gen's Reviver, in order to link to inner components. For
-  // example, in `@Foo(const Bar(), baz: <Baz>[Baz.one, Baz.two])`, link to
-  // `Foo`, `Bar`, `Baz`, `Baz.one`, and `Baz.two`.
-  /// The textual representation of the argument(s) supplied to the annotation.
-  String get parameterText {
-    var source = annotation.toSource();
+  String get linkedNameWithParameters {
+    var source = _annotation.toSource();
     var startIndex = source.indexOf('(');
-    return source.substring(startIndex == -1 ? source.length : startIndex);
+
+    // TODO(srawlins): Attempt to revive constructor arguments in an annotation,
+    // akin to source_gen's Reviver, in order to link to inner components. For
+    // example, in `@Foo(const Bar(), baz: <Baz>[Baz.one, Baz.two])`, link to
+    // `Foo`, `Bar`, `Baz`, `Baz.one`, and `Baz.two`.
+    var parameterText =
+        source.substring(startIndex == -1 ? source.length : startIndex);
+
+    return '@$linkedName${const HtmlEscape().convert(parameterText)}';
   }
 
   @override
+  String get linkedName => _annotation.element is PropertyAccessorElement
+      ? _packageGraph.getModelForElement(_annotation.element!).linkedName
+      // TODO(jcollins-g): consider linking to constructor instead of type?
+      : _modelType.linkedName;
+
+  late final ElementType _modelType = switch (_annotation.element) {
+    ConstructorElement(:var returnType) =>
+      _packageGraph.getTypeFor(returnType, _library),
+    PropertyAccessorElement(:var variable) =>
+      (_packageGraph.getModelForElement(variable) as GetterSetterCombo)
+          .modelType,
+    _ => throw StateError(
+        'non-callable element used as annotation?: ${_annotation.element}')
+  };
+
+  @override
   bool get isPublic {
-    final modelType = this.modelType;
+    final modelType = _modelType;
     if (!modelType.isPublic) {
       return false;
     }
@@ -66,15 +67,15 @@ class Annotation extends Attribute {
 
     var modelElement = modelType.modelElement;
     return modelElement is Class &&
-        packageGraph.isAnnotationVisible(modelElement);
+        _packageGraph.isAnnotationVisible(modelElement);
   }
 
   @override
   bool operator ==(Object other) =>
-      other is Annotation && other.annotation == annotation;
+      other is Annotation && other._annotation == _annotation;
 
   @override
-  int get hashCode => annotation.hashCode;
+  int get hashCode => _annotation.hashCode;
 
   @override
   String get cssClassName => '';

--- a/lib/src/model/attribute.dart
+++ b/lib/src/model/attribute.dart
@@ -49,7 +49,7 @@ abstract class Attribute implements Privacy {
   static const overrideSetter = Attribute._builtIn('override-setter', 3);
 }
 
-class _BuiltInAttribute extends Attribute {
+final class _BuiltInAttribute extends Attribute {
   const _BuiltInAttribute(super.name, super.sortGroup);
 
   @override


### PR DESCRIPTION
* Privatize many fields on Annotation: `annotation`, `packageGraph`, `modelType`.
* Convert `linkedNameWithParameters` to a getter.
* Inline the `parameterText` field into its only call site, `linkedNameWithParameters`.
* Make Annotation class and _BuiltInAttribute class final.


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
