### PR TITLE
Hide constructors that cannot be called or referenced by user code

### DIFF
--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -2187,19 +2187,19 @@ class _Renderer_Constructor extends RendererBase<Constructor> {
                       self.renderSimpleVariable(c, remainingNames, 'bool'),
                   getBool: (CT_ c) => c.isConst,
                 ),
-                'isDefaultConstructor': Property(
-                  getValue: (CT_ c) => c.isDefaultConstructor,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(c, remainingNames, 'bool'),
-                  getBool: (CT_ c) => c.isDefaultConstructor,
-                ),
                 'isFactory': Property(
                   getValue: (CT_ c) => c.isFactory,
                   renderVariable: (CT_ c, Property<CT_> self,
                           List<String> remainingNames) =>
                       self.renderSimpleVariable(c, remainingNames, 'bool'),
                   getBool: (CT_ c) => c.isFactory,
+                ),
+                'isPublic': Property(
+                  getValue: (CT_ c) => c.isPublic,
+                  renderVariable: (CT_ c, Property<CT_> self,
+                          List<String> remainingNames) =>
+                      self.renderSimpleVariable(c, remainingNames, 'bool'),
+                  getBool: (CT_ c) => c.isPublic,
                 ),
                 'isUnnamedConstructor': Property(
                   getValue: (CT_ c) => c.isUnnamedConstructor,

--- a/lib/src/model/inheriting_container.dart
+++ b/lib/src/model/inheriting_container.dart
@@ -59,7 +59,7 @@ mixin Constructable implements InheritingContainer {
       yield MapEntry(
           '${constructor.enclosingElement.referenceName}.${constructor.referenceName}',
           constructor);
-      if (constructor.isDefaultConstructor) {
+      if (constructor.isUnnamedConstructor) {
         yield MapEntry('new', constructor);
       }
     }

--- a/test/constructors_test.dart
+++ b/test/constructors_test.dart
@@ -1,0 +1,148 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+import 'package:test_reflective_loader/test_reflective_loader.dart';
+
+import 'dartdoc_test_base.dart';
+import 'src/utils.dart';
+
+void main() {
+  defineReflectiveSuite(() {
+    defineReflectiveTests(ConstructorsTest);
+  });
+}
+
+@reflectiveTest
+class ConstructorsTest extends DartdocTestBase {
+  @override
+  final libraryName = 'constructors';
+
+  void test_classIsAbstractFinal_factory() async {
+    var library = await bootPackageWithLibrary('''
+abstract final class C {
+  /// Constructor.
+  factory C() => throw 'Nope';
+}
+''');
+    var c = library.classes.named('C').constructors.first;
+    expect(c.name, equals('C'));
+    expect(c.isPublic, isTrue);
+    expect(c.documentationAsHtml, '<p>Constructor.</p>');
+  }
+
+  void test_classIsAbstractFinal_unnamed() async {
+    var library = await bootPackageWithLibrary('''
+abstract final class C {
+  /// Constructor.
+  C();
+}
+''');
+    var c = library.classes.named('C').constructors.first;
+    expect(c.name, equals('C'));
+    expect(c.isPublic, isFalse);
+    expect(c.documentationAsHtml, '<p>Constructor.</p>');
+  }
+
+  void test_classIsAbstractInterface_unnamed() async {
+    var library = await bootPackageWithLibrary('''
+abstract interface class C {
+  /// Constructor.
+  C();
+}
+''');
+    var c = library.classes.named('C').constructors.first;
+    expect(c.name, equals('C'));
+    expect(c.isPublic, isFalse);
+    expect(c.documentationAsHtml, '<p>Constructor.</p>');
+  }
+
+  void test_classIsPrivate_named() async {
+    var library = await bootPackageWithLibrary('''
+class C {
+  /// Constructor.
+  C._();
+}
+''');
+    var c = library.classes.named('C').constructors.first;
+    expect(c.name, equals('C._'));
+    expect(c.isPublic, isFalse);
+    expect(c.documentationAsHtml, '<p>Constructor.</p>');
+  }
+
+  void test_classIsPrivate_unnamed() async {
+    var library = await bootPackageWithLibrary('''
+class _C {
+  /// Constructor.
+  _C();
+}
+''');
+    var c = library.classes.named('_C').constructors.first;
+    expect(c.name, equals('_C'));
+    expect(c.isPublic, isFalse);
+    expect(c.documentationAsHtml, '<p>Constructor.</p>');
+  }
+
+  void test_classIsPublic_default() async {
+    var library = await bootPackageWithLibrary('''
+class C {}
+''');
+    var c = library.classes.named('C').constructors.first;
+    expect(c.name, equals('C'));
+    expect(c.isPublic, isTrue);
+    expect(c.documentationAsHtml, '');
+  }
+
+  void test_classIsPublic_named() async {
+    var library = await bootPackageWithLibrary('''
+class C {
+  /// Constructor.
+  C.named();
+}
+''');
+    var c = library.classes.named('C').constructors.first;
+    expect(c.name, equals('C.named'));
+    expect(c.isPublic, isTrue);
+    expect(c.documentationAsHtml, '<p>Constructor.</p>');
+  }
+
+  void test_classIsPublic_unnamed() async {
+    var library = await bootPackageWithLibrary('''
+class C {
+  /// Constructor.
+  C();
+}
+''');
+    var c = library.classes.named('C').constructors.first;
+    expect(c.name, equals('C'));
+    expect(c.isPublic, isTrue);
+    expect(c.documentationAsHtml, '<p>Constructor.</p>');
+  }
+
+  void test_classIsPublic_unnamed_explicitNew() async {
+    var library = await bootPackageWithLibrary('''
+class C {
+  /// Constructor.
+  C.new();
+}
+''');
+    var c = library.classes.named('C').constructors.first;
+    expect(c.name, equals('C'));
+    expect(c.isPublic, isTrue);
+    expect(c.documentationAsHtml, '<p>Constructor.</p>');
+  }
+
+  void test_classIsSealed_unnamed() async {
+    var library = await bootPackageWithLibrary('''
+sealed class C {
+  /// Constructor.
+  C();
+}
+''');
+    var c = library.classes.named('C').constructors.first;
+    expect(c.name, equals('C'));
+    expect(c.isPublic, isFalse);
+    expect(c.documentationAsHtml, '<p>Constructor.</p>');
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/dart-lang/dartdoc/issues/3733 as specified in https://github.com/dart-lang/dartdoc/issues/3733#issuecomment-2187146671.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
