### PR TITLE
Move 'onPlatform' arguments for tests and groups up.

### DIFF
--- a/test/html_generator_test.dart
+++ b/test/html_generator_test.dart
@@ -22,7 +22,9 @@ import 'package:test/test.dart';
 import 'src/utils.dart' as utils;
 
 void main() {
-  group('HTML generator tests', () {
+  group('HTML generator tests', onPlatform: {
+    'windows': Skip('Tests do not work on Windows after NNBD conversion')
+  }, () {
     late MemoryResourceProvider resourceProvider;
     late path.Context pathContext;
 
@@ -86,7 +88,9 @@ void main() {
       }
     });
 
-    test('libraries with no duplicates are not warned about', () async {
+    test('libraries with no duplicates are not warned about',
+        onPlatform: {'windows': Skip('Test does not work on Windows (#2446)')},
+        () async {
       getConvertedFile('$projectPath/lib/a.dart')
           .writeAsStringSync('library a;');
       getConvertedFile('$projectPath/lib/b.dart')
@@ -96,9 +100,11 @@ void main() {
       await generator.generate(packageGraph);
 
       expect(packageGraph.packageWarningCounter.errorCount, 0);
-    }, onPlatform: {'windows': Skip('Test does not work on Windows (#2446)')});
+    });
 
-    test('libraries with duplicate names are warned about', () async {
+    test('libraries with duplicate names are warned about',
+        onPlatform: {'windows': Skip('Test does not work on Windows (#2446)')},
+        () async {
       getConvertedFile('$projectPath/lib/a.dart')
           .writeAsStringSync('library a;');
       getConvertedFile('$projectPath/lib/b.dart')
@@ -112,9 +118,7 @@ void main() {
           packageGraph.localPublicLibraries,
           anyElement((Library l) => packageGraph.packageWarningCounter
               .hasWarning(l, PackageWarning.duplicateFile, expectedPath)));
-    }, onPlatform: {'windows': Skip('Test does not work on Windows (#2446)')});
-  }, onPlatform: {
-    'windows': Skip('Tests do not work on Windows after NNBD conversion')
+    });
   });
 }
 

--- a/test/libraries_test.dart
+++ b/test/libraries_test.dart
@@ -151,7 +151,9 @@ A doc comment.
     );
   });
 
-  test('libraries in SDK package have appropriate data', () async {
+  test('libraries in SDK package have appropriate data',
+      onPlatform: {'windows': Skip('Test does not work on Windows (#2446)')},
+      () async {
     var packageMetaProvider = testPackageMetaProvider;
     var sdkFolder = packageMetaProvider.defaultSdkDir;
     var packageConfigProvider = getTestPackageConfigProvider(sdkFolder.path);
@@ -173,7 +175,7 @@ A doc comment.
     expect(dartAsyncLib.dirName, 'dart-async');
     expect(dartAsyncLib.href,
         '${htmlBasePlaceholder}dart-async/dart-async-library.html');
-  }, onPlatform: {'windows': Skip('Test does not work on Windows (#2446)')});
+  });
 }
 
 @reflectiveTest

--- a/test/packages_test.dart
+++ b/test/packages_test.dart
@@ -47,7 +47,9 @@ void main() {
 
   tearDown(clearPackageMetaCache);
 
-  group('tests', () {
+  group('tests',
+      onPlatform: {'windows': Skip('Test does not work on Windows (#2446)')},
+      () {
     group('typical package', () {
       setUp(() {
         optionSet.parseArguments([]);
@@ -118,13 +120,6 @@ int x;
         expect(packageGraph.defaultPackage.hasHomepage, isTrue);
         expect(packageGraph.defaultPackage.homepage,
             equals('https://github.com/dart-lang'));
-      });
-
-      test('has a public library', () async {
-        var packageGraph = await utils.bootBasicPackage(
-            projectPath, packageMetaProvider, packageConfigProvider);
-        var library = packageGraph.libraries.named('a');
-        expect(library.isDocumented, true);
       });
 
       test('has anonymous libraries', () async {
@@ -492,5 +487,5 @@ int x;
         expect(packageGraph.localPackages.first.categories, isEmpty);
       });
     });
-  }, onPlatform: {'windows': Skip('Test does not work on Windows (#2446)')});
+  });
 }


### PR DESCRIPTION
With named-arguments-anywhere, `onPlatform` can be specified before the group or test's closure. Doing so makes the group or test must more readable.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
