### PR TITLE
Remove Indexable as an unnecessary mixin.

### DIFF
--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -9,7 +9,7 @@ library;
 export 'package:dartdoc/src/dartdoc.dart';
 export 'package:dartdoc/src/dartdoc_options.dart';
 export 'package:dartdoc/src/generator/generator.dart';
-export 'package:dartdoc/src/model/indexable.dart' show Kind;
+export 'package:dartdoc/src/model/kind.dart';
 export 'package:dartdoc/src/model/package_builder.dart';
 export 'package:dartdoc/src/model/package_graph.dart';
 export 'package:dartdoc/src/package_config_provider.dart';

--- a/lib/src/generator/generator_backend.dart
+++ b/lib/src/generator/generator_backend.dart
@@ -105,7 +105,7 @@ abstract class GeneratorBackend {
   }
 
   /// Emits a JSON catalog of [indexedElements] for use with a search index.
-  void generateSearchIndex(List<Indexable> indexedElements) {
+  void generateSearchIndex(List<Documentable> indexedElements) {
     var json = generator_util.generateSearchIndexJson(
       indexedElements,
       packageOrder: options.packageOrder,

--- a/lib/src/generator/generator_frontend.dart
+++ b/lib/src/generator/generator_frontend.dart
@@ -48,7 +48,7 @@ class GeneratorFrontEnd implements Generator {
 
   /// Traverses the [packageGraph] and generates documentation for all contained
   /// elements.
-  List<Indexable> _generateDocs(PackageGraph packageGraph) {
+  List<Documentable> _generateDocs(PackageGraph packageGraph) {
     runtimeStats.resetAccumulators({
       'writtenCategoryFileCount',
       'writtenClassFileCount',
@@ -69,7 +69,7 @@ class GeneratorFrontEnd implements Generator {
     _generatorBackend.generatePackage(
         packageGraph, packageGraph.defaultPackage);
 
-    var indexAccumulator = <Indexable>[];
+    var indexAccumulator = <Documentable>[];
     var multiplePackages = packageGraph.localPackages.length > 1;
 
     void generateConstants(Container container, Library library) {

--- a/lib/src/generator/generator_utils.dart
+++ b/lib/src/generator/generator_utils.dart
@@ -6,9 +6,11 @@ import 'dart:convert';
 
 import 'package:collection/collection.dart';
 import 'package:dartdoc/src/model/directives/categorization.dart';
-import 'package:dartdoc/src/model/indexable.dart';
+import 'package:dartdoc/src/model/documentable.dart';
+import 'package:dartdoc/src/model/inheritable.dart';
 import 'package:dartdoc/src/model/library.dart';
 import 'package:dartdoc/src/model/model_element.dart';
+import 'package:dartdoc/src/model/nameable.dart';
 
 String generateCategoryJson(Iterable<Categorization> categories, bool pretty) {
   final indexItems = [
@@ -37,7 +39,7 @@ String generateCategoryJson(Iterable<Categorization> categories, bool pretty) {
 /// [indexedElements] and [packageOrder].
 ///
 /// Passing `pretty: true` will use a [JsonEncoder] with a single-space indent.
-String generateSearchIndexJson(Iterable<Indexable> indexedElements,
+String generateSearchIndexJson(Iterable<Documentable> indexedElements,
     {required List<String> packageOrder, required bool pretty}) {
   var indexItems = <Map<String, Object?>>[];
 
@@ -52,8 +54,7 @@ String generateSearchIndexJson(Iterable<Indexable> indexedElements,
       'qualifiedName': element.canonicalQualifiedName,
       'href': element.href,
       'kind': element.kind.index,
-      // TODO(srawlins): Only include this for [Inheritable] items.
-      'overriddenDepth': element.overriddenDepth,
+      if (element is Inheritable) 'overriddenDepth': element.overriddenDepth,
     };
 
     if (element is ModelElement) {
@@ -131,7 +132,7 @@ final _htmlTagPattern =
     RegExp(r'<[^>]*>', multiLine: true, caseSensitive: true);
 
 // Compares two elements, first by fully qualified name, then by kind.
-int _compareElementRepresentations(Indexable a, Indexable b) {
+int _compareElementRepresentations(Documentable a, Documentable b) {
   final value =
       compareNatural(a.canonicalQualifiedName, b.canonicalQualifiedName);
   if (value == 0) {
@@ -140,7 +141,7 @@ int _compareElementRepresentations(Indexable a, Indexable b) {
   return value;
 }
 
-extension on Indexable {
+extension on Nameable {
   /// The fully qualified name of this element, but using the canonical library,
   /// if it has one.
   String get canonicalQualifiedName {

--- a/lib/src/generator/template_data.dart
+++ b/lib/src/generator/template_data.dart
@@ -5,6 +5,7 @@
 /// @docImport 'generator_backend.dart';
 library;
 
+import 'package:dartdoc/src/model/kind.dart';
 import 'package:dartdoc/src/model/model.dart';
 
 typedef ContainerSidebar = String Function(

--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -841,7 +841,6 @@ class _Renderer_Category extends RendererBase<Category> {
                 ..._Renderer_MarkdownFileDocumentation.propertyMap<CT_>(),
                 ..._Renderer_LibraryContainer.propertyMap<CT_>(),
                 ..._Renderer_TopLevelContainer.propertyMap<CT_>(),
-                ..._Renderer_Indexable.propertyMap<CT_>(),
                 'aboveSidebarPath': Property(
                   getValue: (CT_ c) => c.aboveSidebarPath,
                   renderVariable:
@@ -6888,73 +6887,6 @@ class _Renderer_HasNoPage extends RendererBase<HasNoPage> {
   }
 }
 
-class _Renderer_Indexable extends RendererBase<Indexable> {
-  static final Map<Type, Object> _propertyMapCache = {};
-  static Map<String, Property<CT_>> propertyMap<CT_ extends Indexable>() =>
-      _propertyMapCache.putIfAbsent(
-          CT_,
-          () => {
-                'href': Property(
-                  getValue: (CT_ c) => c.href,
-                  renderVariable:
-                      (CT_ c, Property<CT_> self, List<String> remainingNames) {
-                    if (remainingNames.isEmpty) {
-                      return self.getValue(c).toString();
-                    }
-                    var name = remainingNames.first;
-                    var nextProperty =
-                        _Renderer_String.propertyMap().getValue(name);
-                    return nextProperty.renderVariable(
-                        self.getValue(c) as String,
-                        nextProperty,
-                        [...remainingNames.skip(1)]);
-                  },
-                  isNullValue: (CT_ c) => c.href == null,
-                  renderValue: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    _render_String(c.href!, ast, r.template, sink, parent: r);
-                  },
-                ),
-                'kind': Property(
-                  getValue: (CT_ c) => c.kind,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(c, remainingNames, 'Kind'),
-                  isNullValue: (CT_ c) => false,
-                  renderValue: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    renderSimple(c.kind, ast, r.template, sink,
-                        parent: r, getters: _invisibleGetters['Kind']!);
-                  },
-                ),
-                'overriddenDepth': Property(
-                  getValue: (CT_ c) => c.overriddenDepth,
-                  renderVariable: (CT_ c, Property<CT_> self,
-                          List<String> remainingNames) =>
-                      self.renderSimpleVariable(c, remainingNames, 'int'),
-                  isNullValue: (CT_ c) => c.overriddenDepth == null,
-                  renderValue: (CT_ c, RendererBase<CT_> r,
-                      List<MustachioNode> ast, StringSink sink) {
-                    renderSimple(c.overriddenDepth, ast, r.template, sink,
-                        parent: r, getters: _invisibleGetters['int']!);
-                  },
-                ),
-              }) as Map<String, Property<CT_>>;
-
-  _Renderer_Indexable(Indexable context, RendererBase<Object>? parent,
-      Template template, StringSink sink)
-      : super(context, parent, template, sink);
-
-  @override
-  Property<Indexable>? getProperty(String key) {
-    if (propertyMap<Indexable>().containsKey(key)) {
-      return propertyMap<Indexable>()[key];
-    } else {
-      return null;
-    }
-  }
-}
-
 class _Renderer_Inheritable extends RendererBase<Inheritable> {
   static final Map<Type, Object> _propertyMapCache = {};
   static Map<String, Property<CT_>> propertyMap<CT_ extends Inheritable>() =>
@@ -10072,7 +10004,6 @@ class _Renderer_ModelElement extends RendererBase<ModelElement> {
                 ..._Renderer_Locatable.propertyMap<CT_>(),
                 ..._Renderer_Nameable.propertyMap<CT_>(),
                 ..._Renderer_SourceCode.propertyMap<CT_>(),
-                ..._Renderer_Indexable.propertyMap<CT_>(),
                 ..._Renderer_FeatureSet.propertyMap<CT_>(),
                 ..._Renderer_DocumentationComment.propertyMap<CT_>(),
                 'annotations': Property(
@@ -12313,7 +12244,7 @@ class _Renderer_Package extends RendererBase<Package> {
   }
 }
 
-String renderIndex(PackageTemplateData context, Template template) {
+String renderSearchPage(PackageTemplateData context, Template template) {
   var buffer = StringBuffer();
   _render_PackageTemplateData(context, template.ast, template, buffer);
   return buffer.toString();
@@ -12551,13 +12482,13 @@ class _Renderer_PackageTemplateData extends RendererBase<PackageTemplateData> {
   }
 }
 
-String renderError(PackageTemplateData context, Template template) {
+String renderIndex(PackageTemplateData context, Template template) {
   var buffer = StringBuffer();
   _render_PackageTemplateData(context, template.ast, template, buffer);
   return buffer.toString();
 }
 
-String renderSearchPage(PackageTemplateData context, Template template) {
+String renderError(PackageTemplateData context, Template template) {
   var buffer = StringBuffer();
   _render_PackageTemplateData(context, template.ast, template, buffer);
   return buffer.toString();

--- a/lib/src/model/accessor.dart
+++ b/lib/src/model/accessor.dart
@@ -11,6 +11,7 @@ import 'package:analyzer/src/dart/element/member.dart' show ExecutableMember;
 import 'package:collection/collection.dart' show IterableExtension;
 import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
+import 'package:dartdoc/src/model/kind.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/utils.dart';
 import 'package:dartdoc/src/warnings.dart';

--- a/lib/src/model/category.dart
+++ b/lib/src/model/category.dart
@@ -6,6 +6,7 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/file_system/file_system.dart';
 import 'package:dartdoc/src/dartdoc_options.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
+import 'package:dartdoc/src/model/kind.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/warnings.dart';
 
@@ -18,8 +19,7 @@ class Category
         Locatable,
         MarkdownFileDocumentation,
         LibraryContainer,
-        TopLevelContainer,
-        Indexable
+        TopLevelContainer
     implements Documentable {
   /// The package in which this category is contained.
   ///

--- a/lib/src/model/class.dart
+++ b/lib/src/model/class.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:analyzer/dart/element/element.dart';
+import 'package:dartdoc/src/model/kind.dart';
 import 'package:dartdoc/src/model/model.dart';
 
 /// A [Container] defined with a `class` declaration.

--- a/lib/src/model/constructor.dart
+++ b/lib/src/model/constructor.dart
@@ -6,6 +6,7 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/source/line_info.dart';
 import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
+import 'package:dartdoc/src/model/kind.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/model_utils.dart';
 

--- a/lib/src/model/directives/categorization.dart
+++ b/lib/src/model/directives/categorization.dart
@@ -9,7 +9,7 @@ final RegExp _categoryRegExp =
     RegExp(r'[ ]*{@(category|subCategory) (.+?)}[ ]*\n?', multiLine: true);
 
 /// Mixin parsing the `@category` directive for ModelElements.
-mixin Categorization on DocumentationComment implements Indexable {
+mixin Categorization on DocumentationComment {
   @override
   String buildDocumentationAddition(String rawDocs) =>
       _stripAndSetDartdocCategories(super.buildDocumentationAddition(rawDocs));

--- a/lib/src/model/documentable.dart
+++ b/lib/src/model/documentable.dart
@@ -5,6 +5,7 @@
 import 'package:analyzer/file_system/file_system.dart';
 import 'package:dartdoc/src/dartdoc_options.dart';
 import 'package:dartdoc/src/io_utils.dart';
+import 'package:dartdoc/src/model/kind.dart';
 import 'package:dartdoc/src/warnings.dart';
 
 import 'model.dart';
@@ -29,9 +30,10 @@ abstract class Documentable with Nameable {
 
   DartdocOptionContext get config;
 
-  String? get href;
-
+  /// A human-friendly name for the kind of element this is.
   Kind get kind;
+
+  String? get href;
 
   /// The full path of the sidebar for elements "above" this element.
   ///

--- a/lib/src/model/dynamic.dart
+++ b/lib/src/model/dynamic.dart
@@ -5,6 +5,7 @@
 import 'package:analyzer/dart/element/element.dart';
 import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
+import 'package:dartdoc/src/model/kind.dart';
 import 'package:dartdoc/src/model/model.dart';
 
 class Dynamic extends ModelElement with HasNoPage {

--- a/lib/src/model/enum.dart
+++ b/lib/src/model/enum.dart
@@ -4,6 +4,7 @@
 
 import 'package:analyzer/dart/analysis/features.dart';
 import 'package:analyzer/dart/element/element.dart';
+import 'package:dartdoc/src/model/kind.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/model_utils.dart' as model_utils;
 import 'package:meta/meta.dart';

--- a/lib/src/model/extension.dart
+++ b/lib/src/model/extension.dart
@@ -7,6 +7,7 @@ import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
+import 'package:dartdoc/src/model/kind.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/model_utils.dart';
 import 'package:meta/meta.dart';

--- a/lib/src/model/extension_type.dart
+++ b/lib/src/model/extension_type.dart
@@ -5,6 +5,7 @@
 import 'package:analyzer/dart/element/element.dart';
 import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
+import 'package:dartdoc/src/model/kind.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:meta/meta.dart';
 

--- a/lib/src/model/field.dart
+++ b/lib/src/model/field.dart
@@ -6,6 +6,7 @@ import 'dart:convert';
 
 import 'package:analyzer/dart/element/element.dart';
 import 'package:dartdoc/src/model/attribute.dart';
+import 'package:dartdoc/src/model/kind.dart';
 import 'package:dartdoc/src/model/model.dart';
 
 class Field extends ModelElement

--- a/lib/src/model/inheritable.dart
+++ b/lib/src/model/inheritable.dart
@@ -175,7 +175,10 @@ mixin Inheritable on ContainerMember {
     return isOverride;
   }();
 
-  @override
+  /// The depth of overrides at which this element lives.
+  ///
+  /// Just a count of how long the chain of this element's `overriddenElement`.
+  /// For use in ranking search results.
   int get overriddenDepth {
     var depth = 0;
     var e = this;

--- a/lib/src/model/kind.dart
+++ b/lib/src/model/kind.dart
@@ -1,8 +1,6 @@
-// Copyright (c) 2019, the Dart project authors. Please see the AUTHORS file
+// Copyright (c) 2024, the Dart project authors. Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
-
-import 'package:dartdoc/src/model/model.dart';
 
 enum Kind {
   accessor,
@@ -81,13 +79,4 @@ enum Kind {
         'type parameter' => typeParameter,
         _ => throw ArgumentError('Unknown kind "$value"'),
       };
-}
-
-/// Something able to be indexed.
-mixin Indexable implements Nameable {
-  String? get href;
-
-  Kind get kind;
-
-  int? get overriddenDepth => 0;
 }

--- a/lib/src/model/library.dart
+++ b/lib/src/model/library.dart
@@ -7,6 +7,7 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/scope.dart';
 import 'package:analyzer/source/line_info.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
+import 'package:dartdoc/src/model/kind.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/package_meta.dart' show PackageMeta;
 import 'package:dartdoc/src/warnings.dart';

--- a/lib/src/model/method.dart
+++ b/lib/src/model/method.dart
@@ -9,6 +9,7 @@ import 'package:analyzer/src/dart/element/member.dart' show ExecutableMember;
 import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/model/attribute.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
+import 'package:dartdoc/src/model/kind.dart';
 import 'package:dartdoc/src/model/model.dart';
 
 class Method extends ModelElement

--- a/lib/src/model/mixin.dart
+++ b/lib/src/model/mixin.dart
@@ -6,6 +6,7 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
+import 'package:dartdoc/src/model/kind.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/model_utils.dart' as model_utils;
 import 'package:dartdoc/src/special_elements.dart';

--- a/lib/src/model/model.dart
+++ b/lib/src/model/model.dart
@@ -21,7 +21,6 @@ export 'extension_type.dart';
 export 'field.dart';
 export 'getter_setter_combo.dart';
 export 'has_no_page.dart';
-export 'indexable.dart';
 export 'inheritable.dart';
 export 'inheriting_container.dart';
 export 'library.dart';

--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -20,6 +20,7 @@ import 'package:dartdoc/src/model/annotation.dart';
 import 'package:dartdoc/src/model/attribute.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
 import 'package:dartdoc/src/model/feature_set.dart';
+import 'package:dartdoc/src/model/kind.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/model/prefix.dart';
 import 'package:dartdoc/src/model_utils.dart';
@@ -67,7 +68,6 @@ abstract class ModelElement
         Locatable,
         Nameable,
         SourceCode,
-        Indexable,
         FeatureSet,
         DocumentationComment
     implements Comparable<ModelElement>, Documentable {

--- a/lib/src/model/model_function.dart
+++ b/lib/src/model/model_function.dart
@@ -5,6 +5,7 @@
 import 'package:analyzer/dart/element/element.dart';
 import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
+import 'package:dartdoc/src/model/kind.dart';
 import 'package:dartdoc/src/model/model.dart';
 
 /// A [ModelElement] for a [FunctionElement] that isn't part of a type definition.

--- a/lib/src/model/never.dart
+++ b/lib/src/model/never.dart
@@ -4,6 +4,7 @@
 
 import 'package:analyzer/dart/element/element.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
+import 'package:dartdoc/src/model/kind.dart';
 import 'package:dartdoc/src/model/model.dart';
 
 class NeverType extends ModelElement with HasNoPage {

--- a/lib/src/model/package.dart
+++ b/lib/src/model/package.dart
@@ -6,6 +6,7 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:dartdoc/src/dartdoc_options.dart';
 import 'package:dartdoc/src/io_utils.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
+import 'package:dartdoc/src/model/kind.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/model_utils.dart';
 import 'package:dartdoc/src/package_meta.dart';

--- a/lib/src/model/parameter.dart
+++ b/lib/src/model/parameter.dart
@@ -7,6 +7,7 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/src/dart/element/member.dart' show ParameterMember;
 import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
+import 'package:dartdoc/src/model/kind.dart';
 import 'package:dartdoc/src/model/model.dart';
 
 class Parameter extends ModelElement with HasNoPage {

--- a/lib/src/model/prefix.dart
+++ b/lib/src/model/prefix.dart
@@ -5,6 +5,7 @@
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/scope.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
+import 'package:dartdoc/src/model/kind.dart';
 import 'package:dartdoc/src/model/model.dart';
 
 /// Represents a [PrefixElement] for dartdoc.

--- a/lib/src/model/top_level_variable.dart
+++ b/lib/src/model/top_level_variable.dart
@@ -5,6 +5,7 @@
 import 'package:analyzer/dart/element/element.dart';
 import 'package:dartdoc/src/model/attribute.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
+import 'package:dartdoc/src/model/kind.dart';
 import 'package:dartdoc/src/model/model.dart';
 
 /// Top-level variables. But also picks up getters and setters?

--- a/lib/src/model/type_parameter.dart
+++ b/lib/src/model/type_parameter.dart
@@ -5,6 +5,7 @@
 import 'package:analyzer/dart/element/element.dart';
 import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
+import 'package:dartdoc/src/model/kind.dart';
 import 'package:dartdoc/src/model/model.dart';
 
 class TypeParameter extends ModelElement with HasNoPage {

--- a/lib/src/model/typedef.dart
+++ b/lib/src/model/typedef.dart
@@ -6,6 +6,7 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
+import 'package:dartdoc/src/model/kind.dart';
 import 'package:dartdoc/src/model/model.dart';
 
 abstract class Typedef extends ModelElement

--- a/lib/src/search.dart
+++ b/lib/src/search.dart
@@ -4,7 +4,7 @@
 
 import 'dart:convert';
 
-import 'package:dartdoc/src/model/indexable.dart';
+import 'package:dartdoc/src/model/kind.dart';
 import 'package:meta/meta.dart';
 
 enum _MatchPosition {

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -13,6 +13,7 @@ import 'package:dartdoc/src/dartdoc_options.dart';
 import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/matching_link_result.dart';
 import 'package:dartdoc/src/model/attribute.dart';
+import 'package:dartdoc/src/model/kind.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/model_utils.dart';
 import 'package:dartdoc/src/package_config_provider.dart';

--- a/test/packages_test.dart
+++ b/test/packages_test.dart
@@ -6,7 +6,7 @@ import 'package:analyzer/file_system/file_system.dart';
 import 'package:analyzer/file_system/memory_file_system.dart';
 import 'package:dartdoc/src/dartdoc_options.dart';
 import 'package:dartdoc/src/model/documentable.dart';
-import 'package:dartdoc/src/model/indexable.dart';
+import 'package:dartdoc/src/model/kind.dart';
 import 'package:dartdoc/src/package_config_provider.dart';
 import 'package:dartdoc/src/package_meta.dart';
 import 'package:dartdoc/src/special_elements.dart';

--- a/test/search_index_test.dart
+++ b/test/search_index_test.dart
@@ -77,7 +77,7 @@ class C {}
     var classItem = jsonIndex.named('index_json.C');
 
     expect(classItem['kind'], equals(Kind.class_.index));
-    expect(classItem['overriddenDepth'], null);
+    expect(classItem['overriddenDepth'], isNull);
     expect(classItem['desc'], equals('A class.'));
     expect(
       classItem['enclosedBy'],
@@ -98,7 +98,7 @@ library;
     var libraryItem = jsonIndex.named('index_json');
 
     expect(libraryItem['kind'], equals(Kind.library.index));
-    expect(libraryItem['overriddenDepth'], null);
+    expect(libraryItem['overriddenDepth'], isNull);
     // TODO(srawlins): Should not be blank.
     expect(libraryItem['desc'], equals(''));
   }

--- a/test/search_index_test.dart
+++ b/test/search_index_test.dart
@@ -5,6 +5,7 @@
 import 'dart:convert';
 
 import 'package:dartdoc/src/generator/generator_utils.dart';
+import 'package:dartdoc/src/model/kind.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/model_utils.dart';
 import 'package:test/test.dart';
@@ -76,7 +77,7 @@ class C {}
     var classItem = jsonIndex.named('index_json.C');
 
     expect(classItem['kind'], equals(Kind.class_.index));
-    expect(classItem['overriddenDepth'], equals(0));
+    expect(classItem['overriddenDepth'], null);
     expect(classItem['desc'], equals('A class.'));
     expect(
       classItem['enclosedBy'],
@@ -97,7 +98,7 @@ library;
     var libraryItem = jsonIndex.named('index_json');
 
     expect(libraryItem['kind'], equals(Kind.library.index));
-    expect(libraryItem['overriddenDepth'], equals(0));
+    expect(libraryItem['overriddenDepth'], null);
     // TODO(srawlins): Should not be blank.
     expect(libraryItem['desc'], equals(''));
   }

--- a/test/search_test.dart
+++ b/test/search_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:dartdoc/src/model/indexable.dart';
+import 'package:dartdoc/src/model/kind.dart';
 import 'package:dartdoc/src/search.dart';
 import 'package:test/test.dart';
 import 'package:test_reflective_loader/test_reflective_loader.dart';


### PR DESCRIPTION
This mixin only served as an interface providing `href` and `kind`, and providing an impl for `overriddenDepth`. This amounted to a lot of complexity. Some APIs were thus written in terms of Indexable. And any class that mixed in Indexable gets an `overriddenDepth` property which is inapplicable, more often than not.

As Documentable has `href` and `kind`, the easiest migration is to switch most Indexable-concerned APIs to use Documentable. We move `overriddenDepth` to _only_ be defined on Inheritable.
below.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
