### PR TITLE
Stop using 'augmented' from the element model.

### DIFF
--- a/lib/src/model/inheriting_container.dart
+++ b/lib/src/model/inheriting_container.dart
@@ -19,7 +19,7 @@ import 'package:meta/meta.dart';
 /// Note that [Constructor]s are not considered to be modifiers so a
 /// [hasModifiers] override is not necessary for this mixin.
 mixin Constructable implements InheritingContainer {
-  late final List<Constructor> constructors = element.augmented.constructors
+  late final List<Constructor> constructors = element.constructors
       .map((e) => getModelFor(e, library) as Constructor)
       .toList(growable: false);
 
@@ -146,12 +146,12 @@ abstract class InheritingContainer extends Container {
 
     // The mapping of all of the inherited element names to their _concrete_
     // implementation element.
-    var concreteInheritanceMap = packageGraph.inheritanceManager
-        .getInheritedConcreteMap2(element.augmented.declaration);
+    var concreteInheritanceMap =
+        packageGraph.inheritanceManager.getInheritedConcreteMap2(element);
     // The mapping of all inherited element names to the nearest inherited
     // element that they resolve to.
-    var inheritanceMap = packageGraph.inheritanceManager
-        .getInheritedMap2(element.augmented.declaration);
+    var inheritanceMap =
+        packageGraph.inheritanceManager.getInheritedMap2(element);
 
     var inheritanceChainElements =
         inheritanceChain.map((c) => c.element).toList(growable: false);
@@ -249,7 +249,7 @@ abstract class InheritingContainer extends Container {
   }();
 
   @override
-  late final List<Method> declaredMethods = element.augmented.methods
+  late final List<Method> declaredMethods = element.methods
       .map((e) => getModelFor(e, library) as Method)
       .toList(growable: false);
 

--- a/lib/src/model/method.dart
+++ b/lib/src/model/method.dart
@@ -124,7 +124,7 @@ class Method extends ModelElement
       return null;
     }
     var parent = element.enclosingElement3 as InterfaceElement;
-    for (var t in parent.augmented.declaration.allSupertypes) {
+    for (var t in parent.allSupertypes) {
       Element? e = t.getMethod(element.name);
       if (e != null) {
         assert(


### PR DESCRIPTION
We decided to rework the element model to make merged elements proper objects, not via `augmented` property.