### PR TITLE
Combine the two implementations of "library canonicalization"

### DIFF
--- a/lib/src/element_type.dart
+++ b/lib/src/element_type.dart
@@ -301,8 +301,7 @@ abstract class DefinedElementType extends ElementType {
   @override
   bool get isPublic {
     var canonicalClass =
-        packageGraph.findCanonicalModelElementFor(modelElement.element) ??
-            modelElement;
+        packageGraph.findCanonicalModelElementFor(modelElement) ?? modelElement;
     return canonicalClass.isPublic;
   }
 

--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -3424,7 +3424,7 @@ class _Renderer_ContainerMember extends RendererBase<ContainerMember> {
                   renderVariable: (CT_ c, Property<CT_> self,
                           List<String> remainingNames) =>
                       self.renderSimpleVariable(
-                          c, remainingNames, 'Iterable<Library>'),
+                          c, remainingNames, 'List<Library>'),
                   renderIterable: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
                     return c.referenceGrandparentOverrides.map((e) =>

--- a/lib/src/model/container_member.dart
+++ b/lib/src/model/container_member.dart
@@ -40,16 +40,8 @@ mixin ContainerMember on ModelElement {
     return canonicalEnclosingContainer;
   }();
 
-  Container? computeCanonicalEnclosingContainer() {
-    final enclosingElement = this.enclosingElement;
-    return switch (enclosingElement) {
-      Extension() =>
-        packageGraph.findCanonicalModelElementFor(enclosingElement.element),
-      ExtensionType() =>
-        packageGraph.findCanonicalModelElementFor(enclosingElement.element),
-      _ => packageGraph.findCanonicalModelElementFor(element.enclosingElement),
-    } as Container?;
-  }
+  Container? computeCanonicalEnclosingContainer() =>
+      packageGraph.findCanonicalModelElementFor(enclosingElement) as Container?;
 
   @override
   // TODO(jcollins-g): dart-lang/dartdoc#2693.
@@ -63,13 +55,12 @@ mixin ContainerMember on ModelElement {
       ];
 
   @override
-  Iterable<Library> get referenceGrandparentOverrides sync* {
-    // TODO(jcollins-g): split Field documentation up between accessors
-    // and resolve the pieces with different scopes.  dart-lang/dartdoc#2693.
-    // Until then, just pretend we're handling this correctly.
-    yield (documentationFrom.first as ModelElement).definingLibrary;
-    // TODO(jcollins-g): Wean users off of depending on canonical library
-    // resolution. dart-lang/dartdoc#2696
-    if (canonicalLibrary != null) yield canonicalLibrary!;
-  }
+  List<Library> get referenceGrandparentOverrides =>
+      // TODO(jcollins-g): split Field documentation up between accessors
+      // and resolve the pieces with different scopes.  dart-lang/dartdoc#2693.
+      // Until then, just pretend we're handling this correctly.
+      [
+        (documentationFrom.first as ModelElement).definingLibrary,
+        (packageGraph.findCanonicalModelElementFor(this) ?? this).library,
+      ];
 }

--- a/lib/src/model/inheritable.dart
+++ b/lib/src/model/inheritable.dart
@@ -70,8 +70,8 @@ mixin Inheritable on ContainerMember {
                 .memberByExample(this)
                 .canonicalEnclosingContainer;
           }
-          var canonicalContainer = packageGraph
-              .findCanonicalModelElementFor(c.element) as Container?;
+          var canonicalContainer =
+              packageGraph.findCanonicalModelElementFor(c) as Container?;
           // TODO(jcollins-g): invert this lookup so traversal is recursive
           // starting from the ModelElement.
           if (canonicalContainer != null) {
@@ -100,7 +100,7 @@ mixin Inheritable on ContainerMember {
       }
     } else if (definingEnclosingContainer is! Extension) {
       // TODO(jcollins-g): factor out extension logic into [Extendable].
-      return packageGraph.findCanonicalModelElementFor(element.enclosingElement)
+      return packageGraph.findCanonicalModelElementFor(enclosingElement)
           as Container?;
     }
     return super.computeCanonicalEnclosingContainer();

--- a/lib/src/model/inheriting_container.dart
+++ b/lib/src/model/inheriting_container.dart
@@ -405,16 +405,26 @@ abstract class InheritingContainer extends Container {
       } else {
         var implementers = packageGraph.implementers[implementer];
         if (implementers != null) {
-          model_utils.findCanonicalFor(implementers).forEach(addToResult);
+          _findCanonicalFor(implementers).forEach(addToResult);
         }
       }
     }
 
     var immediateImplementers = packageGraph.implementers[this];
     if (immediateImplementers != null) {
-      model_utils.findCanonicalFor(immediateImplementers).forEach(addToResult);
+      _findCanonicalFor(immediateImplementers).forEach(addToResult);
     }
     return result.toList(growable: false)..sort(byName);
+  }
+
+  /// Finds canonical classes for all classes in the iterable, if possible.
+  /// If a canonical class can not be found, returns the original class.
+  Iterable<InheritingContainer> _findCanonicalFor(
+      Iterable<InheritingContainer> containers) {
+    return containers.map((container) {
+      var canonical = packageGraph.findCanonicalModelElementFor(container);
+      return canonical as InheritingContainer? ?? container;
+    });
   }
 
   bool get hasPublicInterfaces => publicInterfaces.isNotEmpty;

--- a/lib/src/model_utils.dart
+++ b/lib/src/model_utils.dart
@@ -52,16 +52,6 @@ Iterable<T> filterHasCanonical<T extends ModelElement>(
   return maybeHasCanonicalItems.where((me) => me.canonicalModelElement != null);
 }
 
-/// Finds canonical classes for all classes in the iterable, if possible.
-/// If a canonical class can not be found, returns the original class.
-Iterable<InheritingContainer> findCanonicalFor(
-    Iterable<InheritingContainer> containers) {
-  return containers.map((c) =>
-      c.packageGraph.findCanonicalModelElementFor(c.element)
-          as InheritingContainer? ??
-      c);
-}
-
 extension ElementExtension on Element {
   bool get hasPrivateName {
     final name = this.name;


### PR DESCRIPTION
I was shocked to find that we had two mechanisms for determining an element's "canonical library": `ModelElement.canonicalLibrary` and a `PackageGraph._findCanonicalLibraryFor`. They were not quite the same implementation, but the differences turn out to be uninteresting; the two implementations can be combined. This change removes `PackageGraph._findCanonicalLibraryFor`. This implementation was only used in the package graph to find the canonical element for a given element. That code can now just use `ModelElement.canonicalLibrary`. It requires a fair bit of refactoring all over:

* `PackageGraph.findCanonicalModelElementFor` previously accepted an analyzer Element, instead of a ModelElement, but almost all of the call sites used `foo.element` or some other expression that could easily be replaced with an access to a ModelElement instead of the correlated Element.
* Document `ModelElement.definingLibrary`, `ModelElement.canonicalLibrary`, `ModelElement._searchForCanonicalLibrary`.
* Simplify `ContainerMember.computeCanonicalEnclosingContainer` to stop unnecessarily special-casing extensions and extension types.
* Simplify lookup component of `ModelElement._searchForCanonicalLibrary`.
* Simplity `ContainerMember.referenceGrandparentOverrides` to not use `sync*`.
* Move the top-level `findCanonicalFor` function out of `model_utils.dart` and into `inheriting_container.dart`, the only code that uses it anymore.

- Thanks for your contribution! Please replace this text with a description of what this PR is changing or adding and why, list any relevant issues, and review the contribution guidelines below.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
