### PR TITLE
Pipe the '--stats' flag through for the 'doc sdk' task

### DIFF
--- a/tool/task.dart
+++ b/tool/task.dart
@@ -299,7 +299,7 @@ Future<void> runDoc(ArgResults commandResults) async {
     'flutter' => docFlutter(withStats: stats),
     'help' => _docHelp(),
     'package' => _docPackage(commandResults, withStats: stats),
-    'sdk' => docSdk(),
+    'sdk' => docSdk(withStats: stats),
     'testing-package' => docTestingPackage(),
     _ => throw UnimplementedError('Unknown doc target: "$target"'),
   };
@@ -462,9 +462,10 @@ Future<String> docPackage({
   return path.join(pubPackageDir.absolute.path, 'doc', 'api');
 }
 
-Future<void> docSdk() async => _docSdk(
+Future<void> docSdk({bool withStats = false}) async => _docSdk(
       sdkDocsPath: _sdkDocsDir.path,
       dartdocPath: Directory.current.path,
+      withStats: withStats,
     );
 
 /// Creates a throwaway pub cache and returns the environment variables
@@ -547,6 +548,7 @@ Future<void> compareSdkWarnings() async {
 Future<Iterable<Map<String, Object?>>> _docSdk({
   required String sdkDocsPath,
   required String dartdocPath,
+  bool withStats = false,
 }) async {
   var launcher = SubprocessLauncher('build-sdk-docs');
   await launcher
@@ -570,6 +572,7 @@ Future<Iterable<Map<String, Object?>>> _docSdk({
       'lib/resources/blank.txt',
     ],
     workingDirectory: dartdocPath,
+    withStats: withStats,
   );
 }
 


### PR DESCRIPTION
I think it's just been an oversight that the `--stats` flag didn't do anything for this task.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
