### PR TITLE
Correct a regression for a package with a specified set of included libraries

### DIFF
--- a/lib/src/model/category.dart
+++ b/lib/src/model/category.dart
@@ -21,7 +21,7 @@ class Category
         TopLevelContainer,
         Indexable
     implements Documentable {
-  /// All libraries in [libraries] must come from [_package].
+  /// All libraries in [libraries] must come from [package].
   @override
   final Package package;
 

--- a/lib/src/model/library.dart
+++ b/lib/src/model/library.dart
@@ -5,8 +5,6 @@
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/scope.dart';
 import 'package:analyzer/source/line_info.dart';
-// ignore: implementation_imports
-import 'package:analyzer/src/generated/sdk.dart' show SdkLibrary;
 import 'package:dartdoc/src/model/comment_referable.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/package_meta.dart' show PackageMeta;
@@ -107,13 +105,17 @@ class Library extends ModelElement
   CompilationUnitElement get compilationUnitElement =>
       element.definingCompilationUnit;
 
-  SdkLibrary? get _sdkLib =>
-      packageGraph.sdkLibrarySources[element.librarySource];
-
   @override
+
+  /// Whether this library is considered "public."
+  ///
+  /// A library is considered public if it:
+  /// * is an SDK library and it is documented and it is not internal, or
+  /// * is found in a package's top-level 'lib' directory, and
+  ///   not found in it's 'lib/src' directory, and it is not excluded.
   bool get isPublic {
     if (!super.isPublic) return false;
-    final sdkLib = _sdkLib;
+    final sdkLib = packageGraph.sdkLibrarySources[element.librarySource];
     if (sdkLib != null && (sdkLib.isInternal || !sdkLib.isDocumented)) {
       return false;
     }

--- a/lib/src/model/nameable.dart
+++ b/lib/src/model/nameable.dart
@@ -30,8 +30,7 @@ mixin Nameable {
   ///
   /// A "package-public" element satisfies the following requirements:
   /// * is not documented with the `@nodoc` directive,
-  /// * for a library, is found in a package's top-level 'lib' directory, and
-  ///   not found in it's 'lib/src' directory,
+  /// * for a library, adheres to the documentation for [Library.isPublic],
   /// * for a library member, is in a _public_ library's exported namespace, and
   ///   is not privately named, nor an unnamed extension,
   /// * for a container (class, enum, extension, extension type, mixin) member,

--- a/lib/src/model/package_builder.dart
+++ b/lib/src/model/package_builder.dart
@@ -286,10 +286,8 @@ class PubPackageBuilder implements PackageBuilder {
         if (processedLibraries.contains(resolvedLibrary.element)) {
           continue;
         }
-        if (addingSpecials || _shouldIncludeLibrary(resolvedLibrary.element)) {
-          addLibrary(resolvedLibrary);
-          processedLibraries.add(resolvedLibrary.element);
-        }
+        addLibrary(resolvedLibrary);
+        processedLibraries.add(resolvedLibrary.element);
       }
       files.addAll(newFiles);
       if (!addingSpecials) {
@@ -328,10 +326,6 @@ class PubPackageBuilder implements PackageBuilder {
       progressBarComplete();
     }
   }
-
-  /// Whether [libraryElement] should be included in the libraries-to-document.
-  bool _shouldIncludeLibrary(LibraryElement libraryElement) =>
-      _config.include.isEmpty || _config.include.contains(libraryElement.name);
 
   /// Returns all top level library files in the 'lib/' directory of the given
   /// package root directory.

--- a/test/element_type_test.dart
+++ b/test/element_type_test.dart
@@ -28,15 +28,9 @@ void main() async {
   late FakePackageConfigProvider packageConfigProvider;
   late String packagePath;
 
-  Future<void> setUpPackage(
-    String name, {
-    String? pubspec,
-    String? analysisOptions,
-  }) async {
+  Future<void> setUpPackage(String name) async {
     packagePath = await d.createPackage(
       name,
-      pubspec: pubspec,
-      analysisOptions: analysisOptions,
       resourceProvider: resourceProvider,
     );
 

--- a/test/options_test.dart
+++ b/test/options_test.dart
@@ -208,8 +208,10 @@ class Foo {
 '''),
       ],
       files: [
-        d.dir('vendor/http', [
-          d.dir('lib', [d.file('http.dart', 'class Client {}')])
+        d.dir('vendor', [
+          d.dir('http', [
+            d.dir('lib', [d.file('http.dart', 'class Client {}')])
+          ])
         ])
       ],
     );

--- a/test/src/test_descriptor_utils.dart
+++ b/test/src/test_descriptor_utils.dart
@@ -48,7 +48,10 @@ Future<String> createPackage(
     final dependencies = parsedYaml['dependencies'] as Map;
     for (var dep in dependencies.keys) {
       // This only accepts 'path' deps.
-      final depConfig = dependencies[dep] as Map;
+      final depConfig = dependencies[dep];
+      if (depConfig is! Map) {
+        throw StateError('dep in pubspec must be a Map, but is: "$depConfig"');
+      }
       final pathDep = depConfig['path'];
 
       packagesInfo.writeln(''',{


### PR DESCRIPTION
In 12d271a542c5e7ebb96763a66f560e2f4a99ca24 we change what libraries can count as a 'canonical library', such that when a set of libraries is specified with the 'include' option, any library not in the 'include' list is not canonical. This breaks a few things.

The fix is to add all libraries to the `_allLibraries` field, not taking the 'include' list into consideration. Then when we decide what libraries are considered to be part of a package, we filter down to 'included' libraries.

Fixes https://github.com/dart-lang/dartdoc/issues/3823 and fixes https://github.com/dart-lang/dartdoc/issues/3826

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
