### PR TITLE
Support for enhanced parts

### DIFF
--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -554,12 +554,7 @@ class PackageGraph with CommentReferable, Nameable {
     alreadyTagged.add(key);
     // Mark that `publicLibrary` exports `libraryElement`.
     _libraryExports.putIfAbsent(libraryElement, () => {}).add(publicLibrary);
-
-    var exported = [
-      ...libraryElement.libraryExports,
-      for (var unit in libraryElement.units) ...unit.libraryExports,
-    ];
-    for (var exportedElement in exported) {
+    for (var exportedElement in libraryElement.libraryExports) {
       var exportedLibrary = exportedElement.exportedLibrary;
       if (exportedLibrary != null) {
         // Follow the exports down; as `publicLibrary` exports `libraryElement`,

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -554,7 +554,12 @@ class PackageGraph with CommentReferable, Nameable {
     alreadyTagged.add(key);
     // Mark that `publicLibrary` exports `libraryElement`.
     _libraryExports.putIfAbsent(libraryElement, () => {}).add(publicLibrary);
-    for (var exportedElement in libraryElement.libraryExports) {
+
+    var exported = [
+      ...libraryElement.libraryExports,
+      for (var unit in libraryElement.units) ...unit.libraryExports,
+    ];
+    for (var exportedElement in exported) {
       var exportedLibrary = exportedElement.exportedLibrary;
       if (exportedLibrary != null) {
         // Follow the exports down; as `publicLibrary` exports `libraryElement`,

--- a/test/dartdoc_test_base.dart
+++ b/test/dartdoc_test_base.dart
@@ -43,7 +43,7 @@ abstract class DartdocTestBase {
 
   String get sdkConstraint => '>=3.6.0 <4.0.0';
 
-  List<String> get experiments => ['wildcard-variables'];
+  List<String> get experiments => ['enhanced-parts', 'wildcard-variables'];
 
   bool get skipUnreachableSdkLibraries => true;
 

--- a/test/packages_test.dart
+++ b/test/packages_test.dart
@@ -559,4 +559,30 @@ export 'src/impl.dart';
     expect(library.classes.single,
         isA<Class>().having((c) => c.name, 'name', 'C'));
   }
+
+  void test_exportedElements_fromPartOfPart() async {
+    var graph = await bootPackageFromFiles(
+      [
+        d.dir('lib', [
+          d.file('lib.dart', "part 'part1.dart';"),
+          d.file('part1.dart', '''
+part of 'lib.dart';
+part 'part2.dart';
+'''),
+          d.file('part2.dart', '''
+part of 'part1.dart';
+export 'src/impl.dart';
+'''),
+          d.dir('src', [
+            d.file('impl.dart', 'class C {}'),
+          ]),
+        ]),
+      ],
+    );
+    var library = graph.libraries.named('lib');
+    expect(library.qualifiedName, 'lib');
+    expect(library.classes, isNotEmpty);
+    expect(library.classes.single,
+        isA<Class>().having((c) => c.name, 'name', 'C'));
+  }
 }

--- a/test/packages_test.dart
+++ b/test/packages_test.dart
@@ -5,16 +5,26 @@
 import 'package:analyzer/file_system/file_system.dart';
 import 'package:analyzer/file_system/memory_file_system.dart';
 import 'package:dartdoc/src/dartdoc_options.dart';
+import 'package:dartdoc/src/model/class.dart';
 import 'package:dartdoc/src/model/documentable.dart';
 import 'package:dartdoc/src/model/kind.dart';
 import 'package:dartdoc/src/package_config_provider.dart';
 import 'package:dartdoc/src/package_meta.dart';
 import 'package:dartdoc/src/special_elements.dart';
 import 'package:test/test.dart';
+import 'package:test_reflective_loader/test_reflective_loader.dart';
 
+import 'dartdoc_test_base.dart';
+import 'src/test_descriptor_utils.dart' as d;
 import 'src/utils.dart' as utils;
 
 void main() {
+  defineReflectiveSuite(() {
+    defineReflectiveTests(PackagesTest);
+  });
+
+  // TODO(srawlins): Migrate to test_reflective_loader tests.
+
   late MemoryResourceProvider resourceProvider;
   late PackageMetaProvider packageMetaProvider;
   late FakePackageConfigProvider packageConfigProvider;
@@ -103,6 +113,8 @@ int x;
             projectPath, packageMetaProvider, packageConfigProvider);
 
         expect(packageGraph.localPublicLibraries, hasLength(1));
+        var library = packageGraph.libraries.named('a');
+        expect(library.isDocumented, true);
       });
 
       test('has private libraries', () async {
@@ -488,4 +500,63 @@ int x;
       });
     });
   });
+}
+
+@reflectiveTest
+class PackagesTest extends DartdocTestBase {
+  @override
+  String get libraryName => 'lib';
+
+  void test_exportedElements() async {
+    var graph = await bootPackageFromFiles(
+      [
+        d.dir('lib', [
+          d.file('lib.dart', "export 'src/impl.dart';"),
+          d.dir('src', [
+            d.file('impl.dart', 'class C {}'),
+          ]),
+        ]),
+      ],
+    );
+    var library = graph.libraries.named('lib');
+    expect(library.classes.single.name, 'C');
+  }
+
+  void test_exportedElements_indirectlyExported() async {
+    var graph = await bootPackageFromFiles(
+      [
+        d.dir('lib', [
+          d.file('lib.dart', "export 'src/impl.dart';"),
+          d.dir('src', [
+            d.file('impl.dart', "export 'impl2.dart';"),
+            d.file('impl2.dart', 'class C {}'),
+          ]),
+        ]),
+      ],
+    );
+    var library = graph.libraries.named('lib');
+    expect(library.classes.single.name, 'C');
+  }
+
+  void test_exportedElements_fromPart() async {
+    var graph = await bootPackageFromFiles(
+      [
+        d.dir('lib', [
+          d.file('lib.dart', "part 'part.dart';"),
+          d.file('part.dart', '''
+part of 'lib.dart';
+export 'src/impl.dart';
+'''),
+          d.dir('src', [
+            d.file('impl.dart', 'class C {}'),
+          ]),
+        ]),
+      ],
+    );
+    var library = graph.libraries.named('lib');
+    expect(library.qualifiedName, 'lib');
+    expect(library.classes, isNotEmpty);
+    expect(library.classes.single,
+        isA<Class>().having((c) => c.name, 'name', 'C'));
+  }
 }


### PR DESCRIPTION
There isn't _much_ for dartdoc to be concerned with. Dartdoc basically must be aware of an exports foud in a part, and there might be reasons to be concerned with imports coming from a part. In particular, dartdoc used to skip resolving all part files when searching for libraries, just as an optimization. Can't do that any more.

This might not be a full implementation of enhanced parts support, but it sets up the basics.

Work towards https://github.com/dart-lang/dartdoc/issues/3893


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
