### PR TITLE
Apply section styles to divs as well.

### DIFF
--- a/lib/resources/styles.css
+++ b/lib/resources/styles.css
@@ -314,6 +314,8 @@ a {
 }
 
 section {
+  /* Note that the generated HTML for pub packages may have `section` tags
+     transformed into `div` tags. */
   margin-bottom: 36px;
 }
 
@@ -462,7 +464,9 @@ dt.constant + dd p {
 }
 
 /* indents wrapped lines */
-section.summary dt {
+/* Note that the generated HTML for pub packages may have `section` tags
+   transformed into `div` tags, so we have two selectors here. */
+section.summary dt, div.summary dt {
   margin-left: 24px;
   text-indent: -24px;
 }
@@ -820,7 +824,10 @@ ol.breadcrumbs li a {
   font-style: italic;
 }
 
-section.multi-line-signature div.parameters {
+/* Note that the generated HTML for pub packages may have `section` tags
+   transformed into `div` tags, so we have two selectors here. */
+section.multi-line-signature div.parameters,
+div.multi-line-signature div.parameters {
   margin-left: 24px;
 }
 
@@ -1213,7 +1220,9 @@ a.tt-container {
   box-shadow: 3px 3px 5px rgba(0,0,0,0.1);
 }
 
-section#setter {
+/* Note that the generated HTML for pub packages may have `section` tags
+   transformed into `div` tags, so we have two selectors here. */
+section#setter, div#setter {
   border-top: 1px solid #ddd;
   padding-top: 36px;
 }


### PR DESCRIPTION
The pub.dev infrastructure may rewrite `section` HTML tags to be `div` tags, in generated HTML output. While that is going on, we can apply many styles to both `section` and `div` tags.

Fixes https://github.com/dart-lang/dartdoc/issues/3851

See https://github.com/dart-lang/dartdoc/issues/3851#issuecomment-2325078055 for discussion.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
