### PR TITLE
Cherry-pick #3784 into an 8.0.9+1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 8.0.9+1
+
+* Fix referencing an aliased type parameter. (#3784)
+
 ## 8.0.9
 
 * Deprecate the `missingCodeBlockLanguage` warning. This is replaced with the

--- a/dartdoc_options.yaml
+++ b/dartdoc_options.yaml
@@ -1,4 +1,4 @@
 dartdoc:
   linkToSource:
     root: '.'
-    uriTemplate: 'https://github.com/dart-lang/dartdoc/blob/v8.0.9/%f%#L%l%'
+    uriTemplate: 'https://github.com/dart-lang/dartdoc/blob/v8.0.9+1/%f%#L%l%'

--- a/lib/src/element_type.dart
+++ b/lib/src/element_type.dart
@@ -272,20 +272,28 @@ abstract class DefinedElementType extends ElementType {
 
   factory DefinedElementType._from(DartType type, ModelElement modelElement,
       Library library, PackageGraph packageGraph) {
-    // `TypeAliasElement.alias.element` has different implications.
-    // In that case it is an actual type alias of some kind (generic or
-    // otherwise). Here however `alias.element` signals that this is a type
-    // referring to an alias.
     if (type is! TypeAliasElement && type.alias != null) {
-      return AliasedElementType._(
-          type as ParameterizedType, library, packageGraph, modelElement);
+      // Here, `alias.element` signals that this is a type referring to an
+      // alias. (`TypeAliasElement.alias.element` has different implications.
+      // In that case it is an actual type alias of some kind (generic or
+      // otherwise).)
+      return switch (type) {
+        TypeParameterType() =>
+          TypeParameterElementType._(type, library, packageGraph, modelElement),
+        ParameterizedType() =>
+          AliasedElementType._(type, library, packageGraph, modelElement),
+        _ => throw UnimplementedError(
+            'No ElementType implemented for aliased ${type.runtimeType}'),
+      };
     }
-    if (type is TypeParameterType) {
-      return TypeParameterElementType._(
-          type, library, packageGraph, modelElement);
-    }
-    return ParameterizedElementType._(
-        type as ParameterizedType, library, packageGraph, modelElement);
+    return switch (type) {
+      TypeParameterType() =>
+        TypeParameterElementType._(type, library, packageGraph, modelElement),
+      ParameterizedType() =>
+        ParameterizedElementType._(type, library, packageGraph, modelElement),
+      _ => throw UnimplementedError(
+          'No ElementType implemented for ${type.runtimeType}'),
+    };
   }
 
   @override

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,1 +1,1 @@
-const packageVersion = '8.0.9';
+const packageVersion = '8.0.9+1';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dartdoc
-version: 8.0.9
+version: 8.0.9+1
 description: A non-interactive HTML documentation generator for Dart source code.
 repository: https://github.com/dart-lang/dartdoc
 

--- a/test/typedef_test.dart
+++ b/test/typedef_test.dart
@@ -40,6 +40,21 @@ typedef T = C;
     expect(tTypedef.aliasedType, isA<InterfaceType>());
   }
 
+  void test_extensionType_generic_referenceToTypeParameter() async {
+    var library = await bootPackageWithLibrary('''
+typedef TD<T> = T;
+
+/// Text [T].
+extension type ET<T>(TD<T> _) {}
+''');
+
+    expect(
+      library.extensionTypes.named('ET').documentationAsHtml,
+      // There is no way to link to a type parameter.
+      contains('<p>Text <code>T</code>.</p>'),
+    );
+  }
+
   void test_extensionType_basic() async {
     var library = await bootPackageWithLibrary('''
 extension type E(int i) {}


### PR DESCRIPTION
The flutter roller is blocked and needs the fix in #3784 (https://github.com/dart-lang/dartdoc/commit/14d33d3a120ad3ce621bbcf0a545dc3adeccd7e7) released. Rather than cut a release with unrelated changes (with potential bugs), I'm cutting a cherry-pick release. This avoids ~10 commits between 8.0.9 and https://github.com/dart-lang/dartdoc/commit/14d33d3a120ad3ce621bbcf0a545dc3adeccd7e7, and ~14 commits that have landed since the fix.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
