### PR TITLE
Tidy up Class class, which is not a supertype of Enum class

### DIFF
--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -1671,13 +1671,12 @@ class _Renderer_Class extends RendererBase<Class> {
                   renderVariable: (CT_ c, Property<CT_> self,
                           List<String> remainingNames) =>
                       self.renderSimpleVariable(
-                          c, remainingNames, 'InterfaceElement'),
+                          c, remainingNames, 'ClassElement'),
                   isNullValue: (CT_ c) => false,
                   renderValue: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
                     renderSimple(c.element, ast, r.template, sink,
-                        parent: r,
-                        getters: _invisibleGetters['InterfaceElement']!);
+                        parent: r, getters: _invisibleGetters['ClassElement']!);
                   },
                 ),
                 'fileName': Property(
@@ -15979,6 +15978,27 @@ const _invisibleGetters = {
     'columnNumber',
     'hashCode',
     'lineNumber',
+    'runtimeType'
+  },
+  'ClassElement': {
+    'augmentation',
+    'augmentationTarget',
+    'augmented',
+    'hasNonFinalField',
+    'hashCode',
+    'isAbstract',
+    'isBase',
+    'isConstructable',
+    'isDartCoreEnum',
+    'isDartCoreObject',
+    'isExhaustive',
+    'isFinal',
+    'isInline',
+    'isInterface',
+    'isMixinApplication',
+    'isMixinClass',
+    'isSealed',
+    'isValidMixin',
     'runtimeType'
   },
   'CommentReferable': {

--- a/lib/src/model/class.dart
+++ b/lib/src/model/class.dart
@@ -5,7 +5,7 @@
 import 'package:analyzer/dart/element/element.dart';
 import 'package:dartdoc/src/model/model.dart';
 
-/// A [Container] defined with a `class` or `enum` declaration.
+/// A [Container] defined with a `class` declaration.
 ///
 /// Members follow similar naming rules to [Container], with the following
 /// additions:
@@ -14,7 +14,7 @@ import 'package:dartdoc/src/model/model.dart';
 /// **inherited**: Filtered getters giving only inherited children.
 class Class extends InheritingContainer with Constructable, MixedInTypes {
   @override
-  final InterfaceElement element;
+  final ClassElement element;
 
   @override
   late final List<ModelElement> allModelElements = [
@@ -50,16 +50,10 @@ class Class extends InheritingContainer with Constructable, MixedInTypes {
   String get fileName => '$name-class.html';
 
   @override
-  bool get isAbstract => switch (element) {
-        ClassElement class_ when class_.isAbstract => true,
-        _ => false,
-      };
+  bool get isAbstract => element.isAbstract;
 
   @override
-  bool get isBase => switch (element) {
-        ClassElement class_ when class_.isBase && !class_.isSealed => true,
-        _ => false,
-      };
+  bool get isBase => element.isBase && !element.isSealed;
 
   bool get isErrorOrException {
     bool isError(InterfaceElement element) =>
@@ -72,28 +66,16 @@ class Class extends InheritingContainer with Constructable, MixedInTypes {
   }
 
   @override
-  bool get isFinal => switch (element) {
-        ClassElement class_ when class_.isFinal && !class_.isSealed => true,
-        _ => false,
-      };
+  bool get isFinal => element.isFinal && !element.isSealed;
 
   @override
-  bool get isInterface => switch (element) {
-        ClassElement class_ when class_.isInterface && !class_.isSealed => true,
-        _ => false,
-      };
+  bool get isInterface => element.isInterface && !element.isSealed;
 
   @override
-  bool get isMixinClass => switch (element) {
-        ClassElement class_ when class_.isMixinClass => true,
-        _ => false,
-      };
+  bool get isMixinClass => element.isMixinClass;
 
   @override
-  bool get isSealed => switch (element) {
-        ClassElement class_ when class_.isSealed => true,
-        _ => false,
-      };
+  bool get isSealed => element.isSealed;
 
   @override
   Kind get kind => Kind.class_;


### PR DESCRIPTION
In https://github.com/dart-lang/dartdoc/pull/3697 I had made Enum a subclass of Class, but it turned out to be a step in the wrong direction. I backed out part of that change, but I missed some things. This simplifies Class back to it's much simpler state.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
