### PR TITLE
Strip the enclosing package's lower-case name from a library's dir name

### DIFF
--- a/lib/src/model/library.dart
+++ b/lib/src/model/library.dart
@@ -167,15 +167,17 @@ class Library extends ModelElement
           '"$_restoredUri" must not start with "file:"');
       // Strip the package prefix if the library is part of the default package
       // or if it is being documented remotely.
-      var packageToHide = package.documentedWhere == DocumentLocation.remote
+      var defaultPackage = package.documentedWhere == DocumentLocation.remote
           ? package.packageMeta
           : package.packageGraph.packageMeta;
-      var schemaToHide = 'package:$packageToHide/';
+      var packageNameToHide = defaultPackage.toString().toLowerCase();
+      var schemaToHide = 'package:$packageNameToHide/';
 
       nameFromPath = _restoredUri;
       if (nameFromPath.startsWith(schemaToHide)) {
         nameFromPath = nameFromPath.substring(schemaToHide.length);
       }
+      // Remove the trailing `.dart`.
       if (nameFromPath.endsWith('.dart')) {
         const dartExtensionLength = '.dart'.length;
         nameFromPath = nameFromPath.substring(
@@ -184,6 +186,7 @@ class Library extends ModelElement
     } else {
       nameFromPath = name;
     }
+    // Turn `package:foo/bar/baz` into `package-foo_bar_baz`.
     return nameFromPath.replaceAll(':', '-').replaceAll('/', '_');
   }();
 


### PR DESCRIPTION
Fixes https://github.com/dart-lang/dartdoc/issues/3882

I wish I could write a unit test for this fix but it would be a lot of work, and I fear making too small a unit test (like literally just mocking out a package name to be 'Flutter' and basically just testing `toLowerCase`) would be unhelpful. To make a less mock-y test, with a real SDK-provided 'Flutter' package, and documenting dependencies, and running dartdoc how Flutter does, would be fragile and very complex.

In any case, I did _manually_ check this fix:

1. Run `dart tool/task.dart doc flutter`; see that the generated HTML has the `flutter/widgets/widgets-library.html` path for the widgets library.
2. Edit the flutter checkout that the above command created, in a temp space, to have an _unnamed_ library.
3. Re-run the `create_api_docs.dart` command that is printed out in the first step; see that the generated HTML _still_ has the correct path.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
