### PR TITLE
Declare local variables for the 'href' field, to promote and avoid printing 'null'

### DIFF
--- a/lib/src/markdown_processor.dart
+++ b/lib/src/markdown_processor.dart
@@ -314,15 +314,13 @@ class MarkdownDocument extends md.Document {
     var textContent = _htmlEscape.convert(referenceText);
     var linkedElement = result.commentReferable;
     if (linkedElement != null) {
-      if (linkedElement.href != null) {
+      var href = linkedElement.href;
+      if (href != null) {
         var anchor = md.Element.text('a', textContent);
         if (linkedElement is ModelElement && linkedElement.isDeprecated) {
           anchor.attributes['class'] = 'deprecated';
         }
-        var href = linkedElement.href;
-        if (href != null) {
-          anchor.attributes['href'] = href;
-        }
+        anchor.attributes['href'] = href;
         return anchor;
       } else {
         // Otherwise this would be `linkedElement.linkedName`, but link bodies

--- a/lib/src/markdown_processor.dart
+++ b/lib/src/markdown_processor.dart
@@ -314,8 +314,7 @@ class MarkdownDocument extends md.Document {
     var textContent = _htmlEscape.convert(referenceText);
     var linkedElement = result.commentReferable;
     if (linkedElement != null) {
-      var href = linkedElement.href;
-      if (href != null) {
+      if (linkedElement.href case var href?) {
         var anchor = md.Element.text('a', textContent);
         if (linkedElement is ModelElement && linkedElement.isDeprecated) {
           anchor.attributes['class'] = 'deprecated';

--- a/lib/src/model/category.dart
+++ b/lib/src/model/category.dart
@@ -143,6 +143,11 @@ class Category
   String get linkedName {
     final unbrokenName = name.replaceAll(' ', '&nbsp;');
     if (isDocumented) {
+      final href = this.href;
+      if (href == null) {
+        throw StateError("Requesting the 'linkedName' of a non-canonical "
+            "category: '$name'");
+      }
       return '<a href="$href">$unbrokenName</a>';
     } else {
       return unbrokenName;

--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -687,6 +687,7 @@ abstract class ModelElement
         element.kind == ElementKind.NEVER ||
         this is ModelFunction);
 
+    final href = this.href;
     if (href == null) {
       if (isPublicAndPackageDocumented) {
         warn(PackageWarning.noCanonicalFound);


### PR DESCRIPTION
This change would have more teeth to it if we had a lint rule that guarded against interpolating `null` into a string (https://github.com/dart-lang/linter/issues/3149), but I think it still makes the code a teensy bit safer / more readable.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
