### PR TITLE
In the buildbot CI step, reset built web files before trying to publish

### DIFF
--- a/tool/task.dart
+++ b/tool/task.dart
@@ -834,6 +834,15 @@ Rebuild them with "dart tool/task.dart build" and check the results in.
         'The web frontend (web/docs.dart) needs to be recompiled; rebuild it '
         'with "dart tool/task.dart build web".');
   }
+
+  // Reset some files for `try-publish` step. This check looks for changes in
+  // the current git checkout: https://github.com/dart-lang/pub/pull/4373.
+  Process.runSync('git', [
+    'checkout',
+    '--',
+    'lib/resources/docs.dart.js',
+    'lib/resources/docs.dart.js.map',
+  ]);
 }
 
 /// Whether the analyzer in use (as found in `pubspec.lock`) is the target


### PR DESCRIPTION
These files can have minor differences in them (depending on the version of Dart?), so that it is difficult for them to always be identical to the ones checked in, during CI. Then there is a new warning that `pub publish --dry-run` produces, if the current git checkout is not clean: https://github.com/dart-lang/pub/pull/4373. We need to reset these files to avoid that warning.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
