### PR TITLE
Rename Library.allClasses; tidy other collections

### DIFF
--- a/lib/src/element_type.dart
+++ b/lib/src/element_type.dart
@@ -10,6 +10,7 @@ library;
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';
+import 'package:analyzer/dart/element/type_system.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/render/element_type_renderer.dart';
@@ -305,6 +306,8 @@ abstract class DefinedElementType extends ElementType {
     return canonicalClass.isPublic;
   }
 
+  TypeSystem get _typeSystem => library.element.typeSystem;
+
   DartType get _bound => type;
 
   /// This type, instantiated to bounds if it isn't already.
@@ -313,7 +316,7 @@ abstract class DefinedElementType extends ElementType {
     final bound = _bound;
     if (bound is InterfaceType &&
         !bound.typeArguments.every((t) => t is InterfaceType)) {
-      return library.typeSystem.instantiateInterfaceToBounds(
+      return _typeSystem.instantiateInterfaceToBounds(
           element: bound.element, nullabilitySuffix: _bound.nullabilitySuffix);
     } else {
       return _bound;
@@ -324,7 +327,7 @@ abstract class DefinedElementType extends ElementType {
   /// of [type].
   @override
   bool isSubtypeOf(ElementType type) =>
-      library.typeSystem.isSubtypeOf(instantiatedType, type.instantiatedType);
+      _typeSystem.isSubtypeOf(instantiatedType, type.instantiatedType);
 
   /// Whether at least one supertype (including via mixins and interfaces) is
   /// equivalent to or a subtype of `this` when instantiated to bounds.
@@ -334,7 +337,7 @@ abstract class DefinedElementType extends ElementType {
     if (type is InterfaceType) {
       var superTypes = type.allSupertypes;
       for (var superType in superTypes) {
-        if (library.typeSystem.isSubtypeOf(superType, instantiatedType)) {
+        if (_typeSystem.isSubtypeOf(superType, instantiatedType)) {
           return true;
         }
       }

--- a/lib/src/generator/generator_frontend.dart
+++ b/lib/src/generator/generator_frontend.dart
@@ -164,7 +164,7 @@ class GeneratorFrontEnd implements Generator {
         indexAccumulator.add(lib);
         _generatorBackend.generateLibrary(packageGraph, lib);
 
-        for (var class_ in lib.allClasses.whereDocumented) {
+        for (var class_ in lib.classesAndExceptions.whereDocumented) {
           indexAccumulator.add(class_);
           _generatorBackend.generateClass(packageGraph, lib, class_);
 

--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -8093,18 +8093,6 @@ class _Renderer_Library extends RendererBase<Library> {
                         parent: r);
                   },
                 ),
-                'allClasses': Property(
-                  getValue: (CT_ c) => c.allClasses,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(
-                          c, remainingNames, 'List<Class>'),
-                  renderIterable: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    return c.allClasses.map((e) =>
-                        _render_Class(e, ast, r.template, sink, parent: r));
-                  },
-                ),
                 'allModelElements': Property(
                   getValue: (CT_ c) => c.allModelElements,
                   renderVariable: (CT_ c, Property<CT_> self,
@@ -8185,6 +8173,18 @@ class _Renderer_Library extends RendererBase<Library> {
                   renderIterable: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
                     return c.classes.map((e) =>
+                        _render_Class(e, ast, r.template, sink, parent: r));
+                  },
+                ),
+                'classesAndExceptions': Property(
+                  getValue: (CT_ c) => c.classesAndExceptions,
+                  renderVariable: (CT_ c, Property<CT_> self,
+                          List<String> remainingNames) =>
+                      self.renderSimpleVariable(
+                          c, remainingNames, 'List<Class>'),
+                  renderIterable: (CT_ c, RendererBase<CT_> r,
+                      List<MustachioNode> ast, StringSink sink) {
+                    return c.classesAndExceptions.map((e) =>
                         _render_Class(e, ast, r.template, sink, parent: r));
                   },
                 ),
@@ -8653,19 +8653,6 @@ class _Renderer_Library extends RendererBase<Library> {
                       List<MustachioNode> ast, StringSink sink) {
                     _render_String(c.sidebarPath, ast, r.template, sink,
                         parent: r);
-                  },
-                ),
-                'typeSystem': Property(
-                  getValue: (CT_ c) => c.typeSystem,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(
-                          c, remainingNames, 'TypeSystem'),
-                  isNullValue: (CT_ c) => false,
-                  renderValue: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    renderSimple(c.typeSystem, ast, r.template, sink,
-                        parent: r, getters: _invisibleGetters['TypeSystem']!);
                   },
                 ),
                 'typedefs': Property(
@@ -12435,7 +12422,7 @@ class _Renderer_Package extends RendererBase<Package> {
   }
 }
 
-String renderSearchPage(PackageTemplateData context, Template template) {
+String renderError(PackageTemplateData context, Template template) {
   var buffer = StringBuffer();
   _render_PackageTemplateData(context, template.ast, template, buffer);
   return buffer.toString();
@@ -12673,13 +12660,13 @@ class _Renderer_PackageTemplateData extends RendererBase<PackageTemplateData> {
   }
 }
 
-String renderIndex(PackageTemplateData context, Template template) {
+String renderSearchPage(PackageTemplateData context, Template template) {
   var buffer = StringBuffer();
   _render_PackageTemplateData(context, template.ast, template, buffer);
   return buffer.toString();
 }
 
-String renderError(PackageTemplateData context, Template template) {
+String renderIndex(PackageTemplateData context, Template template) {
   var buffer = StringBuffer();
   _render_PackageTemplateData(context, template.ast, template, buffer);
   return buffer.toString();
@@ -16690,7 +16677,6 @@ const _invisibleGetters = {
     'name',
     'runtimeType'
   },
-  'TypeSystem': {'hashCode', 'runtimeType'},
   'int': {
     'bitLength',
     'hashCode',

--- a/lib/src/model/package.dart
+++ b/lib/src/model/package.dart
@@ -294,7 +294,7 @@ class Package extends LibraryContainer
         addToCategories(
             extensionType, (c) => c.extensionTypes.add(extensionType));
       }
-      for (var class_ in library.allClasses) {
+      for (var class_ in library.classesAndExceptions) {
         addToCategories(class_, (c) => c.addClass(class_));
       }
       for (var enum_ in library.enums) {

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -151,7 +151,7 @@ class PackageGraph with CommentReferable, Nameable {
     // all packages are picked up.
     for (var package in _documentedPackages) {
       for (var library in package.libraries) {
-        _addToImplementers(library.allClasses);
+        _addToImplementers(library.classesAndExceptions);
         _addToImplementers(library.mixins);
         _addToImplementers(library.extensionTypes);
         _extensions.addAll(library.extensions);
@@ -645,7 +645,7 @@ class PackageGraph with CommentReferable, Nameable {
   /// The String name representing the `Object` type.
   late final String dartCoreObject = libraries
           .firstWhereOrNull((library) => library.name == 'dart:core')
-          ?.allClasses
+          ?.classes
           .firstWhereOrNull((c) => c.name == 'Object')
           ?.linkedName ??
       'Object';

--- a/lib/src/model/top_level_container.dart
+++ b/lib/src/model/top_level_container.dart
@@ -12,7 +12,11 @@ import 'package:dartdoc/src/model_utils.dart' as model_utils;
 /// Do not call any methods or members excepting [name] and the private Lists
 /// below before finishing initialization of a [TopLevelContainer].
 mixin TopLevelContainer implements Nameable {
+  /// All top-level classes except those that subtype [Error] or [Exception].
   Iterable<Class> get classes;
+
+  /// All classes that subtype [Error] or [Exception].
+  Iterable<Class> get exceptions;
 
   Iterable<Extension> get extensions;
 
@@ -22,10 +26,10 @@ mixin TopLevelContainer implements Nameable {
 
   Iterable<Mixin> get mixins;
 
-  Iterable<Class> get exceptions;
-
+  /// All top-level constants.
   Iterable<TopLevelVariable> get constants;
 
+  /// All top-level variables ("properties") except constants.
   Iterable<TopLevelVariable> get properties;
 
   Iterable<ModelFunction> get functions;

--- a/test/end2end/dartdoc_test.dart
+++ b/test/end2end/dartdoc_test.dart
@@ -182,8 +182,7 @@ void main() {
       // the 'Bear' class.
       var dartBear =
           dartPackage.libraries.firstWhere((lib) => lib.name == 'dart:bear');
-      expect(
-          dartBear.allClasses.map((cls) => cls.name).contains('Bear'), isTrue);
+      expect(dartBear.classes.map((cls) => cls.name).contains('Bear'), isTrue);
       expect(dartPackage.libraries.wherePublic, hasLength(3));
     });
 

--- a/test/end2end/model_special_cases_test.dart
+++ b/test/end2end/model_special_cases_test.dart
@@ -306,7 +306,7 @@ void main() {
           isNot(contains('{@end-inject-html}')));
     });
     test('tool outputs a macro which outputs injected HTML', () {
-      var ToolPrintingMacroWhichInjectsHtml = injectionExLibrary.allClasses
+      var ToolPrintingMacroWhichInjectsHtml = injectionExLibrary.classes
           .firstWhere((c) => c.name == 'ToolPrintingMacroWhichInjectsHtml');
       var a = ToolPrintingMacroWhichInjectsHtml.instanceFields
           .firstWhere((m) => m.name == 'a');
@@ -433,7 +433,7 @@ void main() {
       var htmlLibrary =
           sdkAsPackageGraph.libraries.singleWhere((l) => l.name == 'dart:html');
       var eventTarget =
-          htmlLibrary.allClasses.singleWhere((c) => c.name == 'EventTarget');
+          htmlLibrary.classes.singleWhere((c) => c.name == 'EventTarget');
       var hashCode = eventTarget.instanceFields.wherePublic
           .singleWhere((f) => f.name == 'hashCode');
       var objectModelElement =

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -303,9 +303,9 @@ void main() async {
           .firstWhere((lib) => lib.name == 'nnbd_class_member_declarations');
       nullableElements = packageGraph.libraries
           .firstWhere((lib) => lib.name == 'nullable_elements');
-      b = nullSafetyClassMemberDeclarations.allClasses
+      b = nullSafetyClassMemberDeclarations.classes
           .firstWhere((c) => c.name == 'B');
-      c = nullSafetyClassMemberDeclarations.allClasses
+      c = nullSafetyClassMemberDeclarations.classes
           .firstWhere((c) => c.name == 'C');
       oddAsyncFunction = nullableElements.functions.wherePublic
           .firstWhere((f) => f.name == 'oddAsyncFunction');
@@ -388,8 +388,8 @@ void main() async {
     });
 
     test('Late final class member test', () {
-      var c = lateFinalWithoutInitializer.allClasses
-          .firstWhere((c) => c.name == 'C');
+      var c =
+          lateFinalWithoutInitializer.classes.firstWhere((c) => c.name == 'C');
       var a = c.instanceFields.firstWhere((f) => f.name == 'a');
       var b = c.instanceFields.firstWhere((f) => f.name == 'b');
       var cField = c.instanceFields.firstWhere((f) => f.name == 'cField');
@@ -431,7 +431,7 @@ void main() async {
     });
 
     test('complex nullable elements are detected and rendered correctly', () {
-      var complexNullableMembers = nullableElements.allClasses
+      var complexNullableMembers = nullableElements.classes
           .firstWhere((c) => c.name == 'ComplexNullableMembers');
       expect(
           complexNullableMembers.nameWithGenerics,
@@ -440,7 +440,7 @@ void main() async {
     });
 
     test('simple nullable elements are detected and rendered correctly', () {
-      var nullableMembers = nullableElements.allClasses
+      var nullableMembers = nullableElements.classes
           .firstWhere((c) => c.name == 'NullableMembers');
       var methodWithNullables = nullableMembers.instanceMethods.wherePublic
           .firstWhere((f) => f.name == 'methodWithNullables');
@@ -551,15 +551,15 @@ void main() async {
         RegExp(r'PACKAGE_INVOCATION_INDEX: (\d+)');
 
     setUpAll(() {
-      NonCanonicalToolUser = fakeLibrary.allClasses
+      NonCanonicalToolUser = fakeLibrary.classes
           .firstWhere((c) => c.name == '_NonCanonicalToolUser');
-      CanonicalToolUser = fakeLibrary.allClasses
-          .firstWhere((c) => c.name == 'CanonicalToolUser');
-      PrivateLibraryToolUser = fakeLibrary.allClasses
+      CanonicalToolUser =
+          fakeLibrary.classes.firstWhere((c) => c.name == 'CanonicalToolUser');
+      PrivateLibraryToolUser = fakeLibrary.classes
           .firstWhere((c) => c.name == 'PrivateLibraryToolUser');
-      ImplementingClassForTool = fakeLibrary.allClasses
+      ImplementingClassForTool = fakeLibrary.classes
           .firstWhere((c) => c.name == 'ImplementingClassForTool');
-      CanonicalPrivateInheritedToolUser = fakeLibrary.allClasses
+      CanonicalPrivateInheritedToolUser = fakeLibrary.classes
           .firstWhere((c) => c.name == 'CanonicalPrivateInheritedToolUser');
       toolUser = exLibrary.classes.firstWhere((c) => c.name == 'ToolUser');
       invokeTool =
@@ -593,8 +593,9 @@ void main() async {
       // Verify setup of the test is correct.
       expect(invokeToolParentDoc.isCanonical, isTrue);
       expect(invokeToolParentDoc.hasDocumentationComment, isFalse);
-      // Error message here might look strange due to toString() on Methods, but if this
-      // fails that means we don't have the correct invokeToolParentDoc instance.
+      // Error message here might look strange due to `toString()` on Methods,
+      // but if this fails that means we don't have the correct
+      // invokeToolParentDoc instance.
       expect(invokeToolParentDoc.documentationFrom,
           contains(invokeToolParentDocOriginal));
       // Tool should be substituted out here.
@@ -888,7 +889,7 @@ void main() async {
     });
 
     test('can be reexported even if the file suffix is not .dart', () {
-      expect(fakeLibrary.allClasses.map((c) => c.name),
+      expect(fakeLibrary.classes.map((c) => c.name),
           contains('MyClassFromADartFile'));
     });
 
@@ -1007,7 +1008,7 @@ void main() async {
           fakeLibrary.enums.firstWhere((e) => e.name == 'MacrosFromAccessors');
       macroReferencedHere = MacrosFromAccessors.publicEnumValues
           .firstWhere((e) => e.name == 'macroReferencedHere') as EnumField;
-      ClassTemplateOneLiner = exLibrary.allClasses
+      ClassTemplateOneLiner = exLibrary.classes
           .firstWhere((c) => c.name == 'ClassTemplateOneLiner');
     });
 
@@ -1196,7 +1197,7 @@ void main() async {
       superAwesomeClass = fakeLibrary.classes
           .firstWhere((cls) => cls.name == 'SuperAwesomeClass');
       foo2 = fakeLibrary.classes.firstWhere((cls) => cls.name == 'Foo2');
-      extendedClass = twoExportsLib.allClasses
+      extendedClass = twoExportsLib.classes
           .firstWhere((clazz) => clazz.name == 'ExtendingClass');
 
       subForDocComments =
@@ -1256,11 +1257,11 @@ void main() async {
         var NodocMeLibrary = packageGraph.defaultPackage.allLibraries
             .firstWhere((l) => l.name == 'nodocme');
         expect(NodocMeLibrary.hasNodoc, isTrue);
-        var NodocMeImplementation = fakeLibrary.allClasses
+        var NodocMeImplementation = fakeLibrary.classes
             .firstWhere((c) => c.name == 'NodocMeImplementation');
         expect(NodocMeImplementation.hasNodoc, isTrue);
         expect(NodocMeImplementation.isPublic, isFalse);
-        var MeNeitherEvenWithoutADocComment = fakeLibrary.allClasses
+        var MeNeitherEvenWithoutADocComment = fakeLibrary.classes
             .firstWhere((c) => c.name == 'MeNeitherEvenWithoutADocComment');
         expect(MeNeitherEvenWithoutADocComment.hasNodoc, isTrue);
         expect(MeNeitherEvenWithoutADocComment.isPublic, isFalse);
@@ -1628,7 +1629,7 @@ void main() async {
     test(
         'code references to privately defined elements in public classes work properly',
         () {
-      var notAMethodFromPrivateClass = fakeLibrary.allClasses
+      var notAMethodFromPrivateClass = fakeLibrary.classes
           .firstWhere((Class c) => c.name == 'ReferringClass')
           .instanceMethods
           .wherePublic
@@ -1711,7 +1712,7 @@ void main() async {
 
     test('Overrides from intermediate abstract classes are picked up correctly',
         () {
-      var IntermediateAbstractSubclass = fakeLibrary.allClasses
+      var IntermediateAbstractSubclass = fakeLibrary.classes
           .firstWhere((c) => c.name == 'IntermediateAbstractSubclass');
       var operatorEquals = IntermediateAbstractSubclass.inheritedOperators
           .firstWhere((o) => o.name == 'operator ==');
@@ -1724,7 +1725,7 @@ void main() async {
         () {
       var dartCore =
           packageGraph.libraries.firstWhere((l) => l.name == 'dart:core');
-      var intClass = dartCore.allClasses.firstWhere((c) => c.name == 'int');
+      var intClass = dartCore.classes.firstWhere((c) => c.name == 'int');
       var operatorEqualsInt = intClass.inheritedOperators
           .firstWhere((o) => o.name == 'operator ==');
       expect(operatorEqualsInt.definingEnclosingContainer.name, equals('num'));
@@ -1733,7 +1734,7 @@ void main() async {
     test('Factories from unrelated classes are linked correctly', () {
       var A = packageGraph.localPublicLibraries
           .firstWhere((l) => l.name == 'unrelated_factories')
-          .allClasses
+          .classes
           .firstWhere((c) => c.name == 'A');
       var fromMap = A.constructors.firstWhere((c) => c.name == 'A.fromMap');
       expect(fromMap.documentationAsHtml,
@@ -1750,7 +1751,7 @@ void main() async {
         () {
       var GadgetExtender = packageGraph.localPublicLibraries
           .firstWhere((l) => l.name == 'gadget_extender')
-          .allClasses
+          .classes
           .firstWhere((c) => c.name == 'GadgetExtender');
       var gadgetGetter = GadgetExtender.instanceFields
           .firstWhere((f) => f.name == 'gadgetGetter');
@@ -2380,7 +2381,7 @@ void main() async {
         typedParam = aTopLevelTypeParameterFunction.parameters
             .firstWhere((t) => t.name == 'typedParam');
 
-        TypeParameterThings = fakeLibrary.allClasses
+        TypeParameterThings = fakeLibrary.classes
             .firstWhere((c) => c.name == 'TypeParameterThings');
         aName = TypeParameterThings.instanceFields
             .firstWhere((f) => f.name == 'aName');
@@ -2400,12 +2401,12 @@ void main() async {
         BTypeParam = TypeParameterThings.typeParameters.firstWhere(
             (t) => t.name == 'BTypeParam extends FactoryConstructorThings');
 
-        TypeParameterThingsExtended = fakeLibrary.allClasses
+        TypeParameterThingsExtended = fakeLibrary.classes
             .firstWhere((c) => c.name == 'TypeParameterThingsExtended');
         aMethodExtended = TypeParameterThingsExtended.instanceMethods
             .firstWhere((m) => m.name == 'aMethod');
 
-        TypeParameterThingsExtendedQ = fakeLibrary.allClasses
+        TypeParameterThingsExtendedQ = fakeLibrary.classes
             .firstWhere((c) => c.name == 'TypeParameterThingsExtendedQ');
         aMethodExtendedQ = TypeParameterThingsExtendedQ.instanceMethods
             .firstWhere((m) => m.name == 'aMethod');
@@ -2525,11 +2526,11 @@ void main() async {
             .firstWhere((v) => v.name == 'NAME_SINGLEUNDERSCORE');
         string = packageGraph.allLibraries.values
             .firstWhere((e) => e.name == 'dart:core')
-            .allClasses
+            .classes
             .firstWhere((c) => c.name == 'String');
         metaUseResult = packageGraph.allLibraries.values
             .firstWhere((e) => e.name == 'meta')
-            .allClasses
+            .classes
             .firstWhere((c) => c.name == 'UseResult');
         baseForDocComments = fakeLibrary.classes
             .firstWhere((c) => c.name == 'BaseForDocComments');
@@ -2912,7 +2913,7 @@ void main() async {
           .firstWhere((e) => e.name == 'DocumentThisExtensionOnce');
       string = packageGraph.allLibraries.values
           .firstWhere((e) => e.name == 'dart:core')
-          .allClasses
+          .classes
           .firstWhere((c) => c.name == 'String');
       apple = exLibrary.classes.firstWhere((e) => e.name == 'Apple');
       ext = exLibrary.extensions.firstWhere((e) => e.name == 'AppleExtension');
@@ -3687,17 +3688,16 @@ String? topLevelFunction(int param1, bool param2, Cool coolBeans,
           .instanceFields
           .firstWhere((c) => c.name == 'lengthX');
 
-      var appleClass =
-          exLibrary.allClasses.firstWhere((c) => c.name == 'Apple');
+      var appleClass = exLibrary.classes.firstWhere((c) => c.name == 'Apple');
 
       sFromApple = appleClass.instanceFields.firstWhere((p) => p.name == 's');
       mFromApple = appleClass.instanceFields.singleWhere((p) => p.name == 'm');
 
-      mInB = exLibrary.allClasses
+      mInB = exLibrary.classes
           .firstWhere((c) => c.name == 'B')
           .instanceFields
           .firstWhere((p) => p.name == 'm');
-      autoCompress = exLibrary.allClasses
+      autoCompress = exLibrary.classes
           .firstWhere((c) => c.name == 'B')
           .instanceFields
           .firstWhere((p) => p.name == 'autoCompress');
@@ -4219,7 +4219,7 @@ String? topLevelFunction(int param1, bool param2, Cool coolBeans,
       cat = exLibrary.constants.firstWhere((c) => c.name == 'MY_CAT');
       deprecated =
           exLibrary.constants.firstWhere((c) => c.name == 'deprecated');
-      var Dog = exLibrary.allClasses.firstWhere((c) => c.name == 'Dog');
+      var Dog = exLibrary.classes.firstWhere((c) => c.name == 'Dog');
       customClassPrivate = fakeLibrary.constants
           .firstWhere((c) => c.name == 'CUSTOM_CLASS_PRIVATE');
       aStaticConstField =
@@ -4980,7 +4980,6 @@ class StringNameHashCode with Nameable {
 }
 
 extension on Library {
-  Class getClassByName(String name) {
-    return allClasses.firstWhere((c) => c.name == name);
-  }
+  Class getClassByName(String name) =>
+      classes.firstWhere((c) => c.name == name);
 }

--- a/test/package_test.dart
+++ b/test/package_test.dart
@@ -306,7 +306,7 @@ dartdoc:
         // TODO(srawlins): Why is there more than one?
         var libraryOne =
             packageOne.allLibraries.lastWhere((l) => l.name == 'one');
-        var classOne = libraryOne.allClasses.named('One');
+        var classOne = libraryOne.classes.named('One');
         expect(packageOne.documentedWhere, equals(DocumentLocation.remote));
         expect(classOne.href,
             equals('https://mypub.topdomain/one/0.0.1/one/One-class.html'));
@@ -347,7 +347,7 @@ dartdoc:
         expect(packageOne.documentedWhere, equals(DocumentLocation.remote));
         // TODO(srawlins): Why is there more than one?
         var libraryScript = packageOne.allLibraries.named('script');
-        var classScript = libraryScript.allClasses.named('Script');
+        var classScript = libraryScript.classesAndExceptions.named('Script');
         expect(
             classScript.href,
             equals(


### PR DESCRIPTION
A few tidyings to prepare for a bigger Library change I'm working on:

* Move all of the library collections (declared in TopLevelContainer) to one region in the file.
* Extract out common code, since they're all defined almost the same way.
* Rename `allClasses` to `classesAndExceptions`. Every time I came across `Library.allClasses` and, for example, `Library.mixins`, I've thought, "why _all_ classes?" It just turns out that it is classes-that-don't-subclass-Error-orException, and classes-that-do. Having the shared combination is still useful; I just renamed it.
* Move `Library.typeSystem` over to `ElementType`, since it is only ever used over there.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
