### PR TITLE
Clean up some sorting, naming, and doc nits

### DIFF
--- a/lib/src/model/accessor.dart
+++ b/lib/src/model/accessor.dart
@@ -26,7 +26,7 @@ class Accessor extends ModelElement {
   /// constructor.
   // TODO(srawlins): This might be super fragile. This field should somehow be
   // initialized by code inside this library.
-  late GetterSetterCombo enclosingCombo;
+  late final GetterSetterCombo enclosingCombo;
 
   Accessor(this.element, super.library, super.packageGraph,
       {ExecutableMember? super.originalMember});
@@ -167,11 +167,21 @@ class Accessor extends ModelElement {
 
 /// A getter or setter that is a member of a [Container].
 class ContainerAccessor extends Accessor with ContainerMember, Inheritable {
+  late final Container _enclosingElement;
+
+  @override
+  final bool isInherited;
+
   ContainerAccessor(super.element, super.library, super.packageGraph,
       [Container? enclosingElement])
       : isInherited = false {
     _enclosingElement = enclosingElement ?? super.enclosingElement as Container;
   }
+
+  ContainerAccessor.inherited(
+      super.element, super.library, super.packageGraph, this._enclosingElement,
+      {super.originalMember})
+      : isInherited = true;
 
   /// The index and values fields are never declared, and must be special cased.
   bool get _isEnumSynthetic =>
@@ -186,18 +196,8 @@ class ContainerAccessor extends Accessor with ContainerMember, Inheritable {
     return super.characterLocation;
   }
 
-  late final Container _enclosingElement;
-
-  @override
-  final bool isInherited;
-
   @override
   bool get isCovariant => isSetter && parameters.first.isCovariant;
-
-  ContainerAccessor.inherited(
-      super.element, super.library, super.packageGraph, this._enclosingElement,
-      {super.originalMember})
-      : isInherited = true;
 
   @override
   Container get enclosingElement => _enclosingElement;

--- a/lib/src/model/inheritable.dart
+++ b/lib/src/model/inheritable.dart
@@ -24,11 +24,10 @@ import 'package:dartdoc/src/special_elements.dart';
 /// place in the documentation, and we pick a canonical class because that's
 /// the one in the public namespace that will be documented.
 mixin Inheritable on ContainerMember {
-  /// True if this [Inheritable] is inherited from a different class.
+  /// Whether this is inherited from a different class or mixin.
   bool get isInherited;
 
-  /// True if this [Inheritable] has a parameter whose type is overridden
-  /// by a subtype.
+  /// Whether this has a parameter whose type is overridden by a subtype.
   bool get isCovariant;
 
   @override

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -771,20 +771,21 @@ class PackageGraph with CommentReferable, Nameable {
           findCanonicalModelElementFor(preferredClass) as Container?;
       if (canonicalClass != null) preferredClass = canonicalClass;
     }
-    var lib = modelElement.canonicalLibrary;
-    if (modelElement is Library) return lib;
+    var library = modelElement.canonicalLibrary;
+    if (modelElement is Library) return library;
 
-    if (lib == null && preferredClass != null) {
-      lib = preferredClass.canonicalLibrary;
+    if (library == null && preferredClass != null) {
+      library = preferredClass.canonicalLibrary;
     }
     // For elements defined in extensions, they are canonical.
     var enclosingElement = element.enclosingElement3;
     if (enclosingElement is ExtensionElement) {
-      lib ??= getModelForElement(enclosingElement.library) as Library?;
+      library ??= getModelForElement(enclosingElement.library) as Library?;
       // TODO(keertip): Find a better way to exclude members of extensions
       // when libraries are specified using the "--include" flag.
-      if (lib != null && lib.isDocumented) {
-        return getModelFor(element, lib, enclosingContainer: preferredClass);
+      if (library != null && library.isDocumented) {
+        return getModelFor(element, library,
+            enclosingContainer: preferredClass);
       }
     }
     // TODO(jcollins-g): The data structures should be changed to eliminate
@@ -796,20 +797,20 @@ class PackageGraph with CommentReferable, Nameable {
       modelElement = getModelForElement(declaration);
       element = modelElement.element;
       canonicalModelElement = _findCanonicalModelElementForAmbiguous(
-          modelElement, lib,
+          modelElement, library,
           preferredClass: preferredClass as InheritingContainer?);
     } else {
-      if (lib != null) {
+      if (library != null) {
         if (element case PropertyInducingElement(:var getter, :var setter)) {
           var getterElement =
-              getter == null ? null : getModelFor(getter, lib) as Accessor;
+              getter == null ? null : getModelFor(getter, library) as Accessor;
           var setterElement =
-              setter == null ? null : getModelFor(setter, lib) as Accessor;
+              setter == null ? null : getModelFor(setter, library) as Accessor;
           canonicalModelElement = getModelForPropertyInducingElement(
-              element, lib,
+              element, library,
               getter: getterElement, setter: setterElement);
         } else {
-          canonicalModelElement = getModelFor(element, lib);
+          canonicalModelElement = getModelFor(element, library);
         }
       }
       assert(canonicalModelElement is! Inheritable);


### PR DESCRIPTION
* Use `library` instead of `lib` for local variable names; is more idiomatic.
* In `ContainerAccessor`, sort fields before constructors, and group constructors.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
