### PR TITLE
Tidy some tests after stable Dart release

### DIFF
--- a/test/class_modifiers_test.dart
+++ b/test/class_modifiers_test.dart
@@ -27,12 +27,6 @@ class ClassModifiersTest extends DartdocTestBase {
   @override
   String get libraryName => 'class_modifiers';
 
-  @override
-  String get sdkConstraint => '>=3.0.0-0.0-dev <4.0.0';
-
-  @override
-  List<String> get experiments => ['class-modifiers', 'sealed-class'];
-
   /// From the table in the class modifiers feature specification.
   void test_tableOfModifiers() async {
     var library = await bootPackageWithLibrary('''

--- a/test/constant_values_test.dart
+++ b/test/constant_values_test.dart
@@ -11,9 +11,6 @@ import 'src/utils.dart';
 void main() {
   defineReflectiveSuite(() {
     defineReflectiveTests(ConstantValuesTest);
-    if (namedArgumentsAnywhereAllowed) {
-      defineReflectiveTests(ConstantValuesWithNamedArgumentsAnywhereTest);
-    }
     defineReflectiveTests(HiddenConstantsTest);
   });
 }
@@ -132,15 +129,6 @@ const aTearOffUnnamedConstructorArgsTypedef = Ft<String>.new;
     expect(aTearOffUnnamedConstructorArgsTypedef.constantValue,
         equals('Ft&lt;String&gt;.new'));
   }
-}
-
-@reflectiveTest
-class ConstantValuesWithNamedArgumentsAnywhereTest extends DartdocTestBase {
-  @override
-  String get libraryName => 'constant_values';
-
-  @override
-  String get sdkConstraint => '>=2.17.0 <3.0.0';
 
   void test_namedParametersInConstInvocationValue_specifiedLast() async {
     var library = await bootPackageWithLibrary('''

--- a/test/extension_types_test.dart
+++ b/test/extension_types_test.dart
@@ -19,13 +19,7 @@ void main() {
 @reflectiveTest
 class ExtensionTypesTest extends DartdocTestBase {
   @override
-  List<String> get experiments => ['inline-class'];
-
-  @override
   String get libraryName => 'extension_types';
-
-  @override
-  String get sdkConstraint => '>=3.3.0 <4.0.0';
 
   // TODO(srawlins): Test superinterfaces, references to members which exist via
   // `implements`, references to primary constructor.

--- a/test/record_test.dart
+++ b/test/record_test.dart
@@ -21,9 +21,6 @@ class RecordTest extends DartdocTestBase {
   @override
   String get libraryName => 'records';
 
-  @override
-  String get sdkConstraint => '>=3.0.0 <4.0.0';
-
   void test_noFields() async {
     var library = await bootPackageWithLibrary('''
 void f(() r) {}

--- a/test/typedef_test.dart
+++ b/test/typedef_test.dart
@@ -21,13 +21,7 @@ void main() {
 @reflectiveTest
 class TypedefTest extends DartdocTestBase {
   @override
-  List<String> get experiments => ['inline-class'];
-
-  @override
   String get libraryName => 'typedefs';
-
-  @override
-  String get sdkConstraint => '>=3.3.0 <4.0.0';
 
   void test_class_basic() async {
     var library = await bootPackageWithLibrary('''

--- a/tool/task.dart
+++ b/tool/task.dart
@@ -814,7 +814,7 @@ Rebuild them with "dart tool/task.dart build" and check the results in.
 bool get _analyzerInUseIsTarget {
   // TODO(srawlins): Add validation that this number falls within the
   // constraints of the analyzer package which are set in `pubspec.yaml`.
-  const analyzerTarget = '6.5.2';
+  const analyzerTarget = '6.8.0';
 
   var lockfilePath = path.join(Directory.current.path, 'pubspec.lock');
   var lockfile = loadYaml(File(lockfilePath).readAsStringSync()) as YamlMap;


### PR DESCRIPTION
analyzer 6.8.0 is the version I get with `dart pub get` using Dart 3.5.0.

The rest of the tidying is removing old experiments.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
