### PR TITLE
Stop supporting '[this]' as a comment reference.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## 8.0.10-dev
 
 * Un-deprecate the `--resources-dir` option.
+* Remove support for `[this]` as a comment reference. Referring to the
+  containing element can be written as `this [Foo]`, and referring to 'this'
+  can just be written as `` `this` ``.
 
 ## 8.0.9
 

--- a/lib/src/dartdoc_options.dart
+++ b/lib/src/dartdoc_options.dart
@@ -572,7 +572,7 @@ abstract class DartdocOption<T extends Object?> {
   U getValueAs<U>(String name, Folder dir) =>
       _children[name]?.valueAt(dir) as U;
 
-  /// Apply the function [visit] to [this] and all children.
+  /// Apply the function [visit] to this [DartdocOption] and all children.
   void traverse(void Function(DartdocOption option) visit) {
     visit(this);
     for (var value in _children.values) {

--- a/lib/src/model/container.dart
+++ b/lib/src/model/container.dart
@@ -242,7 +242,6 @@ abstract class Container extends ModelElement
             .addEntriesIfAbsent(modelElement.parameters.generateEntries());
       }
     }
-    referenceChildren['this'] = this;
     return referenceChildren;
   }();
 

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -2742,9 +2742,6 @@ void main() async {
                 doAwesomeStuff, 'BaseForDocComments.aNonDefaultConstructor'),
             equals(MatchingLinkResult(aNonDefaultConstructor)));
 
-        expect(referenceLookup(doAwesomeStuff, 'this'),
-            equals(MatchingLinkResult(baseForDocComments)));
-
         expect(referenceLookup(doAwesomeStuff, 'value'),
             equals(MatchingLinkResult(doAwesomeStuffParam)));
 


### PR DESCRIPTION
The analyzer does not support it and does not intend to, so this change aligns
with that effort. It makes analyzing the gap between analyzer and dartdoc
easier as well.

Fixes https://github.com/dart-lang/dartdoc/issues/3761

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
