### PR TITLE
Correct a small unnecessary chunk in Library.allClasses

### DIFF
--- a/lib/src/model/library.dart
+++ b/lib/src/model/library.dart
@@ -343,7 +343,6 @@ class Library extends ModelElement
 
   late final List<Class> allClasses = _exportedAndLocalElements
       .whereType<ClassElement>()
-      .where((e) => e is! EnumElement && e is! MixinElement)
       .map((e) => packageGraph.getModelFor(e, this) as Class)
       .toList(growable: false);
 


### PR DESCRIPTION
EnumElements and MixinElements are not ClassElements so... easy peasy.

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
