### PR TITLE
Fix links in sidebar of extension types

### DIFF
--- a/lib/src/generator/html_generator.dart
+++ b/lib/src/generator/html_generator.dart
@@ -70,7 +70,8 @@ class HtmlGeneratorBackend extends GeneratorBackend {
     var data = ExtensionTypeTemplateData(
         options, packageGraph, library, extensionType);
     var sidebarContent = templates.renderSidebarForContainer(data);
-    write(writer, extensionType.sidebarPath, data, sidebarContent);
+    write(writer, extensionType.sidebarPath, data, sidebarContent,
+        isSidebar: true);
     runtimeStats.incrementAccumulator('writtenSidebarFileCount');
   }
 

--- a/test/templates/extension_type_test.dart
+++ b/test/templates/extension_type_test.dart
@@ -361,10 +361,10 @@ extension type One(int it) {
       htmlLines,
       containsAllInOrder([
         matches(
-          '<a href="../lib/One-extension-type.html#instance-methods">'
+          '<a href="lib/One-extension-type.html#instance-methods">'
           'Methods</a>',
         ),
-        matches('<a href="../lib/One/m1.html">m1</a>'),
+        matches('<a href="lib/One/m1.html">m1</a>'),
       ]),
     );
   }
@@ -381,8 +381,8 @@ extension type One(int it) {
       htmlLines,
       containsAllInOrder([
         matches(
-            '<a href="../lib/One-extension-type.html#operators">Operators</a>'),
-        matches('<a href="../lib/One/operator_greater.html">operator ></a>'),
+            '<a href="lib/One-extension-type.html#operators">Operators</a>'),
+        matches('<a href="lib/One/operator_greater.html">operator ></a>'),
       ]),
     );
   }
@@ -402,10 +402,10 @@ extension type One(int it) {
     expect(
       htmlLines,
       containsAllInOrder([
-        matches('<a href="../lib/One-extension-type.html#static-properties">'
+        matches('<a href="lib/One-extension-type.html#static-properties">'
             'Static properties</a>'),
-        matches('<a href="../lib/One/gs1.html">gs1</a>'),
-        matches('<a href="../lib/One/sf1.html">sf1</a>'),
+        matches('<a href="lib/One/gs1.html">gs1</a>'),
+        matches('<a href="lib/One/sf1.html">sf1</a>'),
       ]),
     );
   }
@@ -421,9 +421,9 @@ extension type One(int it) {
     expect(
       htmlLines,
       containsAllInOrder([
-        matches('<a href="../lib/One-extension-type.html#static-methods">'
+        matches('<a href="lib/One-extension-type.html#static-methods">'
             'Static methods</a>'),
-        matches('<a href="../lib/One/s1.html">s1</a>'),
+        matches('<a href="lib/One/s1.html">s1</a>'),
       ]),
     );
   }


### PR DESCRIPTION
This bug was the simple result of copy-paste errors I believe. Passing `isSidebar: true` enables our custom link fiddling.

Fixes https://github.com/dart-lang/dartdoc/issues/3828

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
