### PR TITLE
Cache ModelElements for dynamic and Never

### DIFF
--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -205,13 +205,6 @@ abstract class ModelElement
         e.kind == ElementKind.DYNAMIC ||
         e.kind == ElementKind.NEVER);
 
-    if (e.kind == ElementKind.DYNAMIC) {
-      return Dynamic(e, packageGraph);
-    }
-    if (e.kind == ElementKind.NEVER) {
-      return NeverType(e, packageGraph);
-    }
-
     Member? originalMember;
     // TODO(jcollins-g): Refactor object model to instantiate 'ModelMembers'
     //                   for members?
@@ -221,10 +214,19 @@ abstract class ModelElement
     }
 
     // Return the cached ModelElement if it exists.
-    var cachedModelElement = packageGraph.allConstructedModelElements[
-        ConstructedModelElementsKey(e, library, enclosingContainer)];
+    var key = ConstructedModelElementsKey(e, library, enclosingContainer);
+    var cachedModelElement = packageGraph.allConstructedModelElements[key];
     if (cachedModelElement != null) {
       return cachedModelElement;
+    }
+
+    if (e.kind == ElementKind.DYNAMIC) {
+      return packageGraph.allConstructedModelElements[key] =
+          Dynamic(e, packageGraph);
+    }
+    if (e.kind == ElementKind.NEVER) {
+      return packageGraph.allConstructedModelElements[key] =
+          NeverType(e, packageGraph);
     }
 
     var newModelElement = ModelElement._constructFromElementDeclaration(


### PR DESCRIPTION
I haven't done a memory benchmark, but for certain packages, I think we are currently creating many instances of dartdoc's `Dynamic` and `NeverType` classes, whenever `dynamic` and `Never` are used in a public API type, even a type argument, etc. Dartdoc's ModelElement classes all participate in an existing cache, so it is pretty simple to start using the cache for these two types.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
