### PR TITLE
Simplify some end2end tests into smaller tests

### DIFF
--- a/lib/src/dartdoc_options.dart
+++ b/lib/src/dartdoc_options.dart
@@ -1424,8 +1424,6 @@ class DartdocProgramOptionContext extends DartdocGeneratorOptionContext
 
   /// Whether to generate docs or perform a dry run.
   bool get generateDocs => optionSet['generateDocs'].valueAt(context);
-  bool get help => optionSet['help'].valueAt(context);
-  bool get version => optionSet['version'].valueAt(context);
 }
 
 List<DartdocOption<bool>> createDartdocProgramOptions(
@@ -1472,12 +1470,14 @@ DartdocProgramOptionContext? parseOptions(
     return null;
   }
   if (optionRoot['help'].valueAtCurrent() as bool) {
-    _printHelp(optionRoot.argParser);
+    logInfo('dartdoc version: $dartdocVersion');
+    logInfo('Generate HTML documentation for Dart libraries.\n');
+    logInfo(optionRoot.argParser.usage);
     exitCode = 0;
     return null;
   }
   if (optionRoot['version'].valueAtCurrent() as bool) {
-    _printVersion(optionRoot.argParser);
+    logInfo('dartdoc version: $dartdocVersion');
     exitCode = 0;
     return null;
   }
@@ -1501,21 +1501,10 @@ DartdocProgramOptionContext? parseOptions(
   return config;
 }
 
-/// Print help if we are passed the help option.
-void _printHelp(ArgParser parser) {
-  print('Generate HTML documentation for Dart libraries.\n');
-  print(parser.usage);
-}
-
 /// Print usage information on invalid command lines.
 void _printUsage(ArgParser parser) {
   print('Usage: dartdoc [OPTIONS]\n');
   print(parser.usage);
-}
-
-/// Print version information.
-void _printVersion(ArgParser parser) {
-  print('dartdoc version: $dartdocVersion');
 }
 
 /// Instantiate dartdoc's configuration file and options parser with the

--- a/lib/src/logging.dart
+++ b/lib/src/logging.dart
@@ -39,10 +39,6 @@ void logProgress(String message) {
   _logger.log(_progressLevel, message);
 }
 
-void logPrint(String message) {
-  _logger.log(printLevel, message);
-}
-
 /// Creates a new deterministic progress bar, and displays it (with zero
 /// progress).
 void progressBarStart(int totalTickCount) {

--- a/test/end2end/dartdoc_integration_test.dart
+++ b/test/end2end/dartdoc_integration_test.dart
@@ -8,7 +8,6 @@ library;
 import 'dart:async';
 import 'dart:io';
 
-import 'package:dartdoc/src/package_meta.dart';
 import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
 import 'package:test_process/test_process.dart';
@@ -34,50 +33,6 @@ Future<TestProcess> runDartdoc(
     );
 
 void main() {
-  test('invoking dartdoc on an empty package does not crash', () async {
-    var packagePath = await d.createPackage('empty');
-    var process = await runDartdoc([], workingDirectory: packagePath);
-    await expectLater(
-      process.stderr,
-      emitsThrough(
-          contains('package:test_package has no documentable libraries')),
-    );
-    await process.shouldExit(0);
-  });
-
-  group('invoking dartdoc on a basic package', () {
-    late String packagePath;
-
-    setUp(() async {
-      packagePath = await d.createPackage('test_package', libFiles: [
-        d.file('lib.dart', '/// [dead] reference\nclass C {}'),
-      ]);
-    });
-
-    test('with --help prints command line args', () async {
-      var process = await runDartdoc(
-        ['--help'],
-        workingDirectory: packagePath,
-      );
-      await expectLater(process.stdout,
-          emitsThrough('Generate HTML documentation for Dart libraries.'));
-      await expectLater(process.stdout,
-          emitsThrough(matches('^-h, --help[ ]+Show command help.')));
-      await process.shouldExit(0);
-    });
-
-    test('Validate --version works', () async {
-      var process = await runDartdoc(
-        ['--version'],
-        workingDirectory: packagePath,
-      );
-      var dartdocMeta = pubPackageMetaProvider.fromFilename(_dartdocPath)!;
-      await expectLater(process.stdout,
-          emitsThrough('dartdoc version: ${dartdocMeta.version}'));
-      await process.shouldExit(0);
-    });
-  });
-
   test('with tool errors cause non-zero exit when warnings are off', () async {
     // TODO(srawlins): Remove test_package_tool_error and generate afresh.
     var packagePath = await d.createPackage('test_package');

--- a/test/options_test.dart
+++ b/test/options_test.dart
@@ -5,6 +5,7 @@
 import 'package:args/args.dart';
 import 'package:dartdoc/src/dartdoc_options.dart';
 import 'package:dartdoc/src/failure.dart';
+import 'package:dartdoc/src/logging.dart';
 import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
 import 'package:test_reflective_loader/test_reflective_loader.dart';
@@ -472,6 +473,37 @@ class Foo {}
             'message', startsWith('Missing required template file'))));
   }
 
+  void test_emptyPackage() async {
+    await createPackage();
+    await (await buildDartdoc()).generateDocs();
+
+    expect(outBuffer, isEmpty);
+    expect(
+      errBuffer.toString(),
+      matches('warning: package:test_package has no documentable libraries'),
+    );
+  }
+
+  void test_helpOption_resultsInPrintedHelp() async {
+    startLogging(
+      isJson: false,
+      isQuiet: false,
+      showProgress: false,
+      outSink: outBuffer,
+      errSink: errBuffer,
+    );
+    parseOptions(packageMetaProvider, ['--help']);
+
+    expect(
+      outBuffer.toString().split('\n'),
+      containsAll([
+        'Generate HTML documentation for Dart libraries.',
+        matches('^-h, --help[ ]+Show command help.')
+      ]),
+    );
+    expect(errBuffer.toString(), isEmpty);
+  }
+
   void test_quietOption_resultsInNoProgressOrOtherLogging() async {
     await createPackage(
       libFiles: [
@@ -646,5 +678,18 @@ class Foo {
     final dartdoc = await buildDartdoc(
         additionalArguments: ['--max-total-size', '15000000']);
     await dartdoc.generateDocs();
+  }
+
+  void test_versionOption_resultsInPrintedVersion() async {
+    startLogging(
+      isJson: false,
+      isQuiet: false,
+      showProgress: false,
+      outSink: outBuffer,
+      errSink: errBuffer,
+    );
+    parseOptions(packageMetaProvider, ['--version']);
+
+    expect(outBuffer.toString(), matches(r'dartdoc version: \d+.\d+.\d+'));
   }
 }


### PR DESCRIPTION
Some of these tests, as e2e tests, take 20 seconds per test. Much faster as unit-style tests.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
