### PR TITLE
Revert "Deprecate --resources-dir option. (#3696)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 8.0.10-dev
+
+* Un-deprecate the `--resources-dir` option.
+
 ## 8.0.9
 
 * Deprecate the `missingCodeBlockLanguage` warning. This is replaced with the

--- a/dartdoc_options.yaml
+++ b/dartdoc_options.yaml
@@ -1,4 +1,4 @@
 dartdoc:
   linkToSource:
     root: '.'
-    uriTemplate: 'https://github.com/dart-lang/dartdoc/blob/v8.0.9/%f%#L%l%'
+    uriTemplate: 'https://github.com/dart-lang/dartdoc/blob/v8.0.10-dev/%f%#L%l%'

--- a/lib/src/dartdoc_options.dart
+++ b/lib/src/dartdoc_options.dart
@@ -1669,11 +1669,8 @@ List<DartdocOption> createDartdocOptions(
         help:
             'A list of package names to place first when grouping libraries in '
             'packages. Unmentioned packages are placed after these.'),
-    // Deprecated. Use of this option is reported.
-    // TODO(kallentu): Remove this option.
     DartdocOptionArgOnly<String?>('resourcesDir', null, resourceProvider,
-        help: "(deprecated) An absolute path to dartdoc's resources directory.",
-        hide: true),
+        help: "An absolute path to dartdoc's resources directory.", hide: true),
     DartdocOptionArgOnly<bool>('sdkDocs', false, resourceProvider,
         help: 'Generate ONLY the docs for the Dart SDK.'),
     DartdocOptionArgSynth<String?>('sdkDir',

--- a/lib/src/generator/generator_frontend.dart
+++ b/lib/src/generator/generator_frontend.dart
@@ -27,13 +27,6 @@ class GeneratorFrontEnd implements Generator {
             'longer be supported.',
       );
     }
-    if (_generatorBackend.options.resourcesDir != null) {
-      packageGraph?.defaultPackage.warn(
-        PackageWarning.deprecated,
-        message: "The '--resources-dir' option is deprecated, and will soon be "
-            'removed.',
-      );
-    }
 
     await _generatorBackend.generateAdditionalFiles();
 

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,1 +1,1 @@
-const packageVersion = '8.0.9';
+const packageVersion = '8.0.10-dev';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dartdoc
-version: 8.0.9
+version: 8.0.10-dev
 description: A non-interactive HTML documentation generator for Dart source code.
 repository: https://github.com/dart-lang/dartdoc
 


### PR DESCRIPTION
This reverts commit cec45fbedf85b938670314e5bcdac3fbdde94f99.

Fixes https://github.com/dart-lang/dartdoc/issues/3779

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
