### PR TITLE
Remove using example-path-prefix in tool/task.dart

### DIFF
--- a/tool/task.dart
+++ b/tool/task.dart
@@ -498,8 +498,6 @@ Future<String> docTestingPackage() async {
       path.join(Directory.current.absolute.path, 'bin', 'dartdoc.dart'),
       '--output',
       outputPath,
-      '--example-path-prefix',
-      'examples',
       '--include-source',
       '--json',
       '--link-to-remote',


### PR DESCRIPTION
Fixing the fact that we can't run dartdoc test package generation without removing this, after removing `@example`.

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
