### PR TITLE
Add tests supporting the wildcard feature

### DIFF
--- a/test/dartdoc_test_base.dart
+++ b/test/dartdoc_test_base.dart
@@ -40,7 +40,7 @@ abstract class DartdocTestBase {
 
   String get sdkConstraint => '>=3.3.0 <4.0.0';
 
-  List<String> get experiments => [];
+  List<String> get experiments => ['wildcards'];
 
   bool get skipUnreachableSdkLibraries => true;
 

--- a/test/dartdoc_test_base.dart
+++ b/test/dartdoc_test_base.dart
@@ -40,7 +40,7 @@ abstract class DartdocTestBase {
 
   String get sdkConstraint => '>=3.3.0 <4.0.0';
 
-  List<String> get experiments => ['wildcards'];
+  List<String> get experiments => ['wildcard-variables'];
 
   bool get skipUnreachableSdkLibraries => true;
 

--- a/test/parameter_test.dart
+++ b/test/parameter_test.dart
@@ -243,7 +243,48 @@ class A {
       '''));
   }
 
-  void test_superConstructorParameter_fieldFormal() async {
+  void test_fieldFormalParameter_referenced() async {
+    var library = await bootPackageWithLibrary('''
+class C {
+  int p;
+  /// Text [p].
+  C(this.p);
+}
+''');
+    var cConstructor = library.classes.named('C').constructors.named('C');
+    // There is no link, but also no wrong link or crash.
+    expect(cConstructor.documentationAsHtml, '<p>Text <code>p</code>.</p>');
+  }
+
+  void test_fieldFormalParameter_referenced_wildcard() async {
+    var library = await bootPackageWithLibrary('''
+class C {
+  int _;
+  /// Text [_].
+  C(this._);
+}
+''');
+    var cConstructor = library.classes.named('C').constructors.named('C');
+    // There is no link, but also no wrong link or crash.
+    expect(cConstructor.documentationAsHtml, '<p>Text <code>_</code>.</p>');
+  }
+
+  void test_superParameter_referenced_wildcard() async {
+    var library = await bootPackageWithLibrary('''
+class C {
+  C(int _);
+}
+class D extends C {
+  /// Text [_].
+  D(super._) {}
+}
+''');
+    var dConstructor = library.classes.named('D').constructors.named('D');
+    // There is no link, but also no wrong link or crash.
+    expect(dConstructor.documentationAsHtml, '<p>Text <code>_</code>.</p>');
+  }
+
+  void test_superParameter_fieldFormal() async {
     var library = await bootPackageWithLibrary('''
 class C {
   int f;
@@ -265,7 +306,7 @@ class D extends C {
       '''));
   }
 
-  void test_superConstructorParameter_isSubtype() async {
+  void test_superParameter_isSubtype() async {
     var library = await bootPackageWithLibrary('''
 class C {
   C.positionalNum(num g);
@@ -286,7 +327,7 @@ class D extends C {
       '''));
   }
 
-  void test_superConstructorParameter_superParameter() async {
+  void test_superParameter_superParameter() async {
     var library = await bootPackageWithLibrary('''
 class C {
   C.requiredPositional(int a);

--- a/test/parameter_test.dart
+++ b/test/parameter_test.dart
@@ -20,8 +20,48 @@ void main() {
 class ParameterTest extends DartdocTestBase {
   @override
   String get libraryName => 'parameters';
-  @override
-  String get sdkConstraint => '>=2.17.0 <3.0.0';
+
+  void test_formalParameter_referenced() async {
+    var library = await bootPackageWithLibrary('''
+/// Text [p].
+void f(int p) {}
+''');
+    var f = library.functions.named('f');
+    // There is no link, but also no wrong link or crash.
+    expect(f.documentationAsHtml, '<p>Text <code>p</code>.</p>');
+  }
+
+  void test_formalParameter_referenced_notShadowedElement() async {
+    var library = await bootPackageWithLibrary('''
+/// Text [p].
+void f(int p) {}
+var p = 0;
+''');
+    var f = library.functions.named('f');
+    // There is no link, but also no wrong link or crash.
+    expect(f.documentationAsHtml, '<p>Text <code>p</code>.</p>');
+  }
+
+  void test_formalParameter_referenced_notShadowedPrefix() async {
+    var library = await bootPackageWithLibrary('''
+import 'dart:async' as p;
+/// Text [p].
+void f(int p) {}
+''');
+    var f = library.functions.named('f');
+    // There is no link, but also no wrong link or crash.
+    expect(f.documentationAsHtml, '<p>Text <code>p</code>.</p>');
+  }
+
+  void test_formalParameter_referenced_wildcard() async {
+    var library = await bootPackageWithLibrary('''
+/// Text [_].
+void f(int _) {}
+''');
+    var f = library.functions.named('f');
+    // There is no link, but also no wrong link or crash.
+    expect(f.documentationAsHtml, '<p>Text <code>_</code>.</p>');
+  }
 
   void test_formalParameter_generic_method() async {
     var library = await bootPackageWithLibrary('''

--- a/test/type_parameter_test.dart
+++ b/test/type_parameter_test.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/test/type_parameter_test.dart
+++ b/test/type_parameter_test.dart
@@ -1,0 +1,54 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+import 'package:test_reflective_loader/test_reflective_loader.dart';
+
+import 'dartdoc_test_base.dart';
+import 'src/utils.dart';
+
+void main() {
+  defineReflectiveSuite(() {
+    defineReflectiveTests(TypeParameterTest);
+  });
+}
+
+@reflectiveTest
+class TypeParameterTest extends DartdocTestBase {
+  @override
+  String get libraryName => 'type_parameters';
+
+  void test_referenced() async {
+    var library = await bootPackageWithLibrary('''
+/// Text [T].
+void f<T>(int p) {}
+typedef T = int;
+''');
+    var f = library.functions.named('f');
+    // There is no link, but also no wrong link or crash.
+    expect(f.documentationAsHtml, '<p>Text <code>T</code>.</p>');
+  }
+
+  void test_referenced_wildcard() async {
+    var library = await bootPackageWithLibrary('''
+/// Text [_].
+void f<_>() {}
+''');
+    var f = library.functions.named('f');
+    // There is no link, but also no wrong link or crash.
+    expect(f.documentationAsHtml, '<p>Text <code>_</code>.</p>');
+  }
+
+  void test_referenced_wildcardInParent() async {
+    var library = await bootPackageWithLibrary('''
+class C<_> {
+  /// Text [_].
+  void m() {}
+}
+''');
+    var m = library.classes.named('C').instanceMethods.named('m');
+    // There is no link, but also no wrong link or crash.
+    expect(m.documentationAsHtml, '<p>Text <code>_</code>.</p>');
+  }
+}


### PR DESCRIPTION
No implementation work to do; parameters and type parameters were not linkable before. They are still not linkable, and don't crash.

I think I want one more PR for prefixes. We don't currently have any unit tests specific for prefixes, so I'll want to do that right.

Work towards https://github.com/dart-lang/dartdoc/issues/3769

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
