### PR TITLE
Fix bug around ref resolution of type mentioned in type arguments

### DIFF
--- a/lib/src/markdown_processor.dart
+++ b/lib/src/markdown_processor.dart
@@ -165,30 +165,15 @@ MatchingLinkResult _getMatchingLinkElement(
     String referenceText, Warnable element) {
   var commentReference = ModelCommentReference(referenceText);
 
-  // A filter to be used by [CommentReferable.referenceBy].
-  bool Function(CommentReferable?) filter;
+  var filter = commentReference.hasCallableHint
+      // Trailing parens indicate we are looking for a callable.
+      ? _requireCallable
+      // Without hints, reject unnamed constructors and their parameters to
+      // force resolution to the class.
+      : _rejectUnnamedAndShadowingConstructors;
 
-  // An "allow tree" filter to be used by [CommentReferable.referenceBy].
-  bool Function(CommentReferable?) allowTree;
-
-  if (commentReference.hasCallableHint) {
-    allowTree = (_) => true;
-    // Trailing parens indicate we are looking for a callable.
-    filter = _requireCallable;
-  } else {
-    allowTree = (_) => true;
-    // Neither reject, nor require, an unnamed constructor in the event the
-    // comment reference structure implies one. (We cannot require it in case a
-    // library name is the same as a member class name and the class is the
-    // intended lookup).
-    filter = commentReference.hasCallableHint
-        ? _requireCallable
-        // Without hints, reject unnamed constructors and their parameters to
-        // force resolution to the class.
-        : filter = _rejectUnnamedAndShadowingConstructors;
-  }
-  var lookupResult = element.referenceBy(commentReference.referenceBy,
-      allowTree: allowTree, filter: filter);
+  var lookupResult =
+      element.referenceBy(commentReference.referenceBy, filter: filter);
 
   // TODO(jcollins-g): Consider prioritizing analyzer resolution before custom.
   return MatchingLinkResult(lookupResult);

--- a/lib/src/model/method.dart
+++ b/lib/src/model/method.dart
@@ -138,10 +138,24 @@ class Method extends ModelElement
       return from.referenceChildren;
     }
     return _referenceChildren ??= <String, CommentReferable>{
-      ...modelType.returnType.typeArguments.explicitOnCollisionWith(this),
-      ...modelType.typeArguments.explicitOnCollisionWith(this),
+      // If we want to include all types referred to in the signature of this
+      // method, this is woefully incomplete. Notice we don't currently include
+      // the element of the returned type itself, nor nested type arguments,
+      // nor other nested types e.g. in the case of function types or record
+      // types. But this is all being replaced with analyzer's resolution soon.
+      ...modelType.returnType.typeArguments.modelElements
+          .explicitOnCollisionWith(this),
       ...parameters.explicitOnCollisionWith(this),
       ...typeParameters.explicitOnCollisionWith(this),
     };
   }
+}
+
+extension on Iterable<ElementType> {
+  /// The [ModelElement] associated with each type, for each type that is a
+  /// [DefinedElementType].
+  List<ModelElement> get modelElements => [
+        for (var type in this)
+          if (type is DefinedElementType) type.modelElement,
+      ];
 }

--- a/test/comment_referable/comment_referable_test.dart
+++ b/test/comment_referable/comment_referable_test.dart
@@ -23,11 +23,11 @@ abstract class Base with Nameable, CommentReferable {
   /// Returns the added (or already existing) [Base].
   Base add(String newName);
 
-  CommentReferable? lookup<T extends CommentReferable?>(String value,
-      {bool Function(CommentReferable?)? allowTree,
-      bool Function(CommentReferable?)? filter}) {
-    return referenceBy(value.split(_separator),
-        allowTree: allowTree ?? (_) => true, filter: filter ?? (_) => true);
+  CommentReferable? lookup<T extends CommentReferable?>(
+    String value, {
+    bool Function(CommentReferable?)? filter,
+  }) {
+    return referenceBy(value.split(_separator), filter: filter ?? (_) => true);
   }
 
   @override
@@ -163,20 +163,6 @@ void main() {
       expect(referable.lookup('lib3'), isA<TopChild>());
       expect(referable.lookup('lib3', filter: (r) => r is GenericChild),
           isA<GenericChild>());
-    });
-
-    test('Check that allowTree works', () {
-      referable.add('lib4');
-      var lib4lib4 = referable.add('lib4.lib4');
-      var tooDeepSub1 = referable.add('lib4.lib4.sub1');
-      var sub1 = referable.add('lib4.sub1');
-      var sub2 = referable.add('lib4.sub2');
-      expect(sub2.lookup('lib4.lib4'), equals(lib4lib4));
-      expect(sub2.lookup('lib4.sub1'), equals(tooDeepSub1));
-      expect(
-          sub2.lookup('lib4.sub1',
-              allowTree: (r) => r is Base && (r.parent is Top)),
-          equals(sub1));
     });
 
     test('Check that grandparent overrides work', () {

--- a/test/enum_test.dart
+++ b/test/enum_test.dart
@@ -641,4 +641,64 @@ class C {}
       '<a href="$linkPrefix/E/values-constant.html">E.values</a>.</p>',
     );
   }
+
+  void test_canBeReferenced_whenFoundAsReturnType() async {
+    var library = await bootPackageWithLibrary('''
+enum E {
+  one, two
+}
+
+class C {
+  /// [E] can be referenced.
+  E m() => E.one;
+}
+''');
+    var m = library.classes.named('C').instanceMethods.named('m');
+
+    expect(m.hasDocumentationComment, true);
+    expect(
+      m.documentationAsHtml,
+      '<p><a href="$linkPrefix/E.html">E</a> can be referenced.</p>',
+    );
+  }
+
+  void test_canBeReferenced_whenFoundAsReturnType_typeArgument() async {
+    var library = await bootPackageWithLibrary('''
+enum E {
+  one, two
+}
+
+class C {
+  /// [E] can be referenced.
+  Future<E> m() async => E.one;
+}
+''');
+    var m = library.classes.named('C').instanceMethods.named('m');
+
+    expect(m.hasDocumentationComment, true);
+    expect(
+      m.documentationAsHtml,
+      '<p><a href="$linkPrefix/E.html">E</a> can be referenced.</p>',
+    );
+  }
+
+  void test_canBeReferenced_whenFoundAsParameterType() async {
+    var library = await bootPackageWithLibrary('''
+enum E {
+  one, two
+}
+
+class C {
+  /// [E] can be referenced.
+  void m(E p) {}
+}
+''');
+    var m = library.classes.named('C').instanceMethods.named('m');
+
+    expect(m.hasDocumentationComment, true);
+    expect(
+      m.documentationAsHtml,
+      '<p><a href="$linkPrefix/E.html">E</a> can be referenced.</p>',
+    );
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/dart-lang/dartdoc/issues/3758

The main fix is in `method.dart`, when finding "elements nearby" a method, we were including the ElementType for things like "type arguments in the return type," as in `Vehicle` in `Future<Vehicle>`. But the ElementType does not have an `href`; it has a ModelElement which _does have_ an `href`.

I also simplify a few things:

* Also in `method`, we were looking at the "type arguments" of a method declartion, but this is implemented in the ElementType hierarchy to be `const []`. Oy. OK, removed.
* A recent refactor meant that `allowTree` was only ever `(_) => true`, so I scrapped that parameter in a few functions, simplfying everything.
* 

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
