### PR TITLE
Deprecate the `missingCodeBlockLanguage` warning.

### DIFF
--- a/lib/src/model/documentation_comment.dart
+++ b/lib/src/model/documentation_comment.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'dart:io';
 
 import 'package:analyzer/dart/element/element.dart';

--- a/lib/src/model/documentation_comment.dart
+++ b/lib/src/model/documentation_comment.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:analyzer/dart/element/element.dart';
 import 'package:args/args.dart';
 import 'package:crypto/crypto.dart' as crypto;
@@ -676,6 +678,8 @@ mixin DocumentationComment
     for (var element in firstOfPair) {
       final result = element.group(2)!.trim();
       if (result.isEmpty) {
+        stderr.writeln("The warning 'missingCodeBlockLanguage' is deprecated. "
+            'Use the `missing_code_block_language_in_doc_comment` lint instead.');
         warn(PackageWarning.missingCodeBlockLanguage,
             message:
                 'A fenced code block in Markdown should have a language specified');

--- a/lib/src/model/documentation_comment.dart
+++ b/lib/src/model/documentation_comment.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:io';
-
 import 'package:analyzer/dart/element/element.dart';
 import 'package:args/args.dart';
 import 'package:crypto/crypto.dart' as crypto;
@@ -682,8 +680,6 @@ mixin DocumentationComment
     for (var element in firstOfPair) {
       final result = element.group(2)!.trim();
       if (result.isEmpty) {
-        stderr.writeln("The warning 'missingCodeBlockLanguage' is deprecated. "
-            'Use the `missing_code_block_language_in_doc_comment` lint instead.');
         warn(PackageWarning.missingCodeBlockLanguage,
             message:
                 'A fenced code block in Markdown should have a language specified');

--- a/lib/src/warnings.dart
+++ b/lib/src/warnings.dart
@@ -291,6 +291,7 @@ enum PackageWarning implements Comparable<PackageWarning> {
         'initial declaration. As an example, to specify Dart you would open '
         'the Markdown code block with ```dart or ~~~dart.',
     defaultWarningMode: PackageWarningMode.ignore,
+    isDeprecated: true,
   );
 
   /// The name which can be used at the command line to enable this warning.
@@ -307,6 +308,8 @@ enum PackageWarning implements Comparable<PackageWarning> {
 
   final String _longHelp;
 
+  final bool _isDeprecated;
+
   final PackageWarningMode _defaultWarningMode;
 
   const PackageWarning(
@@ -316,11 +319,13 @@ enum PackageWarning implements Comparable<PackageWarning> {
     String longHelp = '',
     String warnablePrefix = 'from',
     String referredFromPrefix = 'referred to by',
+    bool isDeprecated = false,
     PackageWarningMode defaultWarningMode = PackageWarningMode.warn,
   })  : _shortHelp = shortHelp,
         _longHelp = longHelp,
         _warnablePrefix = warnablePrefix,
         _referredFromPrefix = referredFromPrefix,
+        _isDeprecated = isDeprecated,
         _defaultWarningMode = defaultWarningMode;
 
   static PackageWarning? _byName(String name) =>
@@ -404,6 +409,7 @@ class PackageWarningOptions {
     for (var warningName in errorsForDir) {
       var packageWarning = PackageWarning._byName(warningName);
       if (packageWarning != null) {
+        newOptions.writeErrorOnDeprecation(packageWarning);
         newOptions.error(packageWarning);
       }
     }
@@ -412,6 +418,7 @@ class PackageWarningOptions {
     for (var warningName in warningsForDir) {
       var packageWarning = PackageWarning._byName(warningName);
       if (packageWarning != null) {
+        newOptions.writeErrorOnDeprecation(packageWarning);
         newOptions.warn(packageWarning);
       }
     }
@@ -457,14 +464,21 @@ class PackageWarningOptions {
     return newOptions;
   }
 
+  void error(PackageWarning kind) =>
+      warningModes[kind] = PackageWarningMode.error;
+
   void ignore(PackageWarning kind) =>
       warningModes[kind] = PackageWarningMode.ignore;
 
   void warn(PackageWarning kind) =>
       warningModes[kind] = PackageWarningMode.warn;
 
-  void error(PackageWarning kind) =>
-      warningModes[kind] = PackageWarningMode.error;
+  void writeErrorOnDeprecation(PackageWarning warning) {
+    if (warning._isDeprecated) {
+      stderr.writeln("The warning 'missingCodeBlockLanguage' is deprecated. "
+          'Use the `missing_code_block_language_in_doc_comment` lint instead.');
+    }
+  }
 
   PackageWarningMode getMode(PackageWarning kind) => warningModes[kind]!;
 }

--- a/lib/src/warnings.dart
+++ b/lib/src/warnings.dart
@@ -279,15 +279,17 @@ enum PackageWarning implements Comparable<PackageWarning> {
     'deprecated dartdoc usage: {0}',
     shortHelp: 'A dartdoc directive has a deprecated format.',
   ),
+  // TODO(kallentu): Remove this warning.
   missingCodeBlockLanguage(
     'missing-code-block-language',
     'missing code block language: {0}',
-    shortHelp: 'A fenced code block is missing a specified language.',
-    longHelp:
-        'To enable proper syntax highlighting of Markdown code blocks, Dartdoc '
-        'requires code blocks to specify the language used after the initial '
-        'declaration. As an example, to specify Dart you would open the '
-        'Markdown code block with ```dart or ~~~dart.',
+    shortHelp: '(Deprecated: Use `missing_code_block_language_in_doc_comment` '
+        'lint) A fenced code block is missing a specified language.',
+    longHelp: '(Deprecated: Use `missing_code_block_language_in_doc_comment` '
+        'lint) To enable proper syntax highlighting of Markdown code blocks, '
+        'Dartdoc requires code blocks to specify the language used after the '
+        'initial declaration. As an example, to specify Dart you would open '
+        'the Markdown code block with ```dart or ~~~dart.',
     defaultWarningMode: PackageWarningMode.ignore,
   );
 

--- a/lib/src/warnings.dart
+++ b/lib/src/warnings.dart
@@ -475,8 +475,7 @@ class PackageWarningOptions {
 
   void writeErrorOnDeprecation(PackageWarning warning) {
     if (warning._isDeprecated) {
-      stderr.writeln("The warning 'missingCodeBlockLanguage' is deprecated. "
-          'Use the `missing_code_block_language_in_doc_comment` lint instead.');
+      stderr.writeln("The warning '${warning._flagName}' is deprecated.");
     }
   }
 


### PR DESCRIPTION
Deprecates the `missingCodeBlockLanguage` warning. This will be replaced by the `missing_code_block_language_in_doc_comment` lint.

This is a part of the effort to move more Dartdoc logic to the analyzer/linter.

See lint proposal here: https://github.com/dart-lang/linter/issues/4904

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
