### PR TITLE
Start using docImport resolution when resolving references

### DIFF
--- a/lib/src/model/extension.dart
+++ b/lib/src/model/extension.dart
@@ -75,7 +75,7 @@ class Extension extends Container {
       setter = ContainerAccessor(fieldSetter, library, packageGraph);
     }
     return getModelForPropertyInducingElement(field, library,
-        getter: getter, setter: setter) as Field;
+        getter: getter, setter: setter, enclosingContainer: this) as Field;
   }).toList(growable: false);
 
   @override

--- a/lib/src/model/inheriting_container.dart
+++ b/lib/src/model/inheriting_container.dart
@@ -566,7 +566,7 @@ abstract class InheritingContainer extends Container {
         (setter == null || setter.isInherited)) {
       // Field is 100% inherited.
       return getModelForPropertyInducingElement(field, library,
-          enclosingContainer: this, getter: getter, setter: setter) as Field;
+          getter: getter, setter: setter, enclosingContainer: this) as Field;
     } else {
       // Field is <100% inherited (could be half-inherited).
       // TODO(jcollins-g): Navigation is probably still confusing for

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -2317,8 +2317,7 @@ void main() async {
       late final Class TypeParameterThings,
           TypeParameterThingsExtended,
           TypeParameterThingsExtendedQ;
-      late final Extension UnboundTypeTargetExtension;
-      late final Field aName, aThing, doesNotCrash;
+      late final Field aName, aThing;
       late final TypeParameter ATypeParam,
           BTypeParam,
           CTypeParam,
@@ -2329,11 +2328,6 @@ void main() async {
       late final ModelFunction aTopLevelTypeParameterFunction;
 
       setUpAll(() {
-        UnboundTypeTargetExtension =
-            fakeLibrary.extensions.named('UnboundTypeTargetExtension');
-        doesNotCrash =
-            UnboundTypeTargetExtension.instanceFields.named('doesNotCrash');
-
         aTopLevelTypeParameterFunction =
             fakeLibrary.functions.named('aTopLevelTypeParameterFunction');
         // TODO(jcollins-g): dart-lang/dartdoc#2704, HTML and type parameters
@@ -2366,11 +2360,6 @@ void main() async {
         aMethodExtendedQ =
             TypeParameterThingsExtendedQ.instanceMethods.named('aMethod');
         QTypeParam = aMethodExtendedQ.typeParameters.named('QTypeParam');
-      });
-
-      test('on extension targeting an unbound type', () {
-        expect(referenceLookup(UnboundTypeTargetExtension, 'doesNotCrash'),
-            equals(MatchingLinkResult(doesNotCrash)));
       });
 
       test('on inherited documentation', () {

--- a/test/extensions_test.dart
+++ b/test/extensions_test.dart
@@ -53,6 +53,38 @@ var f() {}
     );
   }
 
+  void test_referenceToExtensionGetter() async {
+    var library = await bootPackageWithLibrary('''
+extension Ex on int {
+  bool get b => true;
+}
+
+/// Text [Ex.b].
+var f() {}
+''');
+
+    expect(
+      library.functions.named('f').documentationAsHtml,
+      contains('<a href="$linkPrefix/Ex/b.html">Ex.b</a>'),
+    );
+  }
+
+  void test_referenceToExtensionSetter() async {
+    var library = await bootPackageWithLibrary('''
+extension Ex on int {
+  set b(int value) {}
+}
+
+/// Text [Ex.b].
+var f() {}
+''');
+
+    expect(
+      library.functions.named('f').documentationAsHtml,
+      contains('<a href="$linkPrefix/Ex/b.html">Ex.b</a>'),
+    );
+  }
+
   // TODO(srawlins): Test everything else about extensions.
 }
 

--- a/testing/test_package/lib/fake.dart
+++ b/testing/test_package/lib/fake.dart
@@ -1076,12 +1076,6 @@ extension Leg on Megatron<String> {
   bool get hasRightLeg => true;
 }
 
-/// Refer to [doesNotCrash] here.
-extension UnboundTypeTargetExtension<T> on T {
-  /// We hope so!
-  bool get doesNotCrash => true;
-}
-
 class Megatron<T> {}
 
 class SuperMegaTron<T extends String> extends Megatron<String> {}


### PR DESCRIPTION
Currently dartdoc uses a two-step strategy to resolve doc comment references:

First, for each reference in square brackets, dartdoc asks analyzer's `Scope.lookup` API for what a reference should resolve to. (Note: that API does not support resolution that includes the "doc import" scope which is introduced by `@docImport`.) Second, if `Scope.lookup` could not resolve the reference, dartdoc uses it's own lookup system which searches outward for identifiers (the "universal scope" system).

In this change, we introduce a third step: between the existing two steps, we check the `ModelNode.commentData` references. These references _do_ take the "doc import" scope into account. So here is the new process:

1. Check analyzer's `Scope.lookup` API. If that returns `null`,
2. Check analyzer's earlier resolution, which includes the "doc import" scope. If that returns `null`,
3. Resolve the reference with the "universal scope" system.

This should _not_ change any existing successful resolutions into _different_, _unintended_ resolutions. Introducing the second step should _only_ start resolving references that can be resolved specifically because of an introduced `@docImport`.

The only secondary change here which is needed to facilitate the `@docImport` change is to declare that extension members are "contained" by their enclosing extension. I don't know why this wasn't the case before. It doesn't seem intentional, as the tests continue to pass. I think it was an oversight, or a misunderstanding of extension members.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
