### PR TITLE
Refactor "could apply" logic for extensions

### DIFF
--- a/lib/src/generator/templates.aot_renderers_for_html.dart
+++ b/lib/src/generator/templates.aot_renderers_for_html.dart
@@ -690,15 +690,10 @@ String renderExtension<T extends Extension>(ExtensionTemplateData<T> context0) {
       <dl class="dl-horizontal">
         <dt>on</dt>
         <dd>
-          <ul class="comma-separated clazz-relationships">''');
-  var context3 = context2.extendedType;
-  buffer.writeln();
-  buffer.write('''
-              <li>''');
-  buffer.write(context3.linkedName);
-  buffer.write('''</li>''');
-  buffer.writeln();
-  buffer.write('''
+          <ul class="comma-separated clazz-relationships">
+            <li>''');
+  buffer.write(context2.extendedElement.linkedName);
+  buffer.write('''</li>
           </ul>
         </dd>
       </dl>
@@ -720,7 +715,7 @@ String renderExtension<T extends Extension>(ExtensionTemplateData<T> context0) {
   buffer.write(_renderExtension_partial_static_methods_10(context2));
   buffer.write('\n    ');
   buffer.write(_renderExtension_partial_static_constants_11(context2));
-  var context4 = context0.extension;
+  var context3 = context0.extension;
   buffer.writeln();
   buffer.write('''
 
@@ -1397,7 +1392,7 @@ String renderMethod(MethodTemplateData context0) {
     buffer.write(' ');
     buffer.writeEscaped(context0.parent!.kind.toString());
     buffer.write(''' on ''');
-    buffer.write(context0.parentAsExtension.extendedType.linkedName);
+    buffer.write(context0.parentAsExtension.extendedElement.linkedName);
     buffer.write('''</h5>''');
   }
   if (!context0.isParentExtension) {
@@ -1626,7 +1621,7 @@ String renderProperty(PropertyTemplateData context0) {
     buffer.write(' ');
     buffer.writeEscaped(context0.parent!.kind.toString());
     buffer.write(''' on ''');
-    buffer.write(context0.parentAsExtension.extendedType.linkedName);
+    buffer.write(context0.parentAsExtension.extendedElement.linkedName);
     buffer.write('''</h5>''');
   }
   if (!context0.isParentExtension) {
@@ -3645,7 +3640,7 @@ String _deduplicated_lib_templates__extension_html(Extension context0) {
   buffer.write(context0.linkedName);
   buffer.write('''</span>
   on ''');
-  buffer.write(context0.extendedType.linkedName);
+  buffer.write(context0.extendedElement.linkedName);
   buffer.write('\n  ');
   buffer.write(
       __deduplicated_lib_templates__extension_html_partial_categorization_0(

--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -3467,18 +3467,6 @@ class _Renderer_DefinedElementType extends RendererBase<DefinedElementType> {
                         parent: r);
                   },
                 ),
-                'instantiatedType': Property(
-                  getValue: (CT_ c) => c.instantiatedType,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(c, remainingNames, 'DartType'),
-                  isNullValue: (CT_ c) => false,
-                  renderValue: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    renderSimple(c.instantiatedType, ast, r.template, sink,
-                        parent: r, getters: _invisibleGetters['DartType']!);
-                  },
-                ),
                 'isPublic': Property(
                   getValue: (CT_ c) => c.isPublic,
                   renderVariable: (CT_ c, Property<CT_> self,
@@ -4083,18 +4071,6 @@ class _Renderer_ElementType extends RendererBase<ElementType> {
                         parent: r);
                   },
                 ),
-                'instantiatedType': Property(
-                  getValue: (CT_ c) => c.instantiatedType,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(c, remainingNames, 'DartType'),
-                  isNullValue: (CT_ c) => false,
-                  renderValue: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    renderSimple(c.instantiatedType, ast, r.template, sink,
-                        parent: r, getters: _invisibleGetters['DartType']!);
-                  },
-                ),
                 'isTypedef': Property(
                   getValue: (CT_ c) => c.isTypedef,
                   renderVariable: (CT_ c, Property<CT_> self,
@@ -4611,8 +4587,8 @@ class _Renderer_Extension extends RendererBase<Extension> {
                         parent: r);
                   },
                 ),
-                'extendedType': Property(
-                  getValue: (CT_ c) => c.extendedType,
+                'extendedElement': Property(
+                  getValue: (CT_ c) => c.extendedElement,
                   renderVariable:
                       (CT_ c, Property<CT_> self, List<String> remainingNames) {
                     if (remainingNames.isEmpty) {
@@ -4629,7 +4605,8 @@ class _Renderer_Extension extends RendererBase<Extension> {
                   isNullValue: (CT_ c) => false,
                   renderValue: (CT_ c, RendererBase<CT_> r,
                       List<MustachioNode> ast, StringSink sink) {
-                    _render_ElementType(c.extendedType, ast, r.template, sink,
+                    _render_ElementType(
+                        c.extendedElement, ast, r.template, sink,
                         parent: r);
                   },
                 ),

--- a/lib/src/model/inheriting_container.dart
+++ b/lib/src/model/inheriting_container.dart
@@ -271,7 +271,7 @@ abstract class InheritingContainer extends Container {
   /// defined by [element] can exist where this extension applies, not including
   /// any extension that applies to every type.
   late final List<Extension> potentiallyApplicableExtensionsSorted =
-      packageGraph.extensions.whereDocumented
+      packageGraph.extensions
           .where((e) => !e.alwaysApplies)
           .where((e) => e.couldApplyTo(this))
           .toList(growable: false)

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -160,7 +160,9 @@ class PackageGraph with CommentReferable, Nameable {
         _addToImplementers(library.classesAndExceptions);
         _addToImplementers(library.mixins);
         _addToImplementers(library.extensionTypes);
-        _extensions.addAll(library.extensions);
+        if (library.isCanonical) {
+          _extensions.addAll(library.extensions.whereDocumented);
+        }
       }
       if (package.isLocal && !package.hasPublicLibraries) {
         package.warn(PackageWarning.noDocumentableLibrariesInPackage);
@@ -383,7 +385,7 @@ class PackageGraph with CommentReferable, Nameable {
               clazz.definingContainer.hashCode);
 
   /// A list of extensions that exist in the package graph.
-  final List<Extension> _extensions = [];
+  final Set<Extension> _extensions = {};
 
   /// Name of the default package.
   String get defaultPackageName => packageMeta.name;

--- a/lib/templates/_extension.html
+++ b/lib/templates/_extension.html
@@ -1,6 +1,6 @@
 <dt id="{{ htmlId }}">
   <span class="name {{ #isDeprecated }}deprecated{{ /isDeprecated }}">{{{ linkedName }}}</span>
-  on {{{ extendedType.linkedName }}}
+  on {{{ extendedElement.linkedName }}}
   {{ >categorization }}
 </dt>
 <dd>

--- a/lib/templates/extension.html
+++ b/lib/templates/extension.html
@@ -15,9 +15,7 @@
         <dt>on</dt>
         <dd>
           <ul class="comma-separated clazz-relationships">
-            {{ #extendedType }}
-              <li>{{{ linkedName }}}</li>
-            {{ /extendedType }}
+            <li>{{{ extendedElement.linkedName }}}</li>
           </ul>
         </dd>
       </dl>

--- a/lib/templates/method.html
+++ b/lib/templates/method.html
@@ -24,7 +24,7 @@
   <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
     {{ >search_sidebar }}
     {{ #isParentExtension }}
-    <h5>{{ parent.name }} {{ parent.kind }} on {{{ parentAsExtension.extendedType.linkedName }}}</h5>
+    <h5>{{ parent.name }} {{ parent.kind }} on {{{ parentAsExtension.extendedElement.linkedName }}}</h5>
     {{ /isParentExtension }}
     {{ ^isParentExtension }}
     <h5>{{ parent.name }} {{ parent.kind }}</h5>

--- a/lib/templates/property.html
+++ b/lib/templates/property.html
@@ -36,7 +36,7 @@
 <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
   {{ >search_sidebar }}
   {{ #isParentExtension }}
-  <h5>{{ parent.name }} {{ parent.kind }} on {{{ parentAsExtension.extendedType.linkedName }}}</h5>
+  <h5>{{ parent.name }} {{ parent.kind }} on {{{ parentAsExtension.extendedElement.linkedName }}}</h5>
   {{ /isParentExtension }}
   {{ ^isParentExtension }}
   <h5>{{ parent.name }} {{ parent.kind }}</h5>

--- a/test/classes_test.dart
+++ b/test/classes_test.dart
@@ -19,6 +19,60 @@ class ClassesTest extends DartdocTestBase {
   @override
   String get libraryName => 'classes';
 
+  void test_availableExtensions_onClass() async {
+    var library = await bootPackageWithLibrary('''
+class C {}
+extension Ex on C {}
+''');
+
+    var f = library.classes.named('C');
+    expect(
+      f.potentiallyApplicableExtensionsSorted,
+      contains(library.extensions.named('Ex')),
+    );
+  }
+
+  void test_availableExtensions_onClassWithInstantiatedType() async {
+    var library = await bootPackageWithLibrary('''
+class C<T> {}
+extension Ex on C<int> {}
+''');
+
+    var f = library.classes.named('C');
+    expect(
+      f.potentiallyApplicableExtensionsSorted,
+      contains(library.extensions.named('Ex')),
+    );
+  }
+
+  void test_availableExtensions_onSubtypeOfClass() async {
+    var library = await bootPackageWithLibrary('''
+class C {}
+class D extends C {}
+extension Ex on C {}
+''');
+
+    var f = library.classes.named('D');
+    expect(
+      f.potentiallyApplicableExtensionsSorted,
+      contains(library.extensions.named('Ex')),
+    );
+  }
+
+  void test_availableExtensions_onInstantiatedSubtypeOfClass() async {
+    var library = await bootPackageWithLibrary('''
+class C<T> {}
+class D<T> extends C<T> {}
+extension Ex on C<int> {}
+''');
+
+    var f = library.classes.named('D');
+    expect(
+      f.potentiallyApplicableExtensionsSorted,
+      contains(library.extensions.named('Ex')),
+    );
+  }
+
   void test_publicInterfaces_direct() async {
     var library = await bootPackageWithLibrary('''
 class A {}

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -18,7 +18,6 @@ import 'package:dartdoc/src/model_utils.dart';
 import 'package:dartdoc/src/package_config_provider.dart';
 import 'package:dartdoc/src/package_meta.dart';
 import 'package:dartdoc/src/render/parameter_renderer.dart';
-import 'package:dartdoc/src/special_elements.dart';
 import 'package:dartdoc/src/warnings.dart';
 import 'package:test/test.dart';
 
@@ -2834,35 +2833,6 @@ void main() async {
           orderedEquals([uphill]));
     });
 
-    test('extensions on special types work', () {
-      Extension extensionOnDynamic,
-          extensionOnVoid,
-          extensionOnNull,
-          extensionOnTypeParameter;
-      var object = packageGraph.specialClasses[SpecialClass.object]!;
-      Extension getExtension(String name) => fakeLibrary.extensions.named(name);
-
-      extensionOnDynamic = getExtension('ExtensionOnDynamic');
-      extensionOnNull = getExtension('ExtensionOnNull');
-      extensionOnVoid = getExtension('ExtensionOnVoid');
-      extensionOnTypeParameter = getExtension('ExtensionOnTypeParameter');
-
-      expect(extensionOnDynamic.couldApplyTo(object), isTrue);
-      expect(extensionOnVoid.couldApplyTo(object), isTrue);
-      expect(extensionOnNull.couldApplyTo(object), isFalse);
-      expect(extensionOnTypeParameter.couldApplyTo(object), isTrue);
-
-      expect(extensionOnDynamic.alwaysApplies, isTrue);
-      expect(extensionOnVoid.alwaysApplies, isTrue);
-      expect(extensionOnNull.alwaysApplies, isFalse);
-      expect(extensionOnTypeParameter.alwaysApplies, isTrue);
-
-      // Even though it does have extensions that could apply to it,
-      // extensions that apply to [Object] should always be hidden from
-      // documentation.
-      expect(object.hasPotentiallyApplicableExtensions, isFalse);
-    });
-
     test('applicableExtensions include those from implements & mixins', () {
       Extension extensionCheckLeft,
           extensionCheckRight,
@@ -2953,7 +2923,7 @@ void main() async {
     });
 
     test('has extended type', () {
-      expect(ext.extendedType.name, equals('Apple'));
+      expect(ext.extendedElement.name, equals('Apple'));
     });
 
     test('extension name with generics', () {
@@ -2964,7 +2934,7 @@ void main() async {
     });
 
     test('extended type has generics', () {
-      expect(fancyList.extendedType.nameWithGenerics,
+      expect(fancyList.extendedElement.nameWithGenerics,
           equals('List&lt;<wbr><span class="type-parameter">Z</span>&gt;'));
     });
 

--- a/test/extensions_test.dart
+++ b/test/extensions_test.dart
@@ -23,6 +23,156 @@ class ExtensionMethodsTest extends DartdocTestBase {
   @override
   String get libraryName => 'extension_methods';
 
+  void test_applicability_extensionOnClass_couldApplyToSameClass() async {
+    var library = await bootPackageWithLibrary('''
+class C {}
+extension Ex on C {}
+''');
+    var ex = library.extensions.named('Ex');
+    expect(ex.couldApplyTo(library.classes.named('C')), isTrue);
+  }
+
+  void test_applicability_extensionOnClass_couldApplyToDifferentClass() async {
+    var library = await bootPackageWithLibrary('''
+class C {}
+extension Ex on int {}
+''');
+    var ex = library.extensions.named('Ex');
+    expect(ex.couldApplyTo(library.classes.named('C')), isFalse);
+  }
+
+  void test_applicability_extensionOnClass_couldApplyToSubclass() async {
+    var library = await bootPackageWithLibrary('''
+class C {}
+class D extends C {}
+extension Ex on C {}
+''');
+    var ex = library.extensions.named('Ex');
+    expect(ex.couldApplyTo(library.classes.named('D')), isTrue);
+  }
+
+  void test_applicability_extensionOnClass_couldApplyToInstantiation() async {
+    var library = await bootPackageWithLibrary('''
+class C<T> {}
+extension Ex on C<int> {}
+''');
+    var ex = library.extensions.named('Ex');
+    expect(ex.couldApplyTo(library.classes.named('C')), isTrue);
+  }
+
+  void
+      test_applicability_extensionOnClass_couldApplyToSubclassInstantiation() async {
+    var library = await bootPackageWithLibrary('''
+class C<T> {}
+class D<T> extends C<T> {}
+extension Ex on C<int> {}
+''');
+    var ex = library.extensions.named('Ex');
+    expect(ex.couldApplyTo(library.classes.named('D')), isTrue);
+  }
+
+  void
+      test_applicability_extensionOnClass_couldApplyToSubclassInstantiation2() async {
+    var library = await bootPackageWithLibrary('''
+class C<T> {}
+class D extends C<String> {}
+extension Ex on C<int> {}
+''');
+    var ex = library.extensions.named('Ex');
+    expect(ex.couldApplyTo(library.classes.named('D')), isFalse);
+  }
+
+  void test_applicability_extensionOnObject_couldApplyToClass() async {
+    var library = await bootPackageWithLibrary('''
+extension Ex on Object {}
+class C {}
+''');
+    var ex = library.extensions.named('Ex');
+    expect(ex.couldApplyTo(library.classes.named('C')), isTrue);
+  }
+
+  void test_applicability_extensionOnObject_couldApplyToMixin() async {
+    var library = await bootPackageWithLibrary('''
+extension Ex on Object {}
+mixin M {}
+''');
+    var ex = library.extensions.named('Ex');
+    expect(ex.couldApplyTo(library.mixins.named('M')), isTrue);
+  }
+
+  void test_applicability_extensionOnDynamic_couldApplyToClass() async {
+    var library = await bootPackageWithLibrary('''
+extension Ex on dynamic {}
+class C {}
+''');
+    var ex = library.extensions.named('Ex');
+    expect(ex.couldApplyTo(library.classes.named('C')), isTrue);
+  }
+
+  void test_applicability_extensionOnDynamic_alwaysApplies() async {
+    var library = await bootPackageWithLibrary('''
+extension Ex on dynamic {}
+''');
+    expect(library.extensions.named('Ex').alwaysApplies, isTrue);
+  }
+
+  void test_applicability_extensionOnVoid_couldApplyToClass() async {
+    var library = await bootPackageWithLibrary('''
+extension Ex on void {}
+class C {}
+''');
+    var ex = library.extensions.named('Ex');
+    expect(ex.couldApplyTo(library.classes.named('C')), isTrue);
+  }
+
+  void test_applicability_extensionOnNull_couldApplyToClass() async {
+    var library = await bootPackageWithLibrary('''
+extension Ex on Null {}
+class C {}
+''');
+    var ex = library.extensions.named('Ex');
+    expect(ex.couldApplyTo(library.classes.named('C')), isFalse);
+  }
+
+  void test_applicability_extensionOnTypeVariable_couldApplyToClass() async {
+    var library = await bootPackageWithLibrary('''
+extension Ex<T> on T {}
+class C {}
+''');
+    var ex = library.extensions.named('Ex');
+    expect(ex.couldApplyTo(library.classes.named('C')), isTrue);
+  }
+
+  void test_applicability_extensionOnTypeVariable_alwaysApplies() async {
+    var library = await bootPackageWithLibrary('''
+extension Ex<T> on T {}
+class C {}
+''');
+    var ex = library.extensions.named('Ex');
+    expect(ex.alwaysApplies, isTrue);
+  }
+
+  void
+      test_applicability_extensionOnTypeVariableWithBound_couldApplyToSubtypeOfBound() async {
+    var library = await bootPackageWithLibrary('''
+class C {}
+class D extends C {}
+extension Ex<T extends C> on T {}
+''');
+    var ex = library.extensions.named('Ex');
+    expect(ex.couldApplyTo(library.classes.named('D')), isTrue);
+  }
+
+  void
+      test_applicability_extensionOnTypeVariableWithBound_couldApplyToUnrelated() async {
+    var library = await bootPackageWithLibrary('''
+extension Ex<T extends num> on T {}
+class C {}
+''');
+    var ex = library.extensions.named('Ex');
+    expect(ex.couldApplyTo(library.classes.named('C')), isFalse);
+  }
+
   void test_referenceToExtension() async {
     var library = await bootPackageWithLibrary('''
 extension Ex on int {}

--- a/testing/test_package/lib/fake.dart
+++ b/testing/test_package/lib/fake.dart
@@ -1196,24 +1196,6 @@ extension DoSomething2X<A, B, R> on Function1<A, Function1<B, R>> {
   Function2<A, B, R> something() => (A first, B second) => this(first)(second);
 }
 
-/// Extensions might exist on types defined by the language.
-extension ExtensionOnDynamic on dynamic {
-  void youCanAlwaysCallMe() {}
-}
-
-extension ExtensionOnVoid on void {
-  void youCanStillAlwaysCallMe() {}
-}
-
-extension ExtensionOnNull on Null {
-  void youCanOnlyCallMeOnNulls() {}
-}
-
-/// Extensions might exist on unbound type parameters.
-extension ExtensionOnTypeParameter<T> on T {
-  T aFunctionReturningT(T other) => other;
-}
-
 abstract class IntermediateAbstract extends Object {
   /// This is an override.
   @override


### PR DESCRIPTION
This logic was implemented in a few places between Extension and ElementType (and subtypes). We don't need any logic to live in ElementTypes though, since any calculations that need to be made regarding DartTypes or InterfaceTypes can be made in Extension (`alwaysApplies` and `couldApplyTo`). This fixes https://github.com/dart-lang/dartdoc/issues/3846 and dramatically simplifies the implementation. Also:

* Rename `Extension.extendedType` to `Extension.extendedElement`.
* Change `PackageGraph._extensions` to a Set, to remove duplication in multiple canonical libraries.
* Introduce a classes test.
* Delete some redundant end2end testing code.

- Thanks for your contribution! Please replace this text with a description of what this PR is changing or adding and why, list any relevant issues, and review the contribution guidelines below.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
