### PR TITLE
Simplify Library.allModelElements

### DIFF
--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -7988,7 +7988,7 @@ class _Renderer_Library extends RendererBase<Library> {
                   renderVariable: (CT_ c, Property<CT_> self,
                           List<String> remainingNames) =>
                       self.renderSimpleVariable(
-                          c, remainingNames, 'Iterable<ModelElement>'),
+                          c, remainingNames, 'List<ModelElement>'),
                   renderIterable: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
                     return c.allModelElements.map((e) => _render_ModelElement(
@@ -8378,19 +8378,6 @@ class _Renderer_Library extends RendererBase<Library> {
                       List<MustachioNode> ast, StringSink sink) {
                     return c.mixins.map((e) =>
                         _render_Mixin(e, ast, r.template, sink, parent: r));
-                  },
-                ),
-                'modelElementsMap': Property(
-                  getValue: (CT_ c) => c.modelElementsMap,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(c, remainingNames,
-                          'HashMap<Element, Set<ModelElement>>'),
-                  isNullValue: (CT_ c) => false,
-                  renderValue: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    renderSimple(c.modelElementsMap, ast, r.template, sink,
-                        parent: r, getters: _invisibleGetters['HashMap']!);
                   },
                 ),
                 'name': Property(
@@ -12486,13 +12473,13 @@ class _Renderer_PackageTemplateData extends RendererBase<PackageTemplateData> {
   }
 }
 
-String renderSearchPage(PackageTemplateData context, Template template) {
+String renderIndex(PackageTemplateData context, Template template) {
   var buffer = StringBuffer();
   _render_PackageTemplateData(context, template.ast, template, buffer);
   return buffer.toString();
 }
 
-String renderIndex(PackageTemplateData context, Template template) {
+String renderSearchPage(PackageTemplateData context, Template template) {
   var buffer = StringBuffer();
   _render_PackageTemplateData(context, template.ast, template, buffer);
   return buffer.toString();
@@ -16162,7 +16149,6 @@ const _invisibleGetters = {
     'setter',
     'writeOnly'
   },
-  'HashMap': {'hashCode', 'runtimeType'},
   'Inheritable': {
     'attributes',
     'canonicalLibrary',
@@ -16317,7 +16303,6 @@ const _invisibleGetters = {
     'allInheritableElements',
     'allLibraries',
     'allLibrariesAdded',
-    'allLocalModelElements',
     'analysisContext',
     'breadcrumbName',
     'config',
@@ -16498,7 +16483,6 @@ const _invisibleGetters = {
     'aliasedType',
     'enclosingElement',
     'hashCode',
-    'isAugmentation',
     'name',
     'runtimeType'
   },

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -544,10 +544,9 @@ class PackageGraph with CommentReferable, Nameable {
   }
 
   /// A lookup index for hrefs to allow warnings to indicate where a broken
-  /// link or orphaned file may have come from.  Not cached because
-  /// [ModelElement]s can be created at any time and we're basing this
-  /// on more than just [allLocalModelElements] to make the error messages
-  /// comprehensive.
+  /// link or orphaned file may have come from.
+  ///
+  /// This is not cached because [ModelElement]s can be created at any time.
   Map<String, Set<ModelElement>> get allHrefs {
     final hrefMap = <String, Set<ModelElement>>{};
     // TODO(jcollins-g ): handle calculating hrefs causing new elements better
@@ -894,11 +893,6 @@ class PackageGraph with CommentReferable, Nameable {
 
     return allElements;
   }
-
-  @visibleForTesting
-  late final List<ModelElement> allLocalModelElements = [
-    for (var library in _localLibraries) ...library.allModelElements
-  ];
 
   /// Glob lookups can be expensive.  Cache per filename.
   final _configSetsNodocFor = HashMap<String, bool>();

--- a/test/end2end/model_special_cases_test.dart
+++ b/test/end2end/model_special_cases_test.dart
@@ -205,7 +205,9 @@ void main() {
       classWithHtml = exLibrary.classes.named('SanitizableHtml');
       blockHtml = classWithHtml.instanceMethods.named('blockHtml');
       inlineHtml = classWithHtml.instanceMethods.named('inlineHtml');
-      for (var modelElement in packageGraph.allLocalModelElements) {
+      for (var modelElement in packageGraph.localPublicLibraries
+          .expand((l) => l.allModelElements)) {
+        // Accessing this getter triggers documentation-processing.
         modelElement.documentation;
       }
     });
@@ -270,7 +272,9 @@ void main() {
           htmlInjection.instanceMethods.named('injectSimpleHtml');
       injectHtmlFromTool =
           htmlInjection.instanceMethods.named('injectHtmlFromTool');
-      for (var modelElement in injectionPackageGraph.allLocalModelElements) {
+      for (var modelElement in injectionPackageGraph.localPublicLibraries
+          .expand((l) => l.allModelElements)) {
+        // Accessing this getter triggers documentation-processing.
         modelElement.documentation;
       }
     });

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -564,7 +564,9 @@ void main() async {
           .named('invokeToolParentDoc');
       invokeToolParentDocOriginal =
           ImplementingClassForTool.instanceMethods.named('invokeToolParentDoc');
-      for (var modelElement in packageGraph.allLocalModelElements) {
+      for (var modelElement in packageGraph.localPublicLibraries
+          .expand((l) => l.allModelElements)) {
+        // Accessing this getter triggers documentation-processing.
         modelElement.documentation;
       }
     });

--- a/test/options_test.dart
+++ b/test/options_test.dart
@@ -5,7 +5,6 @@
 import 'package:args/args.dart';
 import 'package:dartdoc/src/dartdoc_options.dart';
 import 'package:dartdoc/src/failure.dart';
-import 'package:dartdoc/src/model/model.dart';
 import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
 import 'package:test_reflective_loader/test_reflective_loader.dart';
@@ -258,10 +257,8 @@ class Foo {}
       packageMetaProvider,
       packageConfigProvider,
     );
-    final classFoo = packageGraph.allLocalModelElements
-        .where((e) => e.isCanonical)
-        .whereType<Class>()
-        .firstWhere((c) => c.name == 'Foo');
+    final classFoo =
+        packageGraph.localPackages.first.libraries.first.classes.named('Foo');
     expect(classFoo.displayedCategories, isNotEmpty);
   }
 

--- a/test/search_index_test.dart
+++ b/test/search_index_test.dart
@@ -51,16 +51,7 @@ class SearchIndexTest extends DartdocTestBase {
             .where((l) => l.name.startsWith('dart:')),
     ];
     var text = generateSearchIndexJson(
-      [
-        // For each library, gather the elements for the library, it's members,
-        // and the members of its container members.
-        for (var library in libraries) ...[
-          library,
-          ...library.allModelElements,
-          for (var element in library.allModelElements.whereType<Container>())
-            ...element.allModelElements,
-        ],
-      ],
+      libraries.expand((library) => library.allModelElements),
       packageOrder: actAsFlutter ? const ['flutter', 'Dart'] : const [],
       pretty: false,
     );


### PR DESCRIPTION
This was backed by another field called `modelElementsMap`, but that is now an unnecessary complexity; so combine the field and getter into just a field.

Additionally, `PackageGraph.allLocalModelElements` is no longer needed. It was used in tests, but those tests can calculate the list of all model elements for themselves.

Also simplify `buildDocumentationAddition`, and improve doc comments.


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
