### PR TITLE
Tidy up ContainerAccessor.isInherited and super parameters

### DIFF
--- a/lib/src/model/accessor.dart
+++ b/lib/src/model/accessor.dart
@@ -29,7 +29,7 @@ class Accessor extends ModelElement {
   late GetterSetterCombo enclosingCombo;
 
   Accessor(this.element, super.library, super.packageGraph,
-      [ExecutableMember? super.originalMember]);
+      {ExecutableMember? super.originalMember});
 
   @override
   CharacterLocation? get characterLocation => element.isSynthetic
@@ -185,24 +185,22 @@ class ContainerAccessor extends Accessor with ContainerMember, Inheritable {
   }
 
   late final Container _enclosingElement;
-  bool _isInherited = false;
+
+  @override
+  final bool isInherited;
 
   @override
   bool get isCovariant => isSetter && parameters.first.isCovariant;
 
-  ContainerAccessor(super.element, super.library, super.packageGraph) {
+  ContainerAccessor(super.element, super.library, super.packageGraph)
+      : isInherited = false {
     _enclosingElement = super.enclosingElement as Container;
   }
 
-  ContainerAccessor.inherited(PropertyAccessorElement element, Library library,
-      PackageGraph packageGraph, this._enclosingElement,
-      {ExecutableMember? originalMember})
-      : super(element, library, packageGraph, originalMember) {
-    _isInherited = true;
-  }
-
-  @override
-  bool get isInherited => _isInherited;
+  ContainerAccessor.inherited(
+      super.element, super.library, super.packageGraph, this._enclosingElement,
+      {super.originalMember})
+      : isInherited = true;
 
   @override
   Container get enclosingElement => _enclosingElement;

--- a/lib/src/model/inheriting_container.dart
+++ b/lib/src/model/inheriting_container.dart
@@ -503,11 +503,11 @@ abstract class InheritingContainer extends Container {
     return typeChain;
   }();
 
-  /// Add a single Field to _fields.
+  /// Creates a single Field.
   ///
-  /// If [field] is not specified, pick the FieldElement from the PropertyAccessorElement
-  /// whose enclosing class inherits from the other (defaulting to the getter)
-  /// and construct a Field using that.
+  /// If [field] is not specified, picks the [FieldElement] from the
+  /// [PropertyAccessorElement] whose enclosing class inherits from the other
+  /// (defaulting to the getter) and constructs a [Field] using that.
   Field _createSingleField(
       PropertyAccessorElement? getterElement,
       PropertyAccessorElement? setterElement,

--- a/lib/src/model/method.dart
+++ b/lib/src/model/method.dart
@@ -28,11 +28,10 @@ class Method extends ModelElement
     _calcTypeParameters();
   }
 
-  Method.inherited(this.element, this._enclosingContainer, Library library,
-      PackageGraph packageGraph,
-      {ExecutableMember? originalMember})
-      : _isInherited = true,
-        super(library, packageGraph, originalMember) {
+  Method.inherited(
+      this.element, this._enclosingContainer, super.library, super.packageGraph,
+      {ExecutableMember? super.originalMember})
+      : _isInherited = true {
     _calcTypeParameters();
   }
 

--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -76,7 +76,8 @@ abstract class ModelElement
 
   final PackageGraph _packageGraph;
 
-  ModelElement(this._library, this._packageGraph, [this._originalMember]);
+  ModelElement(this._library, this._packageGraph, {Member? originalMember})
+      : _originalMember = originalMember;
 
   /// Returns a [ModelElement] for an [Element], which can be a
   /// property-inducing element or not.

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -785,14 +785,14 @@ class PackageGraph with CommentReferable, Nameable {
           preferredClass: preferredClass as InheritingContainer?);
     } else {
       if (lib != null) {
-        if (element is PropertyInducingElement) {
-          var getter =
-              element.getter != null ? getModelFor(element.getter!, lib) : null;
-          var setter =
-              element.setter != null ? getModelFor(element.setter!, lib) : null;
+        if (element case PropertyInducingElement(:var getter, :var setter)) {
+          var getterElement =
+              getter == null ? null : getModelFor(getter, lib) as Accessor;
+          var setterElement =
+              setter == null ? null : getModelFor(setter, lib) as Accessor;
           canonicalModelElement = getModelForPropertyInducingElement(
               element, lib,
-              getter: getter as Accessor?, setter: setter as Accessor?);
+              getter: getterElement, setter: setterElement);
         } else {
           canonicalModelElement = getModelFor(element, lib);
         }

--- a/lib/src/model/parameter.dart
+++ b/lib/src/model/parameter.dart
@@ -13,9 +13,8 @@ class Parameter extends ModelElement with HasNoPage {
   @override
   final ParameterElement element;
 
-  Parameter(this.element, Library library, PackageGraph packageGraph,
-      {ParameterMember? originalMember})
-      : super(library, packageGraph, originalMember);
+  Parameter(this.element, super.library, super.packageGraph,
+      {ParameterMember? super.originalMember});
 
   String? get defaultValue => hasDefaultValue ? element.defaultValueCode : null;
 


### PR DESCRIPTION
ContainerAccessor._isInherited was unnecessarily backed by a getter, unnecessarily mutable, and unnecessarily set in a constructor body rather than an initializer.

This led me to discover we also weren't using super parameters everywhere we could be. So I fixed these as well.

- Thanks for your contribution! Please replace this text with a description of what this PR is changing or adding and why, list any relevant issues, and review the contribution guidelines below.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
