### PR TITLE
Remove redundant ModelElement.filePath implementations

### DIFF
--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -4752,28 +4752,6 @@ class _Renderer_Extension extends RendererBase<Extension> {
                         parent: r);
                   },
                 ),
-                'filePath': Property(
-                  getValue: (CT_ c) => c.filePath,
-                  renderVariable:
-                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
-                    if (remainingNames.isEmpty) {
-                      return self.getValue(c).toString();
-                    }
-                    var name = remainingNames.first;
-                    var nextProperty =
-                        _Renderer_String.propertyMap().getValue(name);
-                    return nextProperty.renderVariable(
-                        self.getValue(c) as String,
-                        nextProperty,
-                        [...remainingNames.skip(1)]);
-                  },
-                  isNullValue: (CT_ c) => false,
-                  renderValue: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    _render_String(c.filePath, ast, r.template, sink,
-                        parent: r);
-                  },
-                ),
                 'kind': Property(
                   getValue: (CT_ c) => c.kind,
                   renderVariable: (CT_ c, Property<CT_> self,
@@ -5197,28 +5175,6 @@ class _Renderer_ExtensionType extends RendererBase<ExtensionType> {
                   renderValue: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
                     _render_String(c.fileName, ast, r.template, sink,
-                        parent: r);
-                  },
-                ),
-                'filePath': Property(
-                  getValue: (CT_ c) => c.filePath,
-                  renderVariable:
-                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
-                    if (remainingNames.isEmpty) {
-                      return self.getValue(c).toString();
-                    }
-                    var name = remainingNames.first;
-                    var nextProperty =
-                        _Renderer_String.propertyMap().getValue(name);
-                    return nextProperty.renderVariable(
-                        self.getValue(c) as String,
-                        nextProperty,
-                        [...remainingNames.skip(1)]);
-                  },
-                  isNullValue: (CT_ c) => false,
-                  renderValue: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    _render_String(c.filePath, ast, r.template, sink,
                         parent: r);
                   },
                 ),

--- a/lib/src/model/extension.dart
+++ b/lib/src/model/extension.dart
@@ -93,9 +93,6 @@ class Extension extends Container {
   ];
 
   @override
-  String get filePath => '${library.dirName}/$fileName';
-
-  @override
   String get sidebarPath => '${library.dirName}/$name-extension-sidebar.html';
 
   Map<String, CommentReferable>? _referenceChildren;

--- a/lib/src/model/extension_type.dart
+++ b/lib/src/model/extension_type.dart
@@ -66,9 +66,6 @@ class ExtensionType extends InheritingContainer with Constructable {
   ];
 
   @override
-  String get filePath => '${library.dirName}/$fileName';
-
-  @override
   String get fileName => '$name-extension-type.html';
 
   @override

--- a/lib/src/model/library.dart
+++ b/lib/src/model/library.dart
@@ -184,12 +184,12 @@ class Library extends ModelElement
   ModelElement? get enclosingElement => null;
 
   @override
-  String get filePath => '${library.dirName}/$fileName';
+  String get filePath => '$dirName/$fileName';
 
   @override
   String get fileName => '$dirName-library.html';
 
-  String get sidebarPath => '${library.dirName}/$dirName-library-sidebar.html';
+  String get sidebarPath => '$dirName/$dirName-library-sidebar.html';
 
   /// The library template manually includes 'packages' in the left/above
   /// sidebar.


### PR DESCRIPTION
These are all covered by `Container.filePath`.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
