### PR TITLE
Format parameters better

### DIFF
--- a/lib/resources/styles.css
+++ b/lib/resources/styles.css
@@ -504,6 +504,21 @@ dl dt.callable .name {
   padding-inline-start: unset;
 }
 
+.parameter-list.single-line {
+  display: inline;
+  margin-left: 0;
+}
+
+.parameter-list.single-line > li {
+  display: inline;
+}
+
+.parameter-list.single-line > li > .parameter {
+  display: inline;
+  margin-left: 0;
+  text-indent: 0;
+}
+
 .signature {
   color: var(--main-text-color);
 }
@@ -726,8 +741,9 @@ td {
 }
 
 .multi-line-signature .parameter {
-  margin-left: 24px;
+  margin-left: 60px;
   display: block;
+  text-indent: -36px;
 }
 
 .breadcrumbs {

--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -690,11 +690,20 @@ abstract class ModelElement extends Canonicalization
   ParameterRenderer get _parameterRendererDetailed =>
       const ParameterRendererHtmlList();
 
+  /// The list of linked parameters, as inline HTML, including metadata.
+  ///
+  /// The text does not contain the leading or trailing parentheses.
   String get linkedParams => _parameterRenderer.renderLinkedParams(parameters);
 
+  /// The list of linked parameters, as block HTML, including metadata.
+  ///
+  /// The text does not contain the leading or trailing parentheses.
   String get linkedParamsLines =>
       _parameterRendererDetailed.renderLinkedParams(parameters).trim();
 
+  /// The list of linked parameters, as inline HTML, without metadata.
+  ///
+  /// The text does not contain the leading or trailing parentheses.
   String? get linkedParamsNoMetadata =>
       _parameterRenderer.renderLinkedParams(parameters, showMetadata: false);
 

--- a/lib/src/render/parameter_renderer.dart
+++ b/lib/src/render/parameter_renderer.dart
@@ -150,32 +150,29 @@ abstract class ParameterRenderer {
       }
 
       for (var p in positionalParams) {
-        var renderedParameter = _renderParameter(p, showMetadata: showMetadata);
         var suffix = identical(p, positionalParams.last) ? trailingText : ', ';
-        var wrappedParameter = parameter('$renderedParameter$suffix', p.htmlId);
-        buffer.write(listItem(wrappedParameter));
+        buffer.write(
+            _renderParameter(p, showMetadata: showMetadata, suffix: suffix));
       }
     }
     if (optionalPositionalParams.isNotEmpty) {
       closingBracket = ']';
 
       for (var p in optionalPositionalParams) {
-        var renderedParameter = _renderParameter(p, showMetadata: showMetadata);
         var suffix = isMultiline || !identical(p, optionalPositionalParams.last)
             ? ', '
             : '';
-        var wrappedParameter = parameter('$renderedParameter$suffix', p.htmlId);
-        buffer.write(listItem(wrappedParameter));
+        buffer.write(
+            _renderParameter(p, showMetadata: showMetadata, suffix: suffix));
       }
     }
     if (namedParams.isNotEmpty) {
       closingBracket = '}';
 
       for (var p in namedParams) {
-        var renderedParameter = _renderParameter(p, showMetadata: showMetadata);
         var suffix = isMultiline || !identical(p, namedParams.last) ? ', ' : '';
-        var wrappedParameter = parameter('$renderedParameter$suffix', p.htmlId);
-        buffer.write(listItem(wrappedParameter));
+        buffer.write(
+            _renderParameter(p, showMetadata: showMetadata, suffix: suffix));
       }
     }
 
@@ -189,7 +186,8 @@ abstract class ParameterRenderer {
 
   String _renderParameter(
     Parameter param, {
-    bool showMetadata = true,
+    required bool showMetadata,
+    required String suffix,
   }) {
     final buffer = StringBuffer();
     final modelType = param.modelType;
@@ -263,6 +261,8 @@ abstract class ParameterRenderer {
       buffer.write(defaultValue(param.defaultValue!));
     }
 
-    return buffer.toString();
+    buffer.write(suffix);
+    var wrappedParameter = parameter(buffer.toString(), param.htmlId);
+    return listItem(wrappedParameter);
   }
 }

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -345,14 +345,14 @@ void main() async {
       expect(
           m1.linkedParamsLines,
           equals(
-              '<ol class="parameter-list"><li><span class="parameter" id="m1-param-some"><span class="type-annotation">int</span> <span class="parameter-name">some</span>, </span></li>\n'
+              '<ol class="parameter-list"> <li><span class="parameter" id="m1-param-some"><span class="type-annotation">int</span> <span class="parameter-name">some</span>, </span></li>\n'
               '<li><span class="parameter" id="m1-param-regular"><span class="type-annotation">dynamic</span> <span class="parameter-name">regular</span>, </span></li>\n'
-              '<li><span class="parameter" id="m1-param-parameters"><span>covariant</span> <span class="type-annotation">dynamic</span> <span class="parameter-name">parameters</span>, </span></li>\n'
-              '<li><span class="parameter" id="m1-param-p1">{<span>required</span> <span class="type-annotation">dynamic</span> <span class="parameter-name">p1</span>, </span></li>\n'
+              '<li><span class="parameter" id="m1-param-parameters"><span>covariant</span> <span class="type-annotation">dynamic</span> <span class="parameter-name">parameters</span>, {</span></li>\n'
+              '<li><span class="parameter" id="m1-param-p1"><span>required</span> <span class="type-annotation">dynamic</span> <span class="parameter-name">p1</span>, </span></li>\n'
               '<li><span class="parameter" id="m1-param-p2"><span class="type-annotation">int</span> <span class="parameter-name">p2</span> = <span class="default-value">3</span>, </span></li>\n'
               '<li><span class="parameter" id="m1-param-p3"><span>required</span> <span>covariant</span> <span class="type-annotation">dynamic</span> <span class="parameter-name">p3</span>, </span></li>\n'
-              '<li><span class="parameter" id="m1-param-p4"><span>required</span> <span>covariant</span> <span class="type-annotation">int</span> <span class="parameter-name">p4</span>}</span></li>\n'
-              '</ol>'));
+              '<li><span class="parameter" id="m1-param-p4"><span>required</span> <span>covariant</span> <span class="type-annotation">int</span> <span class="parameter-name">p4</span>, </span></li>\n'
+              '</ol>}'));
     });
 
     test('verify no regression on ordinary optionals', () {
@@ -369,11 +369,11 @@ void main() async {
       expect(
           m2.linkedParamsLines,
           equals(
-              '<ol class="parameter-list"><li><span class="parameter" id="m2-param-sometimes"><span class="type-annotation">int</span> <span class="parameter-name">sometimes</span>, </span></li>\n'
-              '<li><span class="parameter" id="m2-param-we"><span class="type-annotation">dynamic</span> <span class="parameter-name">we</span>, </span></li>\n'
-              '<li><span class="parameter" id="m2-param-have">[<span class="type-annotation">String</span> <span class="parameter-name">have</span>, </span></li>\n'
-              '<li><span class="parameter" id="m2-param-optionals"><span class="type-annotation">double</span> <span class="parameter-name">optionals</span>]</span></li>\n'
-              '</ol>'));
+              '<ol class="parameter-list"> <li><span class="parameter" id="m2-param-sometimes"><span class="type-annotation">int</span> <span class="parameter-name">sometimes</span>, </span></li>\n'
+              '<li><span class="parameter" id="m2-param-we"><span class="type-annotation">dynamic</span> <span class="parameter-name">we</span>, [</span></li>\n'
+              '<li><span class="parameter" id="m2-param-have"><span class="type-annotation">String</span> <span class="parameter-name">have</span>, </span></li>\n'
+              '<li><span class="parameter" id="m2-param-optionals"><span class="type-annotation">double</span> <span class="parameter-name">optionals</span>, </span></li>\n'
+              '</ol>]'));
     });
 
     test('anonymous callback parameters are correctly marked as nullable', () {
@@ -383,8 +383,8 @@ void main() async {
       expect(listen.isRequiredPositional, isTrue);
       expect(onDone.isNamed, isTrue);
 
-      expect(m3.linkedParamsLines, contains('</ol>\n)?, '));
-      expect(m3.linkedParamsLines, contains('</ol>\n)?}</span>'));
+      expect(m3.linkedParamsLines, contains('</ol>)?, '));
+      expect(m3.linkedParamsLines, contains('</ol>}'));
     });
 
     test('Late final class member test', () {
@@ -3245,7 +3245,7 @@ void main() async {
           topLevelFunction2.linkedParamsLines,
           contains('<span class="parameter-name">p3</span> = '
               '<span class="default-value">const &lt;String, int&gt;{}</span>'
-              ']</span>'));
+              '</span>'));
     });
 
     test('has source code', () {
@@ -3288,11 +3288,11 @@ String? topLevelFunction(int param1, bool param2, Cool coolBeans,
           .renderLinkedParams(doAComplicatedThing.parameters);
       expect(
           params,
-          '<span class="parameter" id="doAComplicatedThing-param-x"><span class="type-annotation">int</span> <span class="parameter-name">x</span>, </span>'
-          '<span class="parameter" id="doAComplicatedThing-param-doSomething">{<span class="type-annotation">void</span> <span class="parameter-name">doSomething</span>(<span class="parameter" id="doSomething-param-aThingParameter"><span class="type-annotation">int</span> <span class="parameter-name">aThingParameter</span>, </span>'
+          '<span class="parameter" id="doAComplicatedThing-param-x"><span class="type-annotation">int</span> <span class="parameter-name">x</span>, {</span>'
+          '<span class="parameter" id="doAComplicatedThing-param-doSomething"><span class="type-annotation">void</span> <span class="parameter-name">doSomething</span>(<span class="parameter" id="doSomething-param-aThingParameter"><span class="type-annotation">int</span> <span class="parameter-name">aThingParameter</span>, </span>'
           '<span class="parameter" id="doSomething-param-anotherThing"><span class="type-annotation">String</span> <span class="parameter-name">anotherThing</span></span>)?, </span>'
           '<span class="parameter" id="doAComplicatedThing-param-doSomethingElse"><span class="type-annotation">void</span> <span class="parameter-name">doSomethingElse</span>(<span class="parameter" id="doSomethingElse-param-aThingParameter"><span class="type-annotation">int</span> <span class="parameter-name">aThingParameter</span>, </span>'
-          '<span class="parameter" id="doSomethingElse-param-somethingElse"><span class="type-annotation">double</span> <span class="parameter-name">somethingElse</span></span>)?}</span>');
+          '<span class="parameter" id="doSomethingElse-param-somethingElse"><span class="type-annotation">double</span> <span class="parameter-name">somethingElse</span></span>)?</span>}');
     });
   });
 
@@ -4532,7 +4532,7 @@ String? topLevelFunction(int param1, bool param2, Cool coolBeans,
       );
       expect(
         aComplexTypedef.linkedParamsLines,
-        '<ol class="parameter-list">'
+        '<ol class="parameter-list single-line"> '
         '<li><span class="parameter" id="param-"><span class="type-annotation">A3</span>, </span></li>\n'
         '<li><span class="parameter" id="param-"><span class="type-annotation">String</span></span></li>\n'
         '</ol>',

--- a/test/parameter_test.dart
+++ b/test/parameter_test.dart
@@ -85,13 +85,12 @@ class A {
 
     expect(named.linkedParams, matchesCompressed(r'''
         <span class="parameter" id="named-param-f">
-          \{
           <span class="type-annotation">
             <a href=".*/dart-core/int-class\.html">int</a>\?
           </span>
           <span class="parameter-name">f</span>
-          \}
         </span>
+        \}
       '''));
   }
 
@@ -106,15 +105,14 @@ class A {
 
     expect(namedWithDefault.linkedParams, matchesCompressed(r'''
         <span class="parameter" id="namedWithDefault-param-f">
-          \{
           <span class="type-annotation">
             <a href=".*/dart-core/int-class\.html">int</a>\?
           </span>
           <span class="parameter-name">f</span>
           =
           <span class="default-value">0</span>
-          \}
         </span>
+        \}
       '''));
   }
 
@@ -129,14 +127,13 @@ class A {
 
     expect(requiredNamed.linkedParams, matchesCompressed(r'''
         <span class="parameter" id="requiredNamed-param-f">
-          \{
           <span>required</span>
           <span class="type-annotation">
             <a href=".*/dart-core/int-class\.html">int</a>\?
           </span>
           <span class="parameter-name">f</span>
-          \}
         </span>
+        \}
       '''));
   }
 
@@ -151,13 +148,12 @@ class A {
 
     expect(optionalPositional.linkedParams, matchesCompressed(r'''
         <span class="parameter" id="optionalPositional-param-f">
-          \[
           <span class="type-annotation">
             <a href=".*/dart-core/int-class\.html">int</a>\?
           </span>
           <span class="parameter-name">f</span>
-          \]
         </span>
+        \]
       '''));
   }
 
@@ -172,15 +168,14 @@ class A {
 
     expect(defaultValue.linkedParams, matchesCompressed(r'''
         <span class="parameter" id="defaultValue-param-f">
-          \[
           <span class="type-annotation">
             <a href=".*/dart-core/int-class\.html">int</a>\?
           </span>
           <span class="parameter-name">f</span>
           =
           <span class="default-value">0</span>
-          \]
         </span>
+        \]
       '''));
   }
 
@@ -283,13 +278,12 @@ class D extends C {
 
     expect(named.linkedParams, matchesCompressed(r'''
         <span class="parameter" id="named-param-a">
-          \{
           <span class="type-annotation">
             <a href=".*/dart-core/int-class\.html">int</a>\?
           </span>
           <span class="parameter-name">a</span>
-          \}
         </span>
+        \}
       '''));
   }
 
@@ -306,15 +300,14 @@ class D extends C {
 
     expect(namedWithDefault.linkedParams, matchesCompressed(r'''
         <span class="parameter" id="namedWithDefault-param-a">
-          \{
           <span class="type-annotation">
             <a href=".*/dart-core/int-class\.html">int</a>
           </span>
           <span class="parameter-name">a</span>
           =
           <span class="default-value">0</span>
-          \}
         </span>
+        \}
       '''));
   }
 
@@ -331,14 +324,13 @@ class D extends C {
 
     expect(requiredNamed.linkedParams, matchesCompressed(r'''
         <span class="parameter" id="requiredNamed-param-a">
-          \{
           <span>required</span>
           <span class="type-annotation">
             <a href=".*/dart-core/int-class\.html">int</a>
           </span>
           <span class="parameter-name">a</span>
-          \}
         </span>
+        \}
       '''));
   }
 
@@ -355,13 +347,12 @@ class D extends C {
 
     expect(optionalPositional.linkedParams, matchesCompressed(r'''
         <span class="parameter" id="optionalPositional-param-a">
-          \[
           <span class="type-annotation">
             <a href=".*/dart-core/int-class\.html">int</a>\?
           </span>
           <span class="parameter-name">a</span>
-          \]
         </span>
+        \]
       '''));
   }
 
@@ -378,15 +369,14 @@ class D extends C {
 
     expect(defaultValue.linkedParams, matchesCompressed(r'''
         <span class="parameter" id="defaultValue-param-a">
-          \[
           <span class="type-annotation">
             <a href=".*/dart-core/int-class\.html">int</a>
           </span>
           <span class="parameter-name">a</span>
           =
           <span class="default-value">0</span>
-          \]
         </span>
+        \]
       '''));
   }
 

--- a/test/parameter_test.dart
+++ b/test/parameter_test.dart
@@ -84,6 +84,7 @@ class A {
     var named = library.constructor('A.named');
 
     expect(named.linkedParams, matchesCompressed(r'''
+        \{
         <span class="parameter" id="named-param-f">
           <span class="type-annotation">
             <a href=".*/dart-core/int-class\.html">int</a>\?
@@ -104,6 +105,7 @@ class A {
     var namedWithDefault = library.constructor('A.namedWithDefault');
 
     expect(namedWithDefault.linkedParams, matchesCompressed(r'''
+        \{
         <span class="parameter" id="namedWithDefault-param-f">
           <span class="type-annotation">
             <a href=".*/dart-core/int-class\.html">int</a>\?
@@ -126,6 +128,7 @@ class A {
     var requiredNamed = library.constructor('A.requiredNamed');
 
     expect(requiredNamed.linkedParams, matchesCompressed(r'''
+        \{
         <span class="parameter" id="requiredNamed-param-f">
           <span>required</span>
           <span class="type-annotation">
@@ -147,6 +150,7 @@ class A {
     var optionalPositional = library.constructor('A.optionalPositional');
 
     expect(optionalPositional.linkedParams, matchesCompressed(r'''
+        \[
         <span class="parameter" id="optionalPositional-param-f">
           <span class="type-annotation">
             <a href=".*/dart-core/int-class\.html">int</a>\?
@@ -167,6 +171,7 @@ class A {
     var defaultValue = library.constructor('A.defaultValue');
 
     expect(defaultValue.linkedParams, matchesCompressed(r'''
+        \[
         <span class="parameter" id="defaultValue-param-f">
           <span class="type-annotation">
             <a href=".*/dart-core/int-class\.html">int</a>\?


### PR DESCRIPTION
Compare:

| Before | After | Notes |
| --- | --- | --- |
| <img width="136" alt="Screenshot 2024-03-20 at 9 51 45 AM" src="https://github.com/dart-lang/dartdoc/assets/103167/0fe6e749-f6ae-4405-ab90-e592a42fd635"> | <img width="215" alt="Screenshot 2024-03-20 at 8 06 32 AM" src="https://github.com/dart-lang/dartdoc/assets/103167/75abddf3-8486-4235-accf-f96d97635dac"> | `test()` and `orElse()` now on one line |
| <img width="418" alt="Screenshot 2024-03-20 at 9 51 57 AM" src="https://github.com/dart-lang/dartdoc/assets/103167/4c59eb1d-f49a-4e26-9fa3-e042ed8a3c95"> | <img width="418" alt="Screenshot 2024-03-20 at 8 06 47 AM" src="https://github.com/dart-lang/dartdoc/assets/103167/70ba13b0-6c4e-4bc5-9827-5637c7316fa5"> | Unchanged |
| <img width="200" alt="Screenshot 2024-03-20 at 9 54 46 AM" src="https://github.com/dart-lang/dartdoc/assets/103167/65d284d3-3b80-4949-bc76-a495ed15183b"> | <img width="195" alt="Screenshot 2024-03-20 at 9 44 29 AM" src="https://github.com/dart-lang/dartdoc/assets/103167/cc537c52-21c7-4b1b-b883-1150f5bceefa"> | braces as in dartfmt, trailing comma |
| <img width="246" alt="Screenshot 2024-03-20 at 9 55 09 AM" src="https://github.com/dart-lang/dartdoc/assets/103167/c3cdb94a-3e90-402e-b6b9-034d8b3d22a4"> | <img width="286" alt="Screenshot 2024-03-20 at 9 45 22 AM" src="https://github.com/dart-lang/dartdoc/assets/103167/63f96ca5-9dc7-415c-af2e-0c04418a4adf"> | braces as in dartfmt, trailing comma |
| <img width="812" alt="Screenshot 2024-03-20 at 9 57 05 AM" src="https://github.com/dart-lang/dartdoc/assets/103167/0f15e32e-7a46-46e1-864c-ea0585e41c63"> | <img width="815" alt="Screenshot 2024-03-20 at 9 49 01 AM" src="https://github.com/dart-lang/dartdoc/assets/103167/2f46b3c2-1037-4910-91e3-4ab92ae1d438"> | Unchanged |
| <img width="457" alt="Screenshot 2024-03-20 at 9 57 15 AM" src="https://github.com/dart-lang/dartdoc/assets/103167/f11f87d2-d185-47a6-9fb1-bef0964044d6"> | <img width="458" alt="Screenshot 2024-03-20 at 9 49 12 AM" src="https://github.com/dart-lang/dartdoc/assets/103167/61467fab-7f64-4318-942e-f14697130d69"> | braces as in dartfmt, trailing comma |


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
