### PR TITLE
Simplify GeneratorFrontend

### DIFF
--- a/lib/src/generator/generator_frontend.dart
+++ b/lib/src/generator/generator_frontend.dart
@@ -35,12 +35,13 @@ class GeneratorFrontEnd implements Generator {
       );
     }
 
-    var indexElements = packageGraph == null
-        ? const <Indexable>[]
-        : _generateDocs(packageGraph);
-
     await _generatorBackend.generateAdditionalFiles();
 
+    if (packageGraph == null) {
+      return;
+    }
+
+    var indexElements = _generateDocs(packageGraph);
     var categories = indexElements
         .whereType<Categorization>()
         .where((e) => e.hasCategorization)
@@ -114,7 +115,7 @@ class GeneratorFrontEnd implements Generator {
       }
     }
 
-    void generateInstanceProperty(Container container) {
+    void generateInstanceProperties(Container container) {
       for (var property in container.instanceFields.whereDocumented) {
         if (!property.isCanonical) continue;
         indexAccumulator.add(property);
@@ -132,7 +133,7 @@ class GeneratorFrontEnd implements Generator {
       }
     }
 
-    void generateStaticProperty(Container container) {
+    void generateStaticProperties(Container container) {
       for (var property in container.variableStaticFields.whereDocumented) {
         if (!property.isCanonical) continue;
         indexAccumulator.add(property);
@@ -171,9 +172,9 @@ class GeneratorFrontEnd implements Generator {
           generateConstructors(class_);
           generateInstanceMethods(class_);
           generateInstanceOperators(class_);
-          generateInstanceProperty(class_);
+          generateInstanceProperties(class_);
           generateStaticMethods(class_);
-          generateStaticProperty(class_);
+          generateStaticProperties(class_);
         }
 
         for (var extension in lib.extensions.whereDocumented) {
@@ -183,9 +184,9 @@ class GeneratorFrontEnd implements Generator {
           generateConstants(extension);
           generateInstanceMethods(extension);
           generateInstanceOperators(extension);
-          generateInstanceProperty(extension);
+          generateInstanceProperties(extension);
           generateStaticMethods(extension);
-          generateStaticProperty(extension);
+          generateStaticProperties(extension);
         }
 
         for (var extensionType in lib.extensionTypes.whereDocumented) {
@@ -197,9 +198,9 @@ class GeneratorFrontEnd implements Generator {
           generateConstructors(extensionType);
           generateInstanceMethods(extensionType);
           generateInstanceOperators(extensionType);
-          generateInstanceProperty(extensionType);
+          generateInstanceProperties(extensionType);
           generateStaticMethods(extensionType);
-          generateStaticProperty(extensionType);
+          generateStaticProperties(extensionType);
         }
 
         for (var mixin in lib.mixins.whereDocumented) {
@@ -207,11 +208,11 @@ class GeneratorFrontEnd implements Generator {
           _generatorBackend.generateMixin(packageGraph, lib, mixin);
 
           generateConstants(mixin);
-          generateInstanceProperty(mixin);
           generateInstanceMethods(mixin);
           generateInstanceOperators(mixin);
+          generateInstanceProperties(mixin);
           generateStaticMethods(mixin);
-          generateStaticProperty(mixin);
+          generateStaticProperties(mixin);
         }
 
         for (var enum_ in lib.enums.whereDocumented) {
@@ -222,9 +223,9 @@ class GeneratorFrontEnd implements Generator {
           generateConstructors(enum_);
           generateInstanceMethods(enum_);
           generateInstanceOperators(enum_);
-          generateInstanceProperty(enum_);
+          generateInstanceProperties(enum_);
           generateStaticMethods(enum_);
-          generateStaticProperty(enum_);
+          generateStaticProperties(enum_);
         }
 
         for (var constant in lib.constants.whereDocumented) {


### PR DESCRIPTION
Previously, this code would determine whether the package graph was `null` (a rather exceptional state), and then carry on a lot of work, even if it was. Instead, we just generate the basic doc layout in this case, and then short circuit return.


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
