### PR TITLE
Make getters and setters actually look like their declarations

### DIFF
--- a/lib/src/generator/templates.aot_renderers_for_html.dart
+++ b/lib/src/generator/templates.aot_renderers_for_html.dart
@@ -4743,6 +4743,7 @@ String _deduplicated_lib_templates__accessor_getter_html(
     buffer.write('''      <span class="returntype">''');
     buffer.write(context1.modelType.returnType.linkedName);
     buffer.write('''</span>
+      get
       ''');
     buffer.write(
         __deduplicated_lib_templates__accessor_getter_html_partial_name_summary_1(
@@ -4869,27 +4870,30 @@ String _deduplicated_lib_templates__accessor_setter_html(
         __deduplicated_lib_templates__accessor_setter_html_partial_annotations_0(
             context1));
     buffer.writeln();
-    buffer.write('''      <span class="returntype">void</span>
-      ''');
-    buffer.write(
-        __deduplicated_lib_templates__accessor_setter_html_partial_name_summary_1(
-            context1));
-    buffer.write('''<span class="signature">(<wbr>''');
+    buffer.write('''      set
+      <span class="name ''');
+    if (context1.isDeprecated) {
+      buffer.write('''deprecated''');
+    }
+    buffer.write('''">''');
+    buffer.writeEscaped(context1.definingCombo.name);
+    buffer.write('''</span>
+      <span class="signature">(<wbr>''');
     buffer.write(context1.linkedParamsNoMetadata);
     buffer.write(''')</span>
       ''');
     buffer.write(
-        __deduplicated_lib_templates__accessor_setter_html_partial_attributes_2(
+        __deduplicated_lib_templates__accessor_setter_html_partial_attributes_1(
             context1));
     buffer.writeln();
     buffer.write('''    </section>
     ''');
     buffer.write(
-        __deduplicated_lib_templates__accessor_setter_html_partial_documentation_3(
+        __deduplicated_lib_templates__accessor_setter_html_partial_documentation_2(
             context1));
     buffer.write('\n    ');
     buffer.write(
-        __deduplicated_lib_templates__accessor_setter_html_partial_source_code_4(
+        __deduplicated_lib_templates__accessor_setter_html_partial_source_code_3(
             context1));
     buffer.writeln();
     buffer.write('''  </section>''');
@@ -4921,25 +4925,7 @@ String __deduplicated_lib_templates__accessor_setter_html_partial_annotations_0(
   return buffer.toString();
 }
 
-String
-    __deduplicated_lib_templates__accessor_setter_html_partial_name_summary_1(
-        Accessor context1) {
-  final buffer = StringBuffer();
-  if (context1.isConst) {
-    buffer.write('''const ''');
-  }
-  buffer.write('''<span class="name ''');
-  if (context1.isDeprecated) {
-    buffer.write('''deprecated''');
-  }
-  buffer.write('''">''');
-  buffer.writeEscaped(context1.name);
-  buffer.write('''</span>''');
-
-  return buffer.toString();
-}
-
-String __deduplicated_lib_templates__accessor_setter_html_partial_attributes_2(
+String __deduplicated_lib_templates__accessor_setter_html_partial_attributes_1(
     Accessor context1) {
   final buffer = StringBuffer();
   if (context1.hasAttributes) {
@@ -4953,7 +4939,7 @@ String __deduplicated_lib_templates__accessor_setter_html_partial_attributes_2(
 }
 
 String
-    __deduplicated_lib_templates__accessor_setter_html_partial_documentation_3(
+    __deduplicated_lib_templates__accessor_setter_html_partial_documentation_2(
         Accessor context1) {
   final buffer = StringBuffer();
   if (context1.hasDocumentation) {
@@ -4969,7 +4955,7 @@ String
   return buffer.toString();
 }
 
-String __deduplicated_lib_templates__accessor_setter_html_partial_source_code_4(
+String __deduplicated_lib_templates__accessor_setter_html_partial_source_code_3(
     Accessor context1) {
   final buffer = StringBuffer();
   if (context1.hasSourceCode) {

--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -6585,6 +6585,27 @@ class _Renderer_GetterSetterCombo extends RendererBase<GetterSetterCombo> {
                         parent: r);
                   },
                 ),
+                'name': Property(
+                  getValue: (CT_ c) => c.name,
+                  renderVariable:
+                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
+                    if (remainingNames.isEmpty) {
+                      return self.getValue(c).toString();
+                    }
+                    var name = remainingNames.first;
+                    var nextProperty =
+                        _Renderer_String.propertyMap().getValue(name);
+                    return nextProperty.renderVariable(
+                        self.getValue(c) as String,
+                        nextProperty,
+                        [...remainingNames.skip(1)]);
+                  },
+                  isNullValue: (CT_ c) => false,
+                  renderValue: (CT_ c, RendererBase<CT_> r,
+                      List<MustachioNode> ast, StringSink sink) {
+                    _render_String(c.name, ast, r.template, sink, parent: r);
+                  },
+                ),
                 'oneLineDoc': Property(
                   getValue: (CT_ c) => c.oneLineDoc,
                   renderVariable:
@@ -16013,6 +16034,7 @@ const _invisibleGetters = {
     'isPublic',
     'linkedParamsNoMetadata',
     'modelType',
+    'name',
     'oneLineDoc',
     'parameters',
     'readOnly',

--- a/lib/src/model/getter_setter_combo.dart
+++ b/lib/src/model/getter_setter_combo.dart
@@ -57,6 +57,11 @@ mixin GetterSetterCombo on ModelElement {
   bool get isInherited;
 
   @override
+  // Food for mustachio; because this is a mixin, mustachio can't figure out
+  // that this implicitly has a `name` property.
+  String get name;
+
+  @override
   String get fileName => isConst ? '$name-constant.html' : '$name.html';
 
   /// Whether this has a constant value which should be displayed.

--- a/lib/templates/_accessor_getter.html
+++ b/lib/templates/_accessor_getter.html
@@ -1,9 +1,9 @@
 {{ #getter }}
   <section id="getter">
-
     <section class="multi-line-signature">
       {{ >annotations }}
       <span class="returntype">{{{ modelType.returnType.linkedName }}}</span>
+      get
       {{ >name_summary }}
       {{ >attributes }}
     </section>

--- a/lib/templates/_accessor_setter.html
+++ b/lib/templates/_accessor_setter.html
@@ -3,8 +3,9 @@
 
     <section class="multi-line-signature">
       {{ >annotations }}
-      <span class="returntype">void</span>
-      {{ >name_summary }}<span class="signature">(<wbr>{{{ linkedParamsNoMetadata }}})</span>
+      set
+      <span class="name {{#isDeprecated}}deprecated{{/isDeprecated}}">{{ definingCombo.name }}</span>
+      <span class="signature">(<wbr>{{{ linkedParamsNoMetadata }}})</span>
       {{ >attributes }}
     </section>
 

--- a/test/templates/field_test.dart
+++ b/test/templates/field_test.dart
@@ -91,6 +91,93 @@ extension type ET(
     );
   }
 
+  void test_getter_signature() async {
+    await createPackageWithLibrary('''
+class C {
+  int get f1 => 1;
+}
+''');
+    var f1Lines = readLines(['lib', 'C', 'f1.html']);
+    f1Lines.expectMainContentContainsAllInOrder(
+      [
+        matches('<h1><span class="kind-property">f1</span> property'),
+        matches('<section class="multi-line-signature">'),
+        matches('<span class="returntype">int</span>'),
+        matches('get'),
+        matches('<span class="name ">f1</span>'),
+      ],
+    );
+  }
+
+  void test_getter_overridingProperty_signature() async {
+    await createPackageWithLibrary('''
+class C {
+  int f1 = 0;
+}
+class D extends C {
+  @override
+  int get f1 => 1;
+}
+''');
+    var f1Lines = readLines(['lib', 'D', 'f1.html']);
+    f1Lines.expectMainContentContainsAllInOrder(
+      [
+        matches('<h1><span class="kind-property">f1</span> property'),
+        matches('<section class="multi-line-signature">'),
+        matches('<span class="returntype">int</span>'),
+        matches('get'),
+        matches('<span class="name ">f1</span>'),
+      ],
+    );
+  }
+
+  void test_setter_signature() async {
+    await createPackageWithLibrary('''
+class C {
+  set f1(int value) {}
+}
+''');
+    var f1Lines = readLines(['lib', 'C', 'f1.html']);
+    f1Lines.expectMainContentContainsAllInOrder(
+      [
+        matches('<section class="multi-line-signature">'),
+        matches('set'),
+        matches('<span class="name ">f1</span>'),
+        matches(r'<span class="signature">\('
+            '<wbr><span class="parameter" id="f1=-param-value">'
+            '<span class="type-annotation">int</span> '
+            '<span class="parameter-name">value</span>'
+            r'</span>\)'
+            '</span>'),
+      ],
+    );
+  }
+
+  void test_setter_overridingProperty_signature() async {
+    await createPackageWithLibrary('''
+class C {
+  int f1 = 0;
+}
+class D extends C {
+  set f1(int value) {}
+}
+''');
+    var f1Lines = readLines(['lib', 'D', 'f1.html']);
+    f1Lines.expectMainContentContainsAllInOrder(
+      [
+        matches('<section class="multi-line-signature">'),
+        matches('set'),
+        matches('<span class="name ">f1</span>'),
+        matches(r'<span class="signature">\('
+            '<wbr><span class="parameter" id="f1=-param-value">'
+            '<span class="type-annotation">int</span> '
+            '<span class="parameter-name">value</span>'
+            r'</span>\)'
+            '</span>'),
+      ],
+    );
+  }
+
   // TODO(srawlins): Add rendering tests:
   // * how inherited fields look on subclass page ('inherited' feature)
   // * static fields


### PR DESCRIPTION
Fixes https://github.com/dart-lang/dartdoc/issues/1846, almost 6 years old! 😬 

Here's a screenshot of what the new signatures look like, with `get` and `set` (I hate that the single parameter on the setter gets newlined, but that's a different issue. Maybe track https://github.com/dart-lang/dartdoc/issues/3721 for that one.

<img width="357" alt="Screenshot 2024-08-30 at 9 47 25 AM" src="https://github.com/user-attachments/assets/1d83c939-c8c8-4c7f-b099-5611449d0ec3">


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
