### PR TITLE
Remove a TODO in Accessor.characterLocation

### DIFF
--- a/lib/src/model/accessor.dart
+++ b/lib/src/model/accessor.dart
@@ -32,14 +32,9 @@ class Accessor extends ModelElement {
       [ExecutableMember? super.originalMember]);
 
   @override
-  CharacterLocation? get characterLocation {
-    if (element.nameOffset < 0) {
-      assert(element.isSynthetic, 'Invalid offset for non-synthetic element');
-      // TODO(jcollins-g): switch to [element.nonSynthetic] after analyzer 1.8
-      return enclosingCombo.characterLocation;
-    }
-    return super.characterLocation;
-  }
+  CharacterLocation? get characterLocation => element.isSynthetic
+      ? enclosingCombo.characterLocation
+      : super.characterLocation;
 
   @override
   ExecutableMember? get originalMember =>


### PR DESCRIPTION
I looked into `nonSynthetic` and it doesn't buy us anything here. Instead, we can just rely on analyzer's `isSynthetic` to get the right location.


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
