### PR TITLE
Store comment reference data on ModelNode

### DIFF
--- a/test/dartdoc_test_base.dart
+++ b/test/dartdoc_test_base.dart
@@ -154,4 +154,11 @@ $libraryContent
     );
     return await Dartdoc.fromContext(context, packageBuilder);
   }
+
+  /// The real offset in a library generated with [bootPackageWithLibrary].
+  ///
+  /// When a library is written via [bootPackageWithLibrary], the test author
+  /// provides `libraryContent`, which is a snippet of Dart library text.
+  int realOffsetFor(int offsetInContent) =>
+      '\n\nlibrary $libraryName\n\n'.length + offsetInContent;
 }

--- a/test/model_node_test.dart
+++ b/test/model_node_test.dart
@@ -2,61 +2,190 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:dartdoc/src/model/model_node.dart' show SourceStringExtensions;
+import 'package:dartdoc/src/model/model_node.dart';
 import 'package:test/test.dart';
+import 'package:test_reflective_loader/test_reflective_loader.dart';
+
+import 'dartdoc_test_base.dart';
+import 'src/utils.dart';
 
 void main() {
-  group('model_utils stripIndentFromSource', () {
-    test('no indent', () {
-      expect(
-        'void foo() {\n  print(1);\n}\n'.stripIndent,
-        'void foo() {\n  print(1);\n}\n',
-      );
-    });
-
-    test('same indent', () {
-      expect(
-        '  void foo() {\n    print(1);\n  }\n'.stripIndent,
-        'void foo() {\n  print(1);\n}\n',
-      );
-    });
-
-    test('odd indent', () {
-      expect(
-        '   void foo() {\n     print(1);\n   }\n'.stripIndent,
-        'void foo() {\n  print(1);\n}\n',
-      );
-    });
+  defineReflectiveSuite(() {
+    defineReflectiveTests(ModelNodeTest);
   });
+}
 
-  group('model_utils stripDartdocCommentsFromSource', () {
-    test('no comments', () {
-      expect(
-        'void foo() {\n  print(1);\n}\n'.stripDocComments,
-        'void foo() {\n  print(1);\n}\n',
-      );
-    });
+@reflectiveTest
+class ModelNodeTest extends DartdocTestBase {
+  @override
+  final libraryName = 'model_node';
 
-    test('line comments', () {
-      expect(
-        '/// foo comment\nvoid foo() {\n  print(1);\n}\n'.stripDocComments,
-        'void foo() {\n  print(1);\n}\n',
-      );
-    });
+  void test_onClass_refersToDartCoreImportedElement() async {
+    var library = await bootPackageWithLibrary('''
+/// Refers to [int].
+class C {}
+''');
+    var c = library.classes.named('C');
+    expect(c.name, equals('C'));
+    var commentReferenceData = c.modelNode!.commentReferenceData!;
+    expect(
+      commentReferenceData['int'],
+      isA<CommentReferenceData>()
+          .having((e) => e.name, 'name', 'int')
+          .having((e) => e.offset, 'offset', realOffsetFor(15))
+          .having((e) => e.length, 'length', 3),
+    );
+  }
 
-    test('block comments 1', () {
-      expect(
-        '/** foo comment */\nvoid foo() {\n  print(1);\n}\n'.stripDocComments,
-        'void foo() {\n  print(1);\n}\n',
-      );
-    });
+  void test_onClass_refersToDocImportedElement() async {
+    var library = await bootPackageWithLibrary('''
+/// @docImport 'dart:async';
+library;
 
-    test('block comments 2', () {
-      expect(
-        '/**\n * foo comment\n */\nvoid foo() {\n  print(1);\n}\n'
-            .stripDocComments,
-        'void foo() {\n  print(1);\n}\n',
-      );
-    });
-  });
+/// Refers to [FutureOr].
+class C {}
+''');
+    var c = library.classes.named('C');
+    expect(c.name, equals('C'));
+    var commentReferenceData = c.modelNode!.commentReferenceData!;
+    expect(
+      commentReferenceData['FutureOr'],
+      isA<CommentReferenceData>()
+          .having((e) => e.name, 'name', 'FutureOr')
+          .having((e) => e.offset, 'offset', realOffsetFor(54))
+          .having((e) => e.length, 'length', 8),
+    );
+  }
+
+  void test_onClass_refersToImportedElement_propertyAccess() async {
+    var library = await bootPackageWithLibrary('''
+import 'dart:async' as async;
+/// Refers to [async.Future.value].
+class C {}
+''');
+    var c = library.classes.named('C');
+    expect(c.name, equals('C'));
+    var commentReferenceData = c.modelNode!.commentReferenceData!;
+    expect(
+      commentReferenceData['async.Future.value'],
+      isA<CommentReferenceData>()
+          .having((e) => e.name, 'name', 'async.Future.value')
+          .having((e) => e.offset, 'offset', realOffsetFor(45))
+          .having((e) => e.length, 'length', 18),
+    );
+  }
+
+  void test_onClass_refersToImportedElement_prefixedIdentifier() async {
+    var library = await bootPackageWithLibrary('''
+/// Refers to [Future.value].
+class C {}
+''');
+    var c = library.classes.named('C');
+    expect(c.name, equals('C'));
+    var commentReferenceData = c.modelNode!.commentReferenceData!;
+    expect(
+      commentReferenceData['Future.value'],
+      isA<CommentReferenceData>()
+          .having((e) => e.name, 'name', 'Future.value')
+          .having((e) => e.offset, 'offset', realOffsetFor(15))
+          .having((e) => e.length, 'length', 12),
+    );
+  }
+
+  void test_onInstanceGetter_refersToDartCoreImportedElement() async {
+    var library = await bootPackageWithLibrary('''
+class C {
+  /// Refers to [int].
+  int get g => 1;
+}
+''');
+    var g = library.classes.named('C').instanceAccessors.named('g');
+    expect(g.name, equals('g'));
+    var commentReferenceData = g.modelNode!.commentReferenceData!;
+    expect(
+      commentReferenceData['int'],
+      isA<CommentReferenceData>()
+          .having((e) => e.name, 'name', 'int')
+          .having((e) => e.offset, 'offset', realOffsetFor(27))
+          .having((e) => e.length, 'length', 3),
+    );
+  }
+
+  void test_onVariableDeclarationList() async {
+    var library = await bootPackageWithLibrary('''
+/// Refers to [int].
+int a = 1, b = 2;
+''');
+    var a = library.properties.named('a');
+    expect(a.name, equals('a'));
+    var aData = a.modelNode!.commentReferenceData!;
+    expect(
+      aData['int'],
+      isA<CommentReferenceData>()
+          .having((e) => e.name, 'name', 'int')
+          .having((e) => e.offset, 'offset', realOffsetFor(15))
+          .having((e) => e.length, 'length', 3),
+    );
+
+    var b = library.properties.named('b');
+    expect(b.name, equals('b'));
+    var bData = b.modelNode!.commentReferenceData!;
+    expect(
+      bData['int'],
+      isA<CommentReferenceData>()
+          .having((e) => e.name, 'name', 'int')
+          .having((e) => e.offset, 'offset', realOffsetFor(15))
+          .having((e) => e.length, 'length', 3),
+    );
+  }
+
+  void test_stripIndent_noIndent() {
+    expect(
+      'void foo() {\n  print(1);\n}\n'.stripIndent,
+      'void foo() {\n  print(1);\n}\n',
+    );
+  }
+
+  void test_stripIndent_sameIndent() {
+    expect(
+      '  void foo() {\n    print(1);\n  }\n'.stripIndent,
+      'void foo() {\n  print(1);\n}\n',
+    );
+  }
+
+  void test_stripIndent_oddIndent() {
+    expect(
+      '   void foo() {\n     print(1);\n   }\n'.stripIndent,
+      'void foo() {\n  print(1);\n}\n',
+    );
+  }
+
+  void test_stripDocComments_noComments() {
+    expect(
+      'void foo() {\n  print(1);\n}\n'.stripDocComments,
+      'void foo() {\n  print(1);\n}\n',
+    );
+  }
+
+  void test_stripDocComments_lineComments() {
+    expect(
+      '/// foo comment\nvoid foo() {\n  print(1);\n}\n'.stripDocComments,
+      'void foo() {\n  print(1);\n}\n',
+    );
+  }
+
+  void test_stripDocComments_blockComments1() {
+    expect(
+      '/** foo comment */\nvoid foo() {\n  print(1);\n}\n'.stripDocComments,
+      'void foo() {\n  print(1);\n}\n',
+    );
+  }
+
+  void test_stripDocComments_blockComments2() {
+    expect(
+      '/**\n * foo comment\n */\nvoid foo() {\n  print(1);\n}\n'
+          .stripDocComments,
+      'void foo() {\n  print(1);\n}\n',
+    );
+  }
 }


### PR DESCRIPTION
This is work towards https://github.com/dart-lang/dartdoc/issues/3798.

The analyzer is now tagging Comment nodes with `references` with various static elements, all backed by the new `@docImport` syntax, via a new DocImportScope (see https://dart-review.googlesource.com/c/sdk/+/345361 and https://dart-review.googlesource.com/c/sdk/+/353232). But they're not available in the element model. So while we have the syntax nodes, in PackageGraph, we must "side-car" the data, by storing it in separate classes (with no references to any AST nodes).

So in this change we introduce the CommentReferenceData class, attach instances to ModelNode.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
