### PR TITLE
Dedupliate library elements

### DIFF
--- a/lib/src/generator/generator_frontend.dart
+++ b/lib/src/generator/generator_frontend.dart
@@ -72,66 +72,66 @@ class GeneratorFrontEnd implements Generator {
     var indexAccumulator = <Indexable>[];
     var multiplePackages = packageGraph.localPackages.length > 1;
 
-    void generateConstants(Container container) {
+    void generateConstants(Container container, Library library) {
       for (var constant in container.constantFields.whereDocumented) {
         if (!constant.isCanonical) continue;
         indexAccumulator.add(constant);
         _generatorBackend.generateProperty(
-            packageGraph, container.library, container, constant);
+            packageGraph, library, container, constant);
       }
     }
 
-    void generateConstructors(Constructable constructable) {
+    void generateConstructors(Constructable constructable, Library library) {
       for (var constructor in constructable.constructors.whereDocumented) {
         if (!constructor.isCanonical) continue;
         indexAccumulator.add(constructor);
         _generatorBackend.generateConstructor(
-            packageGraph, constructable.library, constructable, constructor);
+            packageGraph, library, constructable, constructor);
       }
     }
 
-    void generateInstanceMethods(Container container) {
+    void generateInstanceMethods(Container container, Library library) {
       for (var method in container.instanceMethods.whereDocumented) {
         if (!method.isCanonical) continue;
         indexAccumulator.add(method);
         _generatorBackend.generateMethod(
-            packageGraph, container.library, container, method);
+            packageGraph, library, container, method);
       }
     }
 
-    void generateInstanceOperators(Container container) {
+    void generateInstanceOperators(Container container, Library library) {
       for (var operator in container.instanceOperators.whereDocumented) {
         if (!operator.isCanonical) continue;
         indexAccumulator.add(operator);
         _generatorBackend.generateMethod(
-            packageGraph, container.library, container, operator);
+            packageGraph, library, container, operator);
       }
     }
 
-    void generateInstanceProperties(Container container) {
+    void generateInstanceProperties(Container container, Library library) {
       for (var property in container.instanceFields.whereDocumented) {
         if (!property.isCanonical) continue;
         indexAccumulator.add(property);
         _generatorBackend.generateProperty(
-            packageGraph, container.library, container, property);
+            packageGraph, library, container, property);
       }
     }
 
-    void generateStaticMethods(Container container) {
+    void generateStaticMethods(Container container, Library library) {
       for (var method in container.staticMethods.whereDocumented) {
         if (!method.isCanonical) continue;
         indexAccumulator.add(method);
         _generatorBackend.generateMethod(
-            packageGraph, container.library, container, method);
+            packageGraph, library, container, method);
       }
     }
 
-    void generateStaticProperties(Container container) {
+    void generateStaticProperties(Container container, Library library) {
       for (var property in container.variableStaticFields.whereDocumented) {
         if (!property.isCanonical) continue;
         indexAccumulator.add(property);
         _generatorBackend.generateProperty(
-            packageGraph, container.library, container, property);
+            packageGraph, library, container, property);
       }
     }
 
@@ -157,88 +157,93 @@ class GeneratorFrontEnd implements Generator {
         indexAccumulator.add(lib);
         _generatorBackend.generateLibrary(packageGraph, lib);
 
-        for (var class_ in lib.classesAndExceptions.whereDocumented) {
+        for (var class_ in lib.classesAndExceptions.whereDocumentedIn(lib)) {
           indexAccumulator.add(class_);
           _generatorBackend.generateClass(packageGraph, lib, class_);
 
-          generateConstants(class_);
-          generateConstructors(class_);
-          generateInstanceMethods(class_);
-          generateInstanceOperators(class_);
-          generateInstanceProperties(class_);
-          generateStaticMethods(class_);
-          generateStaticProperties(class_);
+          var canonicalLibrary = class_.canonicalLibraryOrThrow;
+          generateConstants(class_, canonicalLibrary);
+          generateConstructors(class_, canonicalLibrary);
+          generateInstanceMethods(class_, canonicalLibrary);
+          generateInstanceOperators(class_, canonicalLibrary);
+          generateInstanceProperties(class_, canonicalLibrary);
+          generateStaticMethods(class_, canonicalLibrary);
+          generateStaticProperties(class_, canonicalLibrary);
         }
 
-        for (var extension in lib.extensions.whereDocumented) {
+        for (var extension in lib.extensions.whereDocumentedIn(lib)) {
           indexAccumulator.add(extension);
           _generatorBackend.generateExtension(packageGraph, lib, extension);
 
-          generateConstants(extension);
-          generateInstanceMethods(extension);
-          generateInstanceOperators(extension);
-          generateInstanceProperties(extension);
-          generateStaticMethods(extension);
-          generateStaticProperties(extension);
+          var canonicalLibrary = extension.canonicalLibraryOrThrow;
+          generateConstants(extension, canonicalLibrary);
+          generateInstanceMethods(extension, canonicalLibrary);
+          generateInstanceOperators(extension, canonicalLibrary);
+          generateInstanceProperties(extension, canonicalLibrary);
+          generateStaticMethods(extension, canonicalLibrary);
+          generateStaticProperties(extension, canonicalLibrary);
         }
 
-        for (var extensionType in lib.extensionTypes.whereDocumented) {
+        for (var extensionType in lib.extensionTypes.whereDocumentedIn(lib)) {
           indexAccumulator.add(extensionType);
           _generatorBackend.generateExtensionType(
               packageGraph, lib, extensionType);
 
-          generateConstants(extensionType);
-          generateConstructors(extensionType);
-          generateInstanceMethods(extensionType);
-          generateInstanceOperators(extensionType);
-          generateInstanceProperties(extensionType);
-          generateStaticMethods(extensionType);
-          generateStaticProperties(extensionType);
+          var canonicalLibrary = extensionType.canonicalLibraryOrThrow;
+          generateConstants(extensionType, canonicalLibrary);
+          generateConstructors(extensionType, canonicalLibrary);
+          generateInstanceMethods(extensionType, canonicalLibrary);
+          generateInstanceOperators(extensionType, canonicalLibrary);
+          generateInstanceProperties(extensionType, canonicalLibrary);
+          generateStaticMethods(extensionType, canonicalLibrary);
+          generateStaticProperties(extensionType, canonicalLibrary);
         }
 
-        for (var mixin in lib.mixins.whereDocumented) {
+        for (var mixin in lib.mixins.whereDocumentedIn(lib)) {
           indexAccumulator.add(mixin);
           _generatorBackend.generateMixin(packageGraph, lib, mixin);
 
-          generateConstants(mixin);
-          generateInstanceMethods(mixin);
-          generateInstanceOperators(mixin);
-          generateInstanceProperties(mixin);
-          generateStaticMethods(mixin);
-          generateStaticProperties(mixin);
+          var canonicalLibrary = mixin.canonicalLibraryOrThrow;
+          generateConstants(mixin, canonicalLibrary);
+          generateInstanceMethods(mixin, canonicalLibrary);
+          generateInstanceOperators(mixin, canonicalLibrary);
+          generateInstanceProperties(mixin, canonicalLibrary);
+          generateStaticMethods(mixin, canonicalLibrary);
+          generateStaticProperties(mixin, canonicalLibrary);
         }
 
-        for (var enum_ in lib.enums.whereDocumented) {
+        for (var enum_ in lib.enums.whereDocumentedIn(lib)) {
           indexAccumulator.add(enum_);
           _generatorBackend.generateEnum(packageGraph, lib, enum_);
 
-          generateConstants(enum_);
-          generateConstructors(enum_);
-          generateInstanceMethods(enum_);
-          generateInstanceOperators(enum_);
-          generateInstanceProperties(enum_);
-          generateStaticMethods(enum_);
-          generateStaticProperties(enum_);
+          var canonicalLibrary = enum_.canonicalLibraryOrThrow;
+          generateConstants(enum_, canonicalLibrary);
+          generateConstructors(enum_, canonicalLibrary);
+          generateInstanceMethods(enum_, canonicalLibrary);
+          generateInstanceOperators(enum_, canonicalLibrary);
+          generateInstanceProperties(enum_, canonicalLibrary);
+          generateStaticMethods(enum_, canonicalLibrary);
+          generateStaticProperties(enum_, canonicalLibrary);
         }
 
-        for (var constant in lib.constants.whereDocumented) {
+        for (var constant in lib.constants.whereDocumentedIn(lib)) {
           indexAccumulator.add(constant);
           _generatorBackend.generateTopLevelProperty(
               packageGraph, lib, constant);
         }
 
-        for (var property in lib.properties.whereDocumented) {
+        for (var property in lib.properties.whereDocumentedIn(lib)) {
           indexAccumulator.add(property);
           _generatorBackend.generateTopLevelProperty(
               packageGraph, lib, property);
         }
 
-        for (var function in lib.functions.whereDocumented) {
+        for (var function in lib.functions.whereDocumentedIn(lib)) {
           indexAccumulator.add(function);
           _generatorBackend.generateFunction(packageGraph, lib, function);
         }
 
-        for (var typeDef in lib.typedefs.whereDocumented) {
+        for (var typeDef in lib.typedefs.whereDocumentedIn(lib)) {
           indexAccumulator.add(typeDef);
           _generatorBackend.generateTypeDef(packageGraph, lib, typeDef);
         }

--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -1128,28 +1128,6 @@ class _Renderer_Category extends RendererBase<Category> {
                         parent: r);
                   },
                 ),
-                'fullyQualifiedName': Property(
-                  getValue: (CT_ c) => c.fullyQualifiedName,
-                  renderVariable:
-                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
-                    if (remainingNames.isEmpty) {
-                      return self.getValue(c).toString();
-                    }
-                    var name = remainingNames.first;
-                    var nextProperty =
-                        _Renderer_String.propertyMap().getValue(name);
-                    return nextProperty.renderVariable(
-                        self.getValue(c) as String,
-                        nextProperty,
-                        [...remainingNames.skip(1)]);
-                  },
-                  isNullValue: (CT_ c) => false,
-                  renderValue: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    _render_String(c.fullyQualifiedName, ast, r.template, sink,
-                        parent: r);
-                  },
-                ),
                 'functions': Property(
                   getValue: (CT_ c) => c.functions,
                   renderVariable: (CT_ c, Property<CT_> self,
@@ -2111,28 +2089,6 @@ class _Renderer_Constructor extends RendererBase<Constructor> {
                   renderValue: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
                     _render_Container(c.enclosingElement, ast, r.template, sink,
-                        parent: r);
-                  },
-                ),
-                'filePath': Property(
-                  getValue: (CT_ c) => c.filePath,
-                  renderVariable:
-                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
-                    if (remainingNames.isEmpty) {
-                      return self.getValue(c).toString();
-                    }
-                    var name = remainingNames.first;
-                    var nextProperty =
-                        _Renderer_String.propertyMap().getValue(name);
-                    return nextProperty.renderVariable(
-                        self.getValue(c) as String,
-                        nextProperty,
-                        [...remainingNames.skip(1)]);
-                  },
-                  isNullValue: (CT_ c) => false,
-                  renderValue: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    _render_String(c.filePath, ast, r.template, sink,
                         parent: r);
                   },
                 ),
@@ -3402,6 +3358,28 @@ class _Renderer_ContainerMember extends RendererBase<ContainerMember> {
                   renderValue: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
                     _render_Container(c.enclosingElement, ast, r.template, sink,
+                        parent: r);
+                  },
+                ),
+                'filePath': Property(
+                  getValue: (CT_ c) => c.filePath,
+                  renderVariable:
+                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
+                    if (remainingNames.isEmpty) {
+                      return self.getValue(c).toString();
+                    }
+                    var name = remainingNames.first;
+                    var nextProperty =
+                        _Renderer_String.propertyMap().getValue(name);
+                    return nextProperty.renderVariable(
+                        self.getValue(c) as String,
+                        nextProperty,
+                        [...remainingNames.skip(1)]);
+                  },
+                  isNullValue: (CT_ c) => false,
+                  renderValue: (CT_ c, RendererBase<CT_> r,
+                      List<MustachioNode> ast, StringSink sink) {
+                    _render_String(c.filePath, ast, r.template, sink,
                         parent: r);
                   },
                 ),
@@ -5768,28 +5746,6 @@ class _Renderer_Field extends RendererBase<Field> {
                   renderValue: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
                     _render_String(c.fileName, ast, r.template, sink,
-                        parent: r);
-                  },
-                ),
-                'filePath': Property(
-                  getValue: (CT_ c) => c.filePath,
-                  renderVariable:
-                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
-                    if (remainingNames.isEmpty) {
-                      return self.getValue(c).toString();
-                    }
-                    var name = remainingNames.first;
-                    var nextProperty =
-                        _Renderer_String.propertyMap().getValue(name);
-                    return nextProperty.renderVariable(
-                        self.getValue(c) as String,
-                        nextProperty,
-                        [...remainingNames.skip(1)]);
-                  },
-                  isNullValue: (CT_ c) => false,
-                  renderValue: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    _render_String(c.filePath, ast, r.template, sink,
                         parent: r);
                   },
                 ),
@@ -9195,28 +9151,6 @@ class _Renderer_Method extends RendererBase<Method> {
                         parent: r);
                   },
                 ),
-                'filePath': Property(
-                  getValue: (CT_ c) => c.filePath,
-                  renderVariable:
-                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
-                    if (remainingNames.isEmpty) {
-                      return self.getValue(c).toString();
-                    }
-                    var name = remainingNames.first;
-                    var nextProperty =
-                        _Renderer_String.propertyMap().getValue(name);
-                    return nextProperty.renderVariable(
-                        self.getValue(c) as String,
-                        nextProperty,
-                        [...remainingNames.skip(1)]);
-                  },
-                  isNullValue: (CT_ c) => false,
-                  renderValue: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    _render_String(c.filePath, ast, r.template, sink,
-                        parent: r);
-                  },
-                ),
                 'fullkind': Property(
                   getValue: (CT_ c) => c.fullkind,
                   renderVariable:
@@ -10066,6 +10000,29 @@ class _Renderer_ModelElement extends RendererBase<ModelElement> {
                         parent: r);
                   },
                 ),
+                'canonicalLibraryOrThrow': Property(
+                  getValue: (CT_ c) => c.canonicalLibraryOrThrow,
+                  renderVariable:
+                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
+                    if (remainingNames.isEmpty) {
+                      return self.getValue(c).toString();
+                    }
+                    var name = remainingNames.first;
+                    var nextProperty =
+                        _Renderer_Library.propertyMap().getValue(name);
+                    return nextProperty.renderVariable(
+                        self.getValue(c) as Library,
+                        nextProperty,
+                        [...remainingNames.skip(1)]);
+                  },
+                  isNullValue: (CT_ c) => false,
+                  renderValue: (CT_ c, RendererBase<CT_> r,
+                      List<MustachioNode> ast, StringSink sink) {
+                    _render_Library(
+                        c.canonicalLibraryOrThrow, ast, r.template, sink,
+                        parent: r);
+                  },
+                ),
                 'canonicalModelElement': Property(
                   getValue: (CT_ c) => c.canonicalModelElement,
                   renderVariable:
@@ -10130,28 +10087,6 @@ class _Renderer_ModelElement extends RendererBase<ModelElement> {
                     renderSimple(c.config, ast, r.template, sink,
                         parent: r,
                         getters: _invisibleGetters['DartdocOptionContext']!);
-                  },
-                ),
-                'definingLibrary': Property(
-                  getValue: (CT_ c) => c.definingLibrary,
-                  renderVariable:
-                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
-                    if (remainingNames.isEmpty) {
-                      return self.getValue(c).toString();
-                    }
-                    var name = remainingNames.first;
-                    var nextProperty =
-                        _Renderer_Library.propertyMap().getValue(name);
-                    return nextProperty.renderVariable(
-                        self.getValue(c) as Library,
-                        nextProperty,
-                        [...remainingNames.skip(1)]);
-                  },
-                  isNullValue: (CT_ c) => false,
-                  renderValue: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    _render_Library(c.definingLibrary, ast, r.template, sink,
-                        parent: r);
                   },
                 ),
                 'displayedCategories': Property(
@@ -12203,7 +12138,7 @@ class _Renderer_Package extends RendererBase<Package> {
   }
 }
 
-String renderError(PackageTemplateData context, Template template) {
+String renderSearchPage(PackageTemplateData context, Template template) {
   var buffer = StringBuffer();
   _render_PackageTemplateData(context, template.ast, template, buffer);
   return buffer.toString();
@@ -12447,7 +12382,7 @@ String renderIndex(PackageTemplateData context, Template template) {
   return buffer.toString();
 }
 
-String renderSearchPage(PackageTemplateData context, Template template) {
+String renderError(PackageTemplateData context, Template template) {
   var buffer = StringBuffer();
   _render_PackageTemplateData(context, template.ast, template, buffer);
   return buffer.toString();

--- a/lib/src/model/canonicalization.dart
+++ b/lib/src/model/canonicalization.dart
@@ -5,7 +5,7 @@
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/warnings.dart';
 
-/// Classes extending this class have canonicalization support in Dartdoc.
+/// Canonicalization support in Dartdoc.
 ///
 /// This provides heuristic scoring to determine which library a human likely
 /// considers this element to be primarily 'from', and therefore, canonical.
@@ -15,6 +15,7 @@ final class Canonicalization {
 
   Canonicalization(this._element);
 
+  /// Calculates a candidate for the canonical library of [_element], among [libraries].
   Library calculateCanonicalCandidate(Iterable<Library> libraries) {
     var locationPieces = _element.element.location
         .toString()

--- a/lib/src/model/category.dart
+++ b/lib/src/model/category.dart
@@ -21,6 +21,8 @@ class Category
         TopLevelContainer,
         Indexable
     implements Documentable {
+  /// The package in which this category is contained.
+  ///
   /// All libraries in [libraries] must come from [package].
   @override
   final Package package;
@@ -102,9 +104,6 @@ class Category
   @override
   late final bool isDocumented =
       documentedWhere != DocumentLocation.missing && documentationFile != null;
-
-  @override
-  String get fullyQualifiedName => name;
 
   String get filePath => 'topics/$name-topic.html';
 

--- a/lib/src/model/class.dart
+++ b/lib/src/model/class.dart
@@ -23,7 +23,8 @@ class Class extends InheritingContainer with Constructable, MixedInTypes {
   ];
 
   @override
-  String get sidebarPath => '${library.dirName}/$name-class-sidebar.html';
+  String get sidebarPath =>
+      '${canonicalLibraryOrThrow.dirName}/$name-class-sidebar.html';
 
   @override
   late final List<InheritingContainer> inheritanceChain = [

--- a/lib/src/model/constructor.dart
+++ b/lib/src/model/constructor.dart
@@ -56,10 +56,6 @@ class Constructor extends ModelElement with ContainerMember, TypeParameters {
       getModelFor(element.enclosingElement, library) as Container;
 
   @override
-  String get filePath =>
-      '${enclosingElement.library.dirName}/${enclosingElement.name}/$fileName';
-
-  @override
   String get aboveSidebarPath => enclosingElement.sidebarPath;
 
   @override

--- a/lib/src/model/container.dart
+++ b/lib/src/model/container.dart
@@ -229,10 +229,10 @@ abstract class Container extends ModelElement
   };
 
   @override
-  Iterable<CommentReferable> get referenceParents => [definingLibrary, library];
+  Iterable<CommentReferable> get referenceParents => [library];
 
   @override
-  String get filePath => '${library.dirName}/$fileName';
+  String get filePath => '${canonicalLibraryOrThrow.dirName}/$fileName';
 
   /// The full path of this element's sidebar file.
   String get sidebarPath;

--- a/lib/src/model/container_member.dart
+++ b/lib/src/model/container_member.dart
@@ -21,6 +21,10 @@ mixin ContainerMember on ModelElement {
   @override
   Container get enclosingElement;
 
+  @override
+  String get filePath =>
+      '${canonicalLibraryOrThrow.dirName}/${enclosingElement.name}/$fileName';
+
   /// The container that contains this member.
   @protected
   @visibleForTesting
@@ -60,7 +64,7 @@ mixin ContainerMember on ModelElement {
       // and resolve the pieces with different scopes.  dart-lang/dartdoc#2693.
       // Until then, just pretend we're handling this correctly.
       [
-        (documentationFrom.first as ModelElement).definingLibrary,
+        (documentationFrom.first as ModelElement).library,
         if (this case Field(:var getter, :var setter))
           packageGraph.findCanonicalModelElementFor(getter ?? setter)?.library
         else

--- a/lib/src/model/documentation_comment.dart
+++ b/lib/src/model/documentation_comment.dart
@@ -9,6 +9,7 @@ import 'package:dartdoc/src/model/documentable.dart';
 import 'package:dartdoc/src/model/documentation.dart';
 import 'package:dartdoc/src/model/inheritable.dart';
 import 'package:dartdoc/src/model/locatable.dart';
+import 'package:dartdoc/src/model/model_element.dart';
 import 'package:dartdoc/src/model/source_code_mixin.dart';
 import 'package:dartdoc/src/utils.dart';
 import 'package:dartdoc/src/warnings.dart';
@@ -273,6 +274,10 @@ mixin DocumentationComment
 
   /// The environment variables to use when running a tool.
   Map<String, String> _toolsEnvironment({required int invocationIndex}) {
+    var self = this;
+    var library = self is ModelElement
+        ? (self.canonicalLibrary ?? this.library)
+        : this.library;
     var env = {
       'SOURCE_LINE': characterLocation?.lineNumber.toString(),
       'SOURCE_COLUMN': characterLocation?.columnNumber.toString(),

--- a/lib/src/model/enum.dart
+++ b/lib/src/model/enum.dart
@@ -31,7 +31,8 @@ class Enum extends InheritingContainer with Constructable, MixedInTypes {
   ];
 
   @override
-  String get sidebarPath => '${library.dirName}/$name-enum-sidebar.html';
+  String get sidebarPath =>
+      '${canonicalLibraryOrThrow.dirName}/$name-enum-sidebar.html';
 
   @override
   Kind get kind => Kind.enum_;
@@ -110,7 +111,6 @@ class EnumField extends Field {
     if (!identical(canonicalModelElement, this)) {
       return canonicalModelElement?.href;
     }
-    assert(canonicalLibrary == library);
     assert(canonicalEnclosingContainer == enclosingElement);
     // TODO(jcollins-g): EnumField should not depend on enclosingElement, but
     // we sort of have to while we are half-converted to [FileStructure].

--- a/lib/src/model/extension.dart
+++ b/lib/src/model/extension.dart
@@ -93,7 +93,8 @@ class Extension extends Container {
   ];
 
   @override
-  String get sidebarPath => '${library.dirName}/$name-extension-sidebar.html';
+  String get sidebarPath =>
+      '${canonicalLibraryOrThrow.dirName}/$name-extension-sidebar.html';
 
   Map<String, CommentReferable>? _referenceChildren;
   @override

--- a/lib/src/model/extension_type.dart
+++ b/lib/src/model/extension_type.dart
@@ -70,7 +70,7 @@ class ExtensionType extends InheritingContainer with Constructable {
 
   @override
   String get sidebarPath =>
-      '${library.dirName}/$name-extension-type-sidebar.html';
+      '${canonicalLibraryOrThrow.dirName}/$name-extension-type-sidebar.html';
 
   Map<String, CommentReferable>? _referenceChildren;
   @override

--- a/lib/src/model/field.dart
+++ b/lib/src/model/field.dart
@@ -77,10 +77,6 @@ class Field extends ModelElement
   }
 
   @override
-  String get filePath =>
-      '${enclosingElement.library.dirName}/${enclosingElement.name}/$fileName';
-
-  @override
   String? get href {
     assert(!identical(canonicalModelElement, this) ||
         canonicalEnclosingContainer == enclosingElement);

--- a/lib/src/model/inheritable.dart
+++ b/lib/src/model/inheritable.dart
@@ -86,19 +86,6 @@ mixin Inheritable on ContainerMember {
           previousNonSkippable = c;
         }
       }
-      // This is still OK because we're never supposed to cloak public
-      // classes.
-      if (definingEnclosingContainer.isCanonical &&
-          definingEnclosingContainer.isPublic) {
-        assert(
-            definingEnclosingContainer == found,
-            "For '$element' (${element.hashCode}) "
-            "(search element: '$searchElement', ${searchElement?.hashCode}, in "
-            "'${searchElement?.enclosingElement}'), expected "
-            "'$definingEnclosingContainer', which is canonical, to be '$found',"
-            "but was not. Here's the inheritance chain: "
-            '${inheritance.reversed}.');
-      }
       if (found != null) {
         return found;
       }

--- a/lib/src/model/inheriting_container.dart
+++ b/lib/src/model/inheriting_container.dart
@@ -288,7 +288,7 @@ abstract class InheritingContainer extends Container {
 
   /// The [InheritingContainer] with the library in which [element] is defined.
   InheritingContainer get definingContainer =>
-      getModelFor(element, definingLibrary) as InheritingContainer;
+      getModelFor(element, library) as InheritingContainer;
 
   @override
   InterfaceElement get element;

--- a/lib/src/model/method.dart
+++ b/lib/src/model/method.dart
@@ -59,10 +59,6 @@ class Method extends ModelElement
       getModelFor(element.enclosingElement, library) as Container;
 
   @override
-  String get filePath =>
-      '${enclosingElement.library.dirName}/${enclosingElement.name}/$fileName';
-
-  @override
   String get aboveSidebarPath => enclosingElement.sidebarPath;
 
   @override

--- a/lib/src/model/mixin.dart
+++ b/lib/src/model/mixin.dart
@@ -27,7 +27,8 @@ class Mixin extends InheritingContainer {
   String get fileName => '$name-mixin.html';
 
   @override
-  String get sidebarPath => '${library.dirName}/$name-mixin-sidebar.html';
+  String get sidebarPath =>
+      '${canonicalLibraryOrThrow.dirName}/$name-mixin-sidebar.html';
 
   @override
   late final List<InheritingContainer> inheritanceChain = [

--- a/lib/src/model/model_function.dart
+++ b/lib/src/model/model_function.dart
@@ -48,7 +48,7 @@ class ModelFunctionTyped extends ModelElement with TypeParameters {
   Library get enclosingElement => library;
 
   @override
-  String get filePath => '${library.dirName}/$fileName';
+  String get filePath => '${canonicalLibrary?.dirName}/$fileName';
 
   @override
   String get aboveSidebarPath => enclosingElement.sidebarPath;
@@ -61,7 +61,6 @@ class ModelFunctionTyped extends ModelElement with TypeParameters {
     if (!identical(canonicalModelElement, this)) {
       return canonicalModelElement?.href;
     }
-    assert(canonicalLibrary == library);
     return '${package.baseHref}$filePath';
   }
 
@@ -78,7 +77,7 @@ class ModelFunctionTyped extends ModelElement with TypeParameters {
   };
 
   @override
-  Iterable<CommentReferable> get referenceParents => [definingLibrary];
+  Iterable<CommentReferable> get referenceParents => [library];
 
   late final Callable modelType = getTypeFor(element.type, library) as Callable;
 }

--- a/lib/src/model/nameable.dart
+++ b/lib/src/model/nameable.dart
@@ -16,9 +16,8 @@ import 'package:dartdoc/src/model/package_graph.dart';
 mixin Nameable {
   String get name;
 
-  /// A "fully" qualified name, mostly for use in the web search functionality,
-  /// and for warnings printed in the terminal; not for display use in rendered
-  /// HTML.
+  /// A "fully" qualified name, used for things like for warnings printed in the
+  /// terminal; not for display use in rendered HTML.
   ///
   /// "Fully" means the name is qualified through the library. For example, a
   /// method named 'baz' in a class named 'Bar' in a library named 'foo' has a

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -827,12 +827,12 @@ class PackageGraph with CommentReferable, Nameable {
     var candidates = <ModelElement>{};
     if (lib != null) {
       var constructedWithKey = allConstructedModelElements[
-          ConstructedModelElementsKey(element, lib, null)];
+          ConstructedModelElementsKey(element, null)];
       if (constructedWithKey != null) {
         candidates.add(constructedWithKey);
       }
       var constructedWithKeyWithClass = allConstructedModelElements[
-          ConstructedModelElementsKey(element, lib, preferredClass)];
+          ConstructedModelElementsKey(element, preferredClass)];
       if (constructedWithKeyWithClass != null) {
         candidates.add(constructedWithKeyWithClass);
       }
@@ -1044,20 +1044,17 @@ class PackageGraph with CommentReferable, Nameable {
 
 class ConstructedModelElementsKey {
   final Element element;
-  final Library library;
   final Container? enclosingElement;
 
-  ConstructedModelElementsKey(
-      this.element, this.library, this.enclosingElement);
+  ConstructedModelElementsKey(this.element, this.enclosingElement);
 
   @override
-  late final int hashCode = Object.hash(element, library, enclosingElement);
+  late final int hashCode = Object.hash(element, enclosingElement);
 
   @override
   bool operator ==(Object other) {
     if (other is! ConstructedModelElementsKey) return false;
     return other.element == element &&
-        other.library == library &&
         other.enclosingElement == enclosingElement;
   }
 }

--- a/lib/src/model/prefix.dart
+++ b/lib/src/model/prefix.dart
@@ -48,5 +48,5 @@ class Prefix extends ModelElement with HasNoPage {
   Map<String, CommentReferable> get referenceChildren => {};
 
   @override
-  Iterable<CommentReferable> get referenceParents => [definingLibrary];
+  Iterable<CommentReferable> get referenceParents => [library];
 }

--- a/lib/src/model/top_level_variable.dart
+++ b/lib/src/model/top_level_variable.dart
@@ -42,7 +42,7 @@ class TopLevelVariable extends ModelElement
   Library get enclosingElement => library;
 
   @override
-  String get filePath => '${library.dirName}/$fileName';
+  String get filePath => '${canonicalLibraryOrThrow.dirName}/$fileName';
 
   @override
   String get aboveSidebarPath => enclosingElement.sidebarPath;
@@ -55,7 +55,6 @@ class TopLevelVariable extends ModelElement
     if (!identical(canonicalModelElement, this)) {
       return canonicalModelElement?.href;
     }
-    assert(canonicalLibrary == library);
     return '${package.baseHref}$filePath';
   }
 
@@ -80,5 +79,5 @@ class TopLevelVariable extends ModelElement
   Set<Attribute> get attributes => {...super.attributes, ...comboAttributes};
 
   @override
-  Iterable<CommentReferable> get referenceParents => [definingLibrary];
+  Iterable<CommentReferable> get referenceParents => [library];
 }

--- a/lib/src/model/typedef.dart
+++ b/lib/src/model/typedef.dart
@@ -32,7 +32,7 @@ abstract class Typedef extends ModelElement
   String get linkedGenericParameters => _renderTypeParameters(isLinked: true);
 
   @override
-  String get filePath => '${library.dirName}/$fileName';
+  String get filePath => '${canonicalLibraryOrThrow.dirName}/$fileName';
 
   @override
   String get aboveSidebarPath => enclosingElement.sidebarPath;
@@ -49,7 +49,6 @@ abstract class Typedef extends ModelElement
     if (!identical(canonicalModelElement, this)) {
       return canonicalModelElement?.href;
     }
-    assert(canonicalLibrary == library);
     return '${package.baseHref}$filePath';
   }
 
@@ -65,7 +64,7 @@ abstract class Typedef extends ModelElement
       .toList(growable: false);
 
   @override
-  Iterable<CommentReferable> get referenceParents => [definingLibrary];
+  Iterable<CommentReferable> get referenceParents => [library];
 
   late final Map<String, CommentReferable> _referenceChildren = {
     ...typeParameters.explicitOnCollisionWith(this),

--- a/lib/src/model_utils.dart
+++ b/lib/src/model_utils.dart
@@ -98,3 +98,9 @@ extension IterableOfDocumentableExtension<E extends Documentable>
 extension IterableOfNameableExtension<E extends Nameable> on Iterable<E> {
   Iterable<E> get wherePublic => where((e) => e.isPublic);
 }
+
+extension IterableOfModelElementExtension<E extends ModelElement>
+    on Iterable<E> {
+  Iterable<E> whereDocumentedIn(Library library) =>
+      whereDocumented.where((e) => e.canonicalLibrary == library);
+}

--- a/test/end2end/model_special_cases_test.dart
+++ b/test/end2end/model_special_cases_test.dart
@@ -370,27 +370,6 @@ void main() {
       expect(IAmAClassWithCategories.displayedCategories, isEmpty);
     });
 
-    // For flutter, we allow reexports to pick up categories from the package
-    // they are exposed in.
-    test('Verify that reexported classes pick up categories', () {
-      var IAmAClassWithCategoriesReexport = ginormousPackageGraph.localPackages
-          .firstWhere((p) => p.name == 'test_package')
-          .libraries
-          .wherePublic
-          .named('fake')
-          .classes
-          .wherePublic
-          .named('IAmAClassWithCategories');
-      expect(IAmAClassWithCategoriesReexport.hasCategoryNames, isTrue);
-      expect(IAmAClassWithCategoriesReexport.categories, hasLength(1));
-      expect(IAmAClassWithCategoriesReexport.categories.first.name,
-          equals('Superb'));
-      expect(IAmAClassWithCategoriesReexport.displayedCategories, isNotEmpty);
-      var category = IAmAClassWithCategoriesReexport.displayedCategories.first;
-      expect(category.categoryIndex, equals(0));
-      expect(category.isDocumented, isTrue);
-    });
-
     test('Verify that multiple categories work correctly', () {
       var fakeLibrary = ginormousPackageGraph.localPackages
           .firstWhere((p) => p.name == 'test_package')

--- a/test/search_index_test.dart
+++ b/test/search_index_test.dart
@@ -6,6 +6,7 @@ import 'dart:convert';
 
 import 'package:dartdoc/src/generator/generator_utils.dart';
 import 'package:dartdoc/src/model/model.dart';
+import 'package:dartdoc/src/model_utils.dart';
 import 'package:test/test.dart';
 import 'package:test_reflective_loader/test_reflective_loader.dart';
 
@@ -50,8 +51,16 @@ class SearchIndexTest extends DartdocTestBase {
         ...library.packageGraph.libraries
             .where((l) => l.name.startsWith('dart:')),
     ];
+    // TODO(srawlins): `Library.allModelElements` is not a great fit for this
+    // test, because we can only calculate the `href` properties of canonical,
+    // documented elements. But this filter gets us approximately what we want.
+    var elements = libraries.expand((library) => library.allModelElements
+        .whereDocumentedIn(library)
+        .where((e) => e is ContainerMember
+            ? e.enclosingElement.canonicalLibrary != null
+            : e.canonicalLibrary != null));
     var text = generateSearchIndexJson(
-      libraries.expand((library) => library.allModelElements),
+      elements,
       packageOrder: actAsFlutter ? const ['flutter', 'Dart'] : const [],
       pretty: false,
     );

--- a/test/src/utils.dart
+++ b/test/src/utils.dart
@@ -380,12 +380,12 @@ extension IterableStringExtension on Iterable<String> {
 
 extension PackageExtension on Package {
   /// Gathers all extensions found across a package.
-  Iterable<Extension> get extensions =>
-      libraries.expand((library) => library.extensions.whereDocumented);
+  Iterable<Extension> get extensions => libraries.wherePublic
+      .expand((library) => library.extensions.whereDocumented);
 
   /// Gathers all functions found across a package.
-  Iterable<ModelFunction> get functions =>
-      libraries.expand((library) => library.functions.whereDocumented);
+  Iterable<ModelFunction> get functions => libraries.wherePublic
+      .expand((library) => library.functions.whereDocumented);
 }
 
 /// Extension methods just for tests.

--- a/testing/test_package/lib/fake.dart
+++ b/testing/test_package/lib/fake.dart
@@ -1163,17 +1163,6 @@ abstract class MIEEThing<K, V> {
   void operator []=(K key, V value);
 }
 
-abstract class _NonCanonicalToolUser {
-  /// Invokes a tool without the $INPUT token or args.
-  ///
-  /// {@tool drill}
-  /// Some text in the drill that references [noInvokeTool].
-  /// {@end-tool}
-  void invokeToolNonCanonical();
-}
-
-abstract class CanonicalToolUser extends _NonCanonicalToolUser {}
-
 abstract class ImplementingClassForTool {
   /// Invokes a tool from inherited documentation via `implemented`
   ///

--- a/testing/test_package/lib/src/tool.dart
+++ b/testing/test_package/lib/src/tool.dart
@@ -1,14 +1,5 @@
 library test_package.tool;
 
-abstract class PrivateLibraryToolUser {
-  /// Invokes a tool from a private library.
-  ///
-  /// {@tool drill}
-  /// Some text in the drill.
-  /// {@end-tool}
-  void invokeToolPrivateLibrary();
-}
-
 abstract class GenericSuperProperty<T> {}
 
 abstract class GenericSuperValue<T> extends GenericSuperProperty<T> {}

--- a/tool/task.dart
+++ b/tool/task.dart
@@ -913,15 +913,18 @@ Future<void> validateSdkDocs() async {
   }
   print('$foundSubLibCount index.html dart: entries in categories found');
 
-  // check for the existence of certain files/dirs
-  var libsCount =
-      _sdkDocsDir.listSync().where((fs) => fs.path.contains('dart-')).length;
-  if (!expectedTotalCounts.contains(libsCount)) {
-    throw StateError('Docs not generated for all the SDK libraries; expected '
-        '$expectedTotalCounts directories, but $libsCount directories were '
-        'generated');
+  // Check for the existence of certain files and directories.
+  var libraries =
+      _sdkDocsDir.listSync().where((fs) => fs.path.contains('dart-'));
+  var libraryCount = libraries.length;
+  if (!expectedTotalCounts.contains(libraryCount)) {
+    var libraryNames =
+        libraries.map((l) => "'${path.basename(l.path)}'").join(', ');
+    throw StateError('Unexpected docs generated for SDK libraries; expected '
+        '$expectedTotalCounts directories, but $libraryCount directories were '
+        'generated: $libraryNames');
   }
-  print("Found $libsCount 'dart:' libraries");
+  print("Found $libraryCount 'dart:' libraries");
 
   var futureConstructorFile =
       File(path.join(_sdkDocsDir.path, 'dart-async', 'Future', 'Future.html'));


### PR DESCRIPTION
Fixes https://github.com/dart-lang/dartdoc/issues/3748. Work towards https://github.com/dart-lang/dartdoc/issues/2021.

This change removes duplication of elements that are declared in one library and exported in another.

The main change that deduplicates library elements is splitting `Library.exportedAndLocalElements` into `Library._localElements` and `Library._exportedElements`, and then `Library._elementsOfType` into `Library._localElementsOfType` and `Library._exportedElementsOfType`. These two lists are separated so that the ModelElements can be instantiated or fetched from the package graph with the "correct" enclosing library. `_localElementsOfType` fetches elements via `getModelFor(e, this)`, and `exportedElementsOfType` fetches elements via `getModelFor(e, packageGraph.getModelForElement(library))`.

Other changes to support this:

* Use an element's `canonicalLibrary` instead of `library` in many places, like in each override of `filePath`, and in GeneratorFrontEnd.
* There is no longer a distinction between an element's library and its _defining_ library. `ModelElement.definingLibrary` is removed.
* Introduce a `canonicalizedQualifiedName` to use when creating `index.json`, which is the same as `fullyQualifiedName` but using the element's canonical library.
* The global map of all elements was keyed on a 3-element key, which can now be a 2-element key (ConstructedModelElementsKey).
* Remove an assert in Inheritable that no longer makes sense with this new model.


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
