### PR TITLE
Properly sort unnamed libraries

### DIFF
--- a/lib/src/model/nameable.dart
+++ b/lib/src/model/nameable.dart
@@ -97,7 +97,7 @@ mixin Nameable implements Privacy {
 /// Compares [a] with [b] by name.
 int byName(Nameable a, Nameable b) {
   if (a is Library && b is Library) {
-    return a.displayName.compareTo(b.displayName);
+    return compareAsciiLowerCaseNatural(a.displayName, b.displayName);
   }
 
   var stringCompare = compareAsciiLowerCaseNatural(a.name, b.name);

--- a/lib/src/model/nameable.dart
+++ b/lib/src/model/nameable.dart
@@ -96,9 +96,14 @@ mixin Nameable implements Privacy {
 
 /// Compares [a] with [b] by name.
 int byName(Nameable a, Nameable b) {
-  var stringCompare = compareAsciiLowerCaseNatural(a.name, b.name);
-  if (stringCompare == 0) {
-    return a.hashCode.compareTo(b.hashCode);
+  if (a is Library && b is Library) {
+    return a.displayName.compareTo(b.displayName);
   }
-  return stringCompare;
+
+  var stringCompare = compareAsciiLowerCaseNatural(a.name, b.name);
+  if (stringCompare != 0) {
+    return stringCompare;
+  }
+
+  return a.hashCode.compareTo(b.hashCode);
 }

--- a/test/library_test.dart
+++ b/test/library_test.dart
@@ -96,6 +96,8 @@ A doc comment.
 
   test('Libraries are sorted properly', () async {
     var packageMetaProvider = testPackageMetaProvider;
+    var resourceProvider =
+        packageMetaProvider.resourceProvider as MemoryResourceProvider;
 
     var packagePath = await d.createPackage(
       'test_package',
@@ -109,8 +111,7 @@ A doc comment.
         d.file('d.dart', 'library;'),
         d.file('e.dart', ''),
       ],
-      resourceProvider:
-          packageMetaProvider.resourceProvider as MemoryResourceProvider,
+      resourceProvider: resourceProvider,
     );
     final packageConfigProvider =
         getTestPackageConfigProvider(packageMetaProvider.defaultSdkDir.path);
@@ -138,7 +139,14 @@ A doc comment.
     ]..sort(byName);
     expect(
       libraries.map((l) => l.displayName),
-      containsAllInOrder(['b', 'c', 'd', 'd/a', 'e', 'e/a']),
+      containsAllInOrder([
+        'b',
+        'c',
+        'd',
+        resourceProvider.convertPath('d/a'),
+        'e',
+        resourceProvider.convertPath('e/a'),
+      ]),
     );
   });
 

--- a/test/library_test.dart
+++ b/test/library_test.dart
@@ -123,8 +123,10 @@ A doc comment.
       packageMetaProvider,
       packageConfigProvider,
     );
-    final daLibrary = packageGraph.libraries.displayNamed('d/a');
-    final eaLibrary = packageGraph.libraries.displayNamed('e/a');
+    final daName = resourceProvider.convertPath('d/a');
+    final eaName = resourceProvider.convertPath('e/a');
+    final daLibrary = packageGraph.libraries.displayNamed(daName);
+    final eaLibrary = packageGraph.libraries.displayNamed(eaName);
     final bLibrary = packageGraph.libraries.displayNamed('b');
     final cLibrary = packageGraph.libraries.displayNamed('c');
     final dLibrary = packageGraph.libraries.displayNamed('d');
@@ -139,14 +141,7 @@ A doc comment.
     ]..sort(byName);
     expect(
       libraries.map((l) => l.displayName),
-      containsAllInOrder([
-        'b',
-        'c',
-        'd',
-        resourceProvider.convertPath('d/a'),
-        'e',
-        resourceProvider.convertPath('e/a'),
-      ]),
+      containsAllInOrder(['b', 'c', 'd', daName, 'e', eaName]),
     );
   });
 

--- a/test/library_test.dart
+++ b/test/library_test.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:analyzer/file_system/memory_file_system.dart';
-import 'package:collection/collection.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:test/test.dart';
 

--- a/test/src/utils.dart
+++ b/test/src/utils.dart
@@ -17,6 +17,7 @@ import 'package:dartdoc/src/logging.dart';
 import 'package:dartdoc/src/markdown_processor.dart';
 import 'package:dartdoc/src/matching_link_result.dart';
 import 'package:dartdoc/src/model/model.dart';
+import 'package:dartdoc/src/model_utils.dart';
 import 'package:dartdoc/src/package_config_provider.dart';
 import 'package:dartdoc/src/package_meta.dart';
 import 'package:dartdoc/src/warnings.dart';
@@ -355,7 +356,10 @@ bool get classModifiersAllowed =>
         .allows(platformVersion);
 
 extension ModelElementIterableExtension<T extends ModelElement> on Iterable<T> {
-  T named(String name) => firstWhere((e) => e.name == name);
+  T named(String name) => singleWhere((e) => e.name == name);
+
+  T displayNamed(String displayName) =>
+      singleWhere((e) => e.displayName == displayName);
 }
 
 extension IterableStringExtension on Iterable<String> {
@@ -377,11 +381,11 @@ extension IterableStringExtension on Iterable<String> {
 extension PackageExtension on Package {
   /// Gathers all extensions found across a package.
   Iterable<Extension> get extensions =>
-      libraries.expand((library) => library.extensions);
+      libraries.expand((library) => library.extensions.whereDocumented);
 
   /// Gathers all functions found across a package.
   Iterable<ModelFunction> get functions =>
-      libraries.expand((library) => library.functions);
+      libraries.expand((library) => library.functions.whereDocumented);
 }
 
 /// Extension methods just for tests.


### PR DESCRIPTION
Found a few little issues with testing:

* The `named` extension getter should only work if there is a _single_ matching element.
* Fixing that showed the issue of re-exported extensions, so I made the `extensions` and `functions` extension getters only return documented members.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
