### PR TITLE
Simplify some Container fields only used for sidebar logic.

### DIFF
--- a/lib/src/generator/templates.aot_renderers_for_html.dart
+++ b/lib/src/generator/templates.aot_renderers_for_html.dart
@@ -1694,27 +1694,25 @@ String renderSidebarForContainer<T extends Documentable>(
   buffer.write('''<ol>''');
   var context1 = context0.container;
   buffer.writeln();
-  if (context1.isClassOrExtensionType) {
-    if (context1.hasPublicConstructors) {
+  if (context1.hasPublicConstructors) {
+    buffer.writeln();
+    buffer.write('''
+      <li class="section-title"><a href="''');
+    buffer.write(context1.href);
+    buffer.write('''#constructors">Constructors</a></li>''');
+    var context2 = context1.publicConstructorsSorted;
+    for (var context3 in context2) {
       buffer.writeln();
       buffer.write('''
-        <li class="section-title"><a href="''');
-      buffer.write(context1.href);
-      buffer.write('''#constructors">Constructors</a></li>''');
-      var context2 = context1.publicConstructorsSorted;
-      for (var context3 in context2) {
-        buffer.writeln();
-        buffer.write('''
-          <li><a''');
-        if (context3.isDeprecated) {
-          buffer.write(''' class="deprecated"''');
-        }
-        buffer.write(''' href="''');
-        buffer.write(context3.href);
-        buffer.write('''">''');
-        buffer.writeEscaped(context3.shortName);
-        buffer.write('''</a></li>''');
+        <li><a''');
+      if (context3.isDeprecated) {
+        buffer.write(''' class="deprecated"''');
       }
+      buffer.write(''' href="''');
+      buffer.write(context3.href);
+      buffer.write('''">''');
+      buffer.writeEscaped(context3.shortName);
+      buffer.write('''</a></li>''');
     }
   }
   buffer.writeln();
@@ -1736,7 +1734,7 @@ String renderSidebarForContainer<T extends Documentable>(
     }
   }
   buffer.write('\n\n    ');
-  if (context1.isClassOrEnum) {
+  if (context1.isInterface) {
     if (context1.hasPublicInstanceFields) {
       buffer.writeln();
       buffer.write('''
@@ -1862,53 +1860,51 @@ String renderSidebarForContainer<T extends Documentable>(
     }
   }
   buffer.write('\n\n    ');
-  if (context1.isInterfaceOrExtension) {
-    if (context1.hasPublicVariableStaticFields) {
-      buffer.writeln();
-      buffer.write('''
-        <li class="section-title"><a href="''');
-      buffer.write(context1.href);
-      buffer.write('''#static-properties">Static properties</a></li>''');
-      var context18 = context1.publicVariableStaticFieldsSorted;
-      for (var context19 in context18) {
-        buffer.writeln();
-        buffer.write('''
-          <li>''');
-        buffer.write(context19.linkedName);
-        buffer.write('''</li>''');
-      }
-    }
+  if (context1.hasPublicVariableStaticFields) {
     buffer.writeln();
-    if (context1.hasPublicStaticMethods) {
+    buffer.write('''
+      <li class="section-title"><a href="''');
+    buffer.write(context1.href);
+    buffer.write('''#static-properties">Static properties</a></li>''');
+    var context18 = context1.publicVariableStaticFieldsSorted;
+    for (var context19 in context18) {
       buffer.writeln();
       buffer.write('''
-        <li class="section-title"><a href="''');
-      buffer.write(context1.href);
-      buffer.write('''#static-methods">Static methods</a></li>''');
-      var context20 = context1.publicStaticMethodsSorted;
-      for (var context21 in context20) {
-        buffer.writeln();
-        buffer.write('''
-          <li>''');
-        buffer.write(context21.linkedName);
-        buffer.write('''</li>''');
-      }
+        <li>''');
+      buffer.write(context19.linkedName);
+      buffer.write('''</li>''');
     }
+  }
+  buffer.writeln();
+  if (context1.hasPublicStaticMethods) {
     buffer.writeln();
-    if (context1.hasPublicConstantFields) {
+    buffer.write('''
+      <li class="section-title"><a href="''');
+    buffer.write(context1.href);
+    buffer.write('''#static-methods">Static methods</a></li>''');
+    var context20 = context1.publicStaticMethodsSorted;
+    for (var context21 in context20) {
       buffer.writeln();
       buffer.write('''
-        <li class="section-title"><a href="''');
-      buffer.write(context1.href);
-      buffer.write('''#constants">Constants</a></li>''');
-      var context22 = context1.publicConstantFieldsSorted;
-      for (var context23 in context22) {
-        buffer.writeln();
-        buffer.write('''
-          <li>''');
-        buffer.write(context23.linkedName);
-        buffer.write('''</li>''');
-      }
+        <li>''');
+      buffer.write(context21.linkedName);
+      buffer.write('''</li>''');
+    }
+  }
+  buffer.writeln();
+  if (context1.hasPublicConstantFields) {
+    buffer.writeln();
+    buffer.write('''
+      <li class="section-title"><a href="''');
+    buffer.write(context1.href);
+    buffer.write('''#constants">Constants</a></li>''');
+    var context22 = context1.publicConstantFieldsSorted;
+    for (var context23 in context22) {
+      buffer.writeln();
+      buffer.write('''
+        <li>''');
+      buffer.write(context23.linkedName);
+      buffer.write('''</li>''');
     }
   }
   buffer.writeln();

--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -1655,12 +1655,12 @@ class _Renderer_Class extends RendererBase<Class> {
                       self.renderSimpleVariable(c, remainingNames, 'bool'),
                   getBool: (CT_ c) => c.isFinal,
                 ),
-                'isInterface': Property(
-                  getValue: (CT_ c) => c.isInterface,
+                'isImplementableInterface': Property(
+                  getValue: (CT_ c) => c.isImplementableInterface,
                   renderVariable: (CT_ c, Property<CT_> self,
                           List<String> remainingNames) =>
                       self.renderSimpleVariable(c, remainingNames, 'bool'),
-                  getBool: (CT_ c) => c.isInterface,
+                  getBool: (CT_ c) => c.isImplementableInterface,
                 ),
                 'isMixinClass': Property(
                   getValue: (CT_ c) => c.isMixinClass,
@@ -2929,20 +2929,6 @@ class _Renderer_Container extends RendererBase<Container> {
                         _render_Operator(e, ast, r.template, sink, parent: r));
                   },
                 ),
-                'isClassOrEnum': Property(
-                  getValue: (CT_ c) => c.isClassOrEnum,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(c, remainingNames, 'bool'),
-                  getBool: (CT_ c) => c.isClassOrEnum,
-                ),
-                'isClassOrExtensionType': Property(
-                  getValue: (CT_ c) => c.isClassOrExtensionType,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(c, remainingNames, 'bool'),
-                  getBool: (CT_ c) => c.isClassOrExtensionType,
-                ),
                 'isEnum': Property(
                   getValue: (CT_ c) => c.isEnum,
                   renderVariable: (CT_ c, Property<CT_> self,
@@ -2957,12 +2943,12 @@ class _Renderer_Container extends RendererBase<Container> {
                       self.renderSimpleVariable(c, remainingNames, 'bool'),
                   getBool: (CT_ c) => c.isExtension,
                 ),
-                'isInterfaceOrExtension': Property(
-                  getValue: (CT_ c) => c.isInterfaceOrExtension,
+                'isInterface': Property(
+                  getValue: (CT_ c) => c.isInterface,
                   renderVariable: (CT_ c, Property<CT_> self,
                           List<String> remainingNames) =>
                       self.renderSimpleVariable(c, remainingNames, 'bool'),
-                  getBool: (CT_ c) => c.isInterfaceOrExtension,
+                  getBool: (CT_ c) => c.isInterface,
                 ),
                 'isMixin': Property(
                   getValue: (CT_ c) => c.isMixin,
@@ -4392,12 +4378,12 @@ class _Renderer_Enum extends RendererBase<Enum> {
                       self.renderSimpleVariable(c, remainingNames, 'bool'),
                   getBool: (CT_ c) => c.isBase,
                 ),
-                'isInterface': Property(
-                  getValue: (CT_ c) => c.isInterface,
+                'isImplementableInterface': Property(
+                  getValue: (CT_ c) => c.isImplementableInterface,
                   renderVariable: (CT_ c, Property<CT_> self,
                           List<String> remainingNames) =>
                       self.renderSimpleVariable(c, remainingNames, 'bool'),
-                  getBool: (CT_ c) => c.isInterface,
+                  getBool: (CT_ c) => c.isImplementableInterface,
                 ),
                 'isMixinClass': Property(
                   getValue: (CT_ c) => c.isMixinClass,
@@ -5146,12 +5132,12 @@ class _Renderer_ExtensionType extends RendererBase<ExtensionType> {
                       self.renderSimpleVariable(c, remainingNames, 'bool'),
                   getBool: (CT_ c) => c.isBase,
                 ),
-                'isInterface': Property(
-                  getValue: (CT_ c) => c.isInterface,
+                'isImplementableInterface': Property(
+                  getValue: (CT_ c) => c.isImplementableInterface,
                   renderVariable: (CT_ c, Property<CT_> self,
                           List<String> remainingNames) =>
                       self.renderSimpleVariable(c, remainingNames, 'bool'),
-                  getBool: (CT_ c) => c.isInterface,
+                  getBool: (CT_ c) => c.isImplementableInterface,
                 ),
                 'isMixinClass': Property(
                   getValue: (CT_ c) => c.isMixinClass,
@@ -7440,12 +7426,12 @@ class _Renderer_InheritingContainer extends RendererBase<InheritingContainer> {
                       self.renderSimpleVariable(c, remainingNames, 'bool'),
                   getBool: (CT_ c) => c.isFinal,
                 ),
-                'isInterface': Property(
-                  getValue: (CT_ c) => c.isInterface,
+                'isImplementableInterface': Property(
+                  getValue: (CT_ c) => c.isImplementableInterface,
                   renderVariable: (CT_ c, Property<CT_> self,
                           List<String> remainingNames) =>
                       self.renderSimpleVariable(c, remainingNames, 'bool'),
-                  getBool: (CT_ c) => c.isInterface,
+                  getBool: (CT_ c) => c.isImplementableInterface,
                 ),
                 'isMixinClass': Property(
                   getValue: (CT_ c) => c.isMixinClass,
@@ -9811,12 +9797,12 @@ class _Renderer_Mixin extends RendererBase<Mixin> {
                       self.renderSimpleVariable(c, remainingNames, 'bool'),
                   getBool: (CT_ c) => c.isFinal,
                 ),
-                'isInterface': Property(
-                  getValue: (CT_ c) => c.isInterface,
+                'isImplementableInterface': Property(
+                  getValue: (CT_ c) => c.isImplementableInterface,
                   renderVariable: (CT_ c, Property<CT_> self,
                           List<String> remainingNames) =>
                       self.renderSimpleVariable(c, remainingNames, 'bool'),
-                  getBool: (CT_ c) => c.isInterface,
+                  getBool: (CT_ c) => c.isImplementableInterface,
                 ),
                 'isMixinClass': Property(
                   getValue: (CT_ c) => c.isMixinClass,

--- a/lib/src/model/class.dart
+++ b/lib/src/model/class.dart
@@ -69,7 +69,7 @@ class Class extends InheritingContainer with Constructable, MixedInTypes {
   bool get isFinal => element.isFinal && !element.isSealed;
 
   @override
-  bool get isInterface => element.isInterface && !element.isSealed;
+  bool get isImplementableInterface => element.isInterface && !element.isSealed;
 
   @override
   bool get isMixinClass => element.isMixinClass;

--- a/lib/src/model/container.dart
+++ b/lib/src/model/container.dart
@@ -40,22 +40,11 @@ abstract class Container extends ModelElement
 
   bool get isExtension => element is ExtensionElement;
 
-  /// Whether this is an interface type (class, enum, mixin, extension type) or
-  /// an extension.
-  ///
-  /// For templates, interfaces and extensions have much in common despite
-  /// differing underlying implementations in the analyzer.
-  bool get isInterfaceOrExtension => element is InterfaceElement || isExtension;
-
   /// Whether this is an enum.
   bool get isEnum => element is EnumElement;
 
-  /// Whether this is a class or an enum.
-  bool get isClassOrEnum => element is InterfaceElement;
-
-  /// Whether this is a class or an extension type.
-  bool get isClassOrExtensionType =>
-      element is ClassElement || element is ExtensionTypeElement;
+  /// Whether this is an interface (e.g. class, enum, mixin, or extension type).
+  bool get isInterface => element is InterfaceElement;
 
   /// Whether this is a mixin.
   bool get isMixin => element is MixinElement;

--- a/lib/src/model/enum.dart
+++ b/lib/src/model/enum.dart
@@ -58,7 +58,7 @@ class Enum extends InheritingContainer with Constructable, MixedInTypes {
   bool get isBase => false;
 
   @override
-  bool get isInterface => false;
+  bool get isImplementableInterface => false;
 
   @override
   bool get isMixinClass => false;

--- a/lib/src/model/extension_type.dart
+++ b/lib/src/model/extension_type.dart
@@ -30,7 +30,7 @@ class ExtensionType extends InheritingContainer with Constructable {
   bool get isBase => false;
 
   @override
-  bool get isInterface => false;
+  bool get isImplementableInterface => false;
 
   @override
   bool get isMixinClass => false;

--- a/lib/src/model/inheriting_container.dart
+++ b/lib/src/model/inheriting_container.dart
@@ -85,7 +85,7 @@ abstract class InheritingContainer extends Container {
     if (isAbstract) ContainerModifier.abstract,
     if (isSealed) ContainerModifier.sealed,
     if (isBase) ContainerModifier.base,
-    if (isInterface) ContainerModifier.interface,
+    if (isImplementableInterface) ContainerModifier.interface,
     if (isFinal) ContainerModifier.finalModifier,
     if (isMixinClass) ContainerModifier.mixin,
   ]..sort();
@@ -350,7 +350,8 @@ abstract class InheritingContainer extends Container {
   @override
   bool get isFinal;
 
-  bool get isInterface;
+  /// Whether this element is a publicly implementable interface.
+  bool get isImplementableInterface;
 
   bool get isMixinClass;
 

--- a/lib/src/model/mixin.dart
+++ b/lib/src/model/mixin.dart
@@ -64,7 +64,7 @@ class Mixin extends InheritingContainer {
   bool get isFinal => false;
 
   @override
-  bool get isInterface => false;
+  bool get isImplementableInterface => false;
 
   @override
 

--- a/lib/templates/_sidebar_for_container.html
+++ b/lib/templates/_sidebar_for_container.html
@@ -1,14 +1,12 @@
 <ol>
   {{ #container }}
 
-    {{ #isClassOrExtensionType }}
-      {{ #hasPublicConstructors }}
-        <li class="section-title"><a href="{{{ href }}}#constructors">Constructors</a></li>
-        {{ #publicConstructorsSorted }}
-          <li><a{{ #isDeprecated }} class="deprecated"{{ /isDeprecated }} href="{{{ href }}}">{{ shortName }}</a></li>
-        {{ /publicConstructorsSorted }}
-      {{ /hasPublicConstructors }}
-    {{ /isClassOrExtensionType }}
+    {{ #hasPublicConstructors }}
+      <li class="section-title"><a href="{{{ href }}}#constructors">Constructors</a></li>
+      {{ #publicConstructorsSorted }}
+        <li><a{{ #isDeprecated }} class="deprecated"{{ /isDeprecated }} href="{{{ href }}}">{{ shortName }}</a></li>
+      {{ /publicConstructorsSorted }}
+    {{ /hasPublicConstructors }}
 
     {{ #isEnum }}
       {{ #hasPublicEnumValues }}
@@ -20,7 +18,7 @@
     {{ /isEnum }}
 
     {{!-- Instance members which may or may not be inherited. --}}
-    {{ #isClassOrEnum }}
+    {{ #isInterface }}
       {{ #hasPublicInstanceFields }}
         <li class="section-title{{ #publicInheritedInstanceFields }} inherited{{ /publicInheritedInstanceFields }}">
           <a href="{{{ href }}}#instance-properties">Properties</a>
@@ -43,7 +41,7 @@
           <li{{ #isInherited }} class="inherited"{{ /isInherited }}>{{{ linkedName }}}</li>
         {{ /publicInstanceOperatorsSorted }}
       {{ /hasPublicInstanceOperators }}
-    {{ /isClassOrEnum }}
+    {{ /isInterface }}
 
     {{!-- Instance members with no inheritance concept. --}}
     {{ #isExtension }}
@@ -70,27 +68,25 @@
     {{ /isExtension }}
 
     {{!-- Static members. --}}
-    {{ #isInterfaceOrExtension }}
-      {{ #hasPublicVariableStaticFields }}
-        <li class="section-title"><a href="{{{ href }}}#static-properties">Static properties</a></li>
-        {{ #publicVariableStaticFieldsSorted }}
-          <li>{{{ linkedName }}}</li>
-        {{ /publicVariableStaticFieldsSorted }}
-      {{ /hasPublicVariableStaticFields }}
+    {{ #hasPublicVariableStaticFields }}
+      <li class="section-title"><a href="{{{ href }}}#static-properties">Static properties</a></li>
+      {{ #publicVariableStaticFieldsSorted }}
+        <li>{{{ linkedName }}}</li>
+      {{ /publicVariableStaticFieldsSorted }}
+    {{ /hasPublicVariableStaticFields }}
 
-      {{ #hasPublicStaticMethods }}
-        <li class="section-title"><a href="{{{ href }}}#static-methods">Static methods</a></li>
-        {{ #publicStaticMethodsSorted }}
-          <li>{{{ linkedName }}}</li>
-        {{ /publicStaticMethodsSorted }}
-      {{ /hasPublicStaticMethods }}
+    {{ #hasPublicStaticMethods }}
+      <li class="section-title"><a href="{{{ href }}}#static-methods">Static methods</a></li>
+      {{ #publicStaticMethodsSorted }}
+        <li>{{{ linkedName }}}</li>
+      {{ /publicStaticMethodsSorted }}
+    {{ /hasPublicStaticMethods }}
 
-      {{ #hasPublicConstantFields }}
-        <li class="section-title"><a href="{{{ href }}}#constants">Constants</a></li>
-        {{ #publicConstantFieldsSorted }}
-          <li>{{{ linkedName }}}</li>
-        {{ /publicConstantFieldsSorted }}
-      {{ /hasPublicConstantFields }}
-    {{ /isInterfaceOrExtension }}
+    {{ #hasPublicConstantFields }}
+      <li class="section-title"><a href="{{{ href }}}#constants">Constants</a></li>
+      {{ #publicConstantFieldsSorted }}
+        <li>{{{ linkedName }}}</li>
+      {{ /publicConstantFieldsSorted }}
+    {{ /hasPublicConstantFields }}
   {{ /container }}
 </ol>


### PR DESCRIPTION
* Rename `isInterface` to `isImplementableInterface`, as that is more accurate.
* Rename `isClassOrEnum` to `isInterface`, as _that_ is more accurate.
* Remove `isInterfaceOrExtension` as all Containers are either interfaces or extensions; unnecessary.
* Remove `isClassOrExtensionType`; this functionality is covered by the existing property, `hasPublicConstructors`.


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
