### PR TITLE
Avoid Lists of MapEntries.

### DIFF
--- a/lib/src/model/comment_referable.dart
+++ b/lib/src/model/comment_referable.dart
@@ -228,25 +228,14 @@ extension CommentReferableEntryGenerators on Iterable<CommentReferable> {
             r.referenceName: r,
       };
 
-  /// Generates entries from this Iterable.
-  Iterable<MapEntry<String, CommentReferable>> generateEntries() =>
-      map((r) => MapEntry(r.referenceName, r));
+  /// A mapping from each [CommentReferable]'s name to itself.
+  Map<String, CommentReferable> get asMapByName => {
+        for (var r in this) r.referenceName: r,
+      };
 
   /// Returns all values not of this type.
   List<CommentReferable> whereNotType<T>() => [
         for (var referable in this)
           if (referable is! T) referable,
       ];
-}
-
-/// A set of utility methods to add entries to
-/// [CommentReferable.referenceChildren].
-extension CommentReferableEntryBuilder on Map<String, CommentReferable> {
-  /// Like [Map.putIfAbsent] except works on an iterable of entries.
-  void addEntriesIfAbsent(
-      Iterable<MapEntry<String, CommentReferable>> entries) {
-    for (var entry in entries) {
-      if (!containsKey(entry.key)) this[entry.key] = entry.value;
-    }
-  }
 }

--- a/lib/src/model/container.dart
+++ b/lib/src/model/container.dart
@@ -221,33 +221,23 @@ abstract class Container extends ModelElement
   /// For subclasses to add items after the main pass but before the
   /// parameter-global.
   @visibleForOverriding
-  Iterable<MapEntry<String, CommentReferable>> get extraReferenceChildren;
+  Map<String, CommentReferable> get extraReferenceChildren;
 
   @override
   @mustCallSuper
-  late final Map<String, CommentReferable> referenceChildren = () {
-    var referenceChildren = <String, CommentReferable>{
-      for (var element in allModelElements
-          .whereNotType<Accessor>()
-          .whereNotType<Constructor>())
-        element.referenceName: element,
-    };
-
-    referenceChildren.addEntriesIfAbsent(extraReferenceChildren);
-    // Process unscoped parameters last to make sure they don't override
-    // other options.
-    for (var modelElement in allModelElements) {
+  late final Map<String, CommentReferable> referenceChildren = {
+    for (var modelElement in allModelElements)
       // Don't complain about references to parameter names, but prefer
       // referring to anything else.
       // TODO(jcollins-g): Figure out something good to do in the ecosystem
       // here to wean people off the habit of unscoped parameter references.
-      if (modelElement.hasParameters) {
-        referenceChildren
-            .addEntriesIfAbsent(modelElement.parameters.generateEntries());
-      }
-    }
-    return referenceChildren;
-  }();
+      if (modelElement.hasParameters) ...modelElement.parameters.asMapByName,
+    ...extraReferenceChildren,
+    for (var element in allModelElements
+        .whereNotType<Accessor>()
+        .whereNotType<Constructor>())
+      element.referenceName: element,
+  };
 
   @override
   Iterable<CommentReferable> get referenceParents => [definingLibrary, library];

--- a/lib/src/model/extension.dart
+++ b/lib/src/model/extension.dart
@@ -107,8 +107,7 @@ class Extension extends Container {
 
   @override
   @visibleForOverriding
-  Iterable<MapEntry<String, CommentReferable>> get extraReferenceChildren =>
-      const [];
+  Map<String, CommentReferable> get extraReferenceChildren => const {};
 
   @override
   String get relationshipsClass => 'clazz-relationships';

--- a/lib/src/model/extension_type.dart
+++ b/lib/src/model/extension_type.dart
@@ -84,8 +84,7 @@ class ExtensionType extends InheritingContainer with Constructable {
 
   @override
   @visibleForOverriding
-  Iterable<MapEntry<String, CommentReferable>> get extraReferenceChildren =>
-      const [];
+  Map<String, CommentReferable> get extraReferenceChildren => const {};
 
   @override
   String get relationshipsClass => 'clazz-relationships';

--- a/lib/src/model/library.dart
+++ b/lib/src/model/library.dart
@@ -386,8 +386,8 @@ class Library extends ModelElement
     var referenceChildrenBuilder = <String, CommentReferable>{};
     var definedNamesModelElements =
         element.exportNamespace.definedNames.values.map(getModelForElement);
-    referenceChildrenBuilder.addEntries(
-        definedNamesModelElements.whereNotType<Accessor>().generateEntries());
+    referenceChildrenBuilder
+        .addAll(definedNamesModelElements.whereNotType<Accessor>().asMapByName);
     // TODO(jcollins-g): warn and get rid of this case where it shows up.
     // If a user is hiding parts of a prefix import, the user should not
     // refer to hidden members via the prefix, because that can be

--- a/lib/src/model/mixin.dart
+++ b/lib/src/model/mixin.dart
@@ -46,8 +46,7 @@ class Mixin extends InheritingContainer {
 
   @override
   @visibleForOverriding
-  Iterable<MapEntry<String, CommentReferable>> get extraReferenceChildren =>
-      const [];
+  Map<String, CommentReferable> get extraReferenceChildren => const {};
 
   @override
   bool get hasModifiers => super.hasModifiers || hasPublicSuperclassConstraints;

--- a/lib/src/model/package.dart
+++ b/lib/src/model/package.dart
@@ -376,14 +376,15 @@ class Package extends LibraryContainer
 
   @override
   late final Map<String, CommentReferable> referenceChildren = {
-    for (var library in publicLibrariesSorted) library.referenceName: library,
-  }
-    // Do not override any preexisting data, and insert based on the
-    // public library sort order.
-    // TODO(jcollins-g): warn when results require package-global
-    // lookups like this.
-    ..addEntriesIfAbsent(
-        publicLibrariesSorted.expand((l) => l.referenceChildren.entries));
+    // Do not override any preexisting data, and insert based on the public
+    // library sort order.
+    // TODO(jcollins-g): warn when results require package-global lookups like
+    // this.
+    for (var library in publicLibrariesSorted) ...{
+      library.referenceName: library,
+      ...library.referenceChildren,
+    }
+  };
 
   @override
   Iterable<CommentReferable> get referenceParents => [packageGraph];

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -990,43 +990,42 @@ class PackageGraph with CommentReferable, Nameable {
 
   @override
   late final Map<String, CommentReferable> referenceChildren = () {
-    var children = <String, CommentReferable>{};
-    // We have to use a stable order or otherwise references depending
-    // on ambiguous resolution (see below) will change where they
-    // resolve based on internal implementation details.
+    // We have to use a stable order or otherwise references depending on
+    // ambiguous resolution (see below) will change where they resolve based on
+    // internal implementation details.
     var sortedPackages = packages.toList(growable: false)..sort(byName);
     var sortedDocumentedPackages = _documentedPackages.toList(growable: false)
       ..sort(byName);
-    // Packages are the top priority.
-    children.addEntries(sortedPackages.generateEntries());
+    return {
+      // TODO(jcollins-g): Warn about directly referencing top level items out
+      // of scope?  Doing this will be even more ambiguous and potentially
+      // confusing than doing so with libraries.
+      ...sortedDocumentedPackages
+          .expand((p) => p.publicLibrariesSorted)
+          .expand((l) => [
+                ...l.constants.wherePublic,
+                ...l.functions.wherePublic,
+                ...l.properties.wherePublic,
+                ...l.typedefs.wherePublic,
+                ...l.extensions.wherePublic,
+                ...l.extensionTypes.wherePublic,
+                ...l.classes.wherePublic,
+                ...l.enums.wherePublic,
+                ...l.mixins.wherePublic,
+              ])
+          .asMapByName,
 
-    // Libraries are next.
-    // TODO(jcollins-g): Warn about directly referencing libraries out of
-    // scope?  Doing this is always going to be ambiguous and potentially
-    // confusing.
-    children.addEntriesIfAbsent(sortedDocumentedPackages
-        .expand((p) => p.publicLibrariesSorted)
-        .generateEntries());
+      // Libraries are next.
+      // TODO(jcollins-g): Warn about directly referencing libraries out of
+      // scope?  Doing this is always going to be ambiguous and potentially
+      // confusing.
+      ...sortedDocumentedPackages
+          .expand((p) => p.publicLibrariesSorted)
+          .asMapByName,
 
-    // TODO(jcollins-g): Warn about directly referencing top level items
-    // out of scope?  Doing this will be even more ambiguous and
-    // potentially confusing than doing so with libraries.
-    children.addEntriesIfAbsent(sortedDocumentedPackages
-        .expand((p) => p.publicLibrariesSorted)
-        .expand((l) => [
-              ...l.constants.wherePublic,
-              ...l.functions.wherePublic,
-              ...l.properties.wherePublic,
-              ...l.typedefs.wherePublic,
-              ...l.extensions.wherePublic,
-              ...l.extensionTypes.wherePublic,
-              ...l.classes.wherePublic,
-              ...l.enums.wherePublic,
-              ...l.mixins.wherePublic,
-            ])
-        .generateEntries());
-
-    return children;
+      // Packages are the top priority.
+      ...sortedPackages.asMapByName,
+    };
   }();
 
   @override

--- a/test/src/utils.dart
+++ b/test/src/utils.dart
@@ -301,20 +301,20 @@ Future<void> writeDartdocResources(ResourceProvider resourceProvider) async {
   }
 }
 
-/// For comparison purposes, return an equivalent [MatchingLinkResult]
-/// for the defining element returned.  May return [originalResult].
-/// We do this to eliminate canonicalization effects from comparison,
-/// as the original lookup code returns canonicalized results and the
-/// new lookup code is only guaranteed to return equivalent results.
+/// For comparison purposes, return an equivalent [MatchingLinkResult] for the
+/// defining element returned. May return [originalResult]. We do this to
+/// eliminate canonicalization effects from comparison, as the original lookup
+/// code returns canonicalized results and the new lookup code is only
+/// guaranteed to return equivalent results.
 MatchingLinkResult definingLinkResult(MatchingLinkResult originalResult) {
-  var definingReferable =
-      originalResult.commentReferable?.definingCommentReferable;
-
-  if (definingReferable != null &&
-      definingReferable != originalResult.commentReferable) {
-    return MatchingLinkResult(definingReferable);
+  var commentReferable = originalResult.commentReferable;
+  if (commentReferable == null) {
+    return originalResult;
   }
-  return originalResult;
+  var definingReferable = commentReferable.definingCommentReferable;
+  return definingReferable == originalResult.commentReferable
+      ? originalResult
+      : MatchingLinkResult(definingReferable);
 }
 
 MatchingLinkResult referenceLookup(Warnable element, String codeRef) =>


### PR DESCRIPTION
In the existing code, a few APIs like `CommentReferableEntryGenerators.generateEntries` and `Container.extraReferenceChildren` used `List<MapEntry<...>>` which I've found super confusing.

They are pretty hard to reason about, and also some "put all if absent" code was employed to wrangle them. But it turns out that given Map `a` and Map `b`, `a.putAllIfAbsent(b)` is the same as `b.addAll(a)`. So this code can be simplified all around by just using Maps as they are meant to be used.

This code is a no-op; same results, just simpler.


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
