### PR TITLE
Fix referencing an aliased type parameter.

### DIFF
--- a/lib/src/element_type.dart
+++ b/lib/src/element_type.dart
@@ -272,20 +272,28 @@ abstract class DefinedElementType extends ElementType {
 
   factory DefinedElementType._from(DartType type, ModelElement modelElement,
       Library library, PackageGraph packageGraph) {
-    // `TypeAliasElement.alias.element` has different implications.
-    // In that case it is an actual type alias of some kind (generic or
-    // otherwise). Here however `alias.element` signals that this is a type
-    // referring to an alias.
     if (type is! TypeAliasElement && type.alias != null) {
-      return AliasedElementType._(
-          type as ParameterizedType, library, packageGraph, modelElement);
+      // Here, `alias.element` signals that this is a type referring to an
+      // alias. (`TypeAliasElement.alias.element` has different implications.
+      // In that case it is an actual type alias of some kind (generic or
+      // otherwise).)
+      return switch (type) {
+        TypeParameterType() =>
+          TypeParameterElementType._(type, library, packageGraph, modelElement),
+        ParameterizedType() =>
+          AliasedElementType._(type, library, packageGraph, modelElement),
+        _ => throw UnimplementedError(
+            'No ElementType implemented for aliased ${type.runtimeType}'),
+      };
     }
-    if (type is TypeParameterType) {
-      return TypeParameterElementType._(
-          type, library, packageGraph, modelElement);
-    }
-    return ParameterizedElementType._(
-        type as ParameterizedType, library, packageGraph, modelElement);
+    return switch (type) {
+      TypeParameterType() =>
+        TypeParameterElementType._(type, library, packageGraph, modelElement),
+      ParameterizedType() =>
+        ParameterizedElementType._(type, library, packageGraph, modelElement),
+      _ => throw UnimplementedError(
+          'No ElementType implemented for ${type.runtimeType}'),
+    };
   }
 
   @override

--- a/test/typedef_test.dart
+++ b/test/typedef_test.dart
@@ -40,6 +40,21 @@ typedef T = C;
     expect(tTypedef.aliasedType, isA<InterfaceType>());
   }
 
+  void test_extensionType_generic_referenceToTypeParameter() async {
+    var library = await bootPackageWithLibrary('''
+typedef TD<T> = T;
+
+/// Text [T].
+extension type ET<T>(TD<T> _) {}
+''');
+
+    expect(
+      library.extensionTypes.named('ET').documentationAsHtml,
+      // There is no way to link to a type parameter.
+      contains('<p>Text <code>T</code>.</p>'),
+    );
+  }
+
   void test_extensionType_basic() async {
     var library = await bootPackageWithLibrary('''
 extension type E(int i) {}


### PR DESCRIPTION
What is an aliased type parameter? Good question! `typedef TD<T> = T;` is such an alias. The fix is pretty simple, we just weren't previously handling this case, or being safe.

Fixes https://github.com/dart-lang/dartdoc/issues/3783

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
