### PR TITLE
Fix issue with extension members and unfound doc comment references

### DIFF
--- a/lib/src/model/comment_referable.dart
+++ b/lib/src/model/comment_referable.dart
@@ -104,10 +104,12 @@ mixin CommentReferable implements Nameable {
       if (resultElement == null) return null;
     }
 
-    if (this case ModelElement(:var modelNode?) when resultElement == null) {
-      var references = modelNode.commentData?.references;
-      if (references != null) {
-        resultElement = references[referenceLookup.lookup]?.element;
+    if (resultElement == null) {
+      if (this case ModelElement(:var modelNode?)) {
+        var references = modelNode.commentData?.references;
+        if (references != null) {
+          resultElement = references[referenceLookup.lookup]?.element;
+        }
       }
     }
 

--- a/lib/src/model/container_member.dart
+++ b/lib/src/model/container_member.dart
@@ -61,6 +61,9 @@ mixin ContainerMember on ModelElement {
       // Until then, just pretend we're handling this correctly.
       [
         (documentationFrom.first as ModelElement).definingLibrary,
-        (packageGraph.findCanonicalModelElementFor(this) ?? this).library,
-      ];
+        if (this case Field(:var getter, :var setter))
+          packageGraph.findCanonicalModelElementFor(getter ?? setter)?.library
+        else
+          (packageGraph.findCanonicalModelElementFor(this) ?? this).library,
+      ].nonNulls.toList();
 }

--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -234,7 +234,6 @@ abstract class ModelElement
       originalMember: originalMember,
     );
 
-    if (enclosingContainer != null) assert(newModelElement is Inheritable);
     _cacheNewModelElement(e, newModelElement, library,
         enclosingContainer: enclosingContainer);
 
@@ -324,11 +323,10 @@ abstract class ModelElement
     if (e.enclosingElement is ExtensionElement ||
         e.enclosingElement is InterfaceElement ||
         e is MultiplyInheritedExecutableElement) {
-      if (enclosingContainer == null) {
+      if (enclosingContainer == null || enclosingContainer is Extension) {
         return ContainerAccessor(e, library, packageGraph);
       }
 
-      assert(e.enclosingElement is! ExtensionElement);
       return ContainerAccessor.inherited(
           e, library, packageGraph, enclosingContainer,
           originalMember: originalMember as ExecutableMember?);

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -769,7 +769,7 @@ class PackageGraph with CommentReferable, Nameable {
       // TODO(keertip): Find a better way to exclude members of extensions
       // when libraries are specified using the "--include" flag.
       if (lib != null && lib.isDocumented) {
-        return getModelFor(element, lib);
+        return getModelFor(element, lib, enclosingContainer: preferredClass);
       }
     }
     // TODO(jcollins-g): The data structures should be changed to eliminate

--- a/test/extensions_test.dart
+++ b/test/extensions_test.dart
@@ -37,6 +37,22 @@ var f() {}
     );
   }
 
+  void test_referenceToMissingElement_onExtensionMember() async {
+    var library = await bootPackageWithLibrary('''
+extension E on int {
+  /// Text [NotFound] text.
+  int get f => 7;
+}
+''');
+
+    // We are primarily testing that dartdoc does not crash when trying to
+    // resolve an unknown reference, from the position of an extension member.
+    expect(
+      library.extensions.first.instanceFields.first.documentationAsHtml,
+      contains('<p>Text <code>NotFound</code> text.</p>'),
+    );
+  }
+
   void test_referenceToExtensionMethod() async {
     var library = await bootPackageWithLibrary('''
 extension Ex on int {


### PR DESCRIPTION
Fixes https://github.com/dart-lang/dartdoc/issues/3808

The main issue is that https://github.com/dart-lang/dartdoc/pull/3805 changed how extension accessors and "fields" (the synthetic ones introduced by accessors) are instantiated. This tidies up a few places related to that. The main thrust of this is in `container_member.dart`, where we prefer the canonical element of a field's getter/setter, rather than the canonical element of the field, which can introduce a weird side effect of stranded accessors without an "enclosingCombo" of the field.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
