### PR TITLE
Convert various Mustachio errors to be exceptions.

### DIFF
--- a/test/mustachio/aot_compiler_render_test.dart
+++ b/test/mustachio/aot_compiler_render_test.dart
@@ -554,7 +554,7 @@ void main() {
         ],
         'Foo()',
       ),
-      throwsA(const TypeMatcher<MustachioResolutionError>()
+      throwsA(const TypeMatcher<MustachioResolutionException>()
           .having((e) => e.message, 'message', contains('''
 line 1, column 8 of lib/templates/foo.html: Failed to resolve '[s2]' as a property on any types in the context chain: [Foo]
   ╷
@@ -573,7 +573,7 @@ line 1, column 8 of lib/templates/foo.html: Failed to resolve '[s2]' as a proper
         ],
         'Foo()',
       ),
-      throwsA(const TypeMatcher<MustachioResolutionError>()
+      throwsA(const TypeMatcher<MustachioResolutionException>()
           .having((e) => e.message, 'message', contains('''
 line 1, column 9 of lib/templates/foo.html: Failed to resolve '[s2]' as a property on any types in the context chain: [Foo]
   ╷
@@ -592,7 +592,7 @@ line 1, column 9 of lib/templates/foo.html: Failed to resolve '[s2]' as a proper
         ],
         'Bar()..foo = Foo()',
       ),
-      throwsA(const TypeMatcher<MustachioResolutionError>()
+      throwsA(const TypeMatcher<MustachioResolutionException>()
           .having((e) => e.message, 'message', contains('''
 line 1, column 8 of lib/templates/bar.html: Failed to resolve 'x' on Bar while resolving [x] as a property chain on any types in the context chain: context0.foo, after first resolving 'foo' to a property on Foo?
   ╷
@@ -612,7 +612,7 @@ line 1, column 8 of lib/templates/bar.html: Failed to resolve 'x' on Bar while r
         ],
         'Bar()..foo = Foo()',
       ),
-      throwsA(const TypeMatcher<MustachioResolutionError>()
+      throwsA(const TypeMatcher<MustachioResolutionException>()
           .having((e) => e.message, 'message', contains('''
 line 1, column 13 of lib/templates/bar.html: Failed to resolve '[x]' as a property on any types in the context chain: [Foo, Bar]
   ╷

--- a/test/mustachio/runtime_renderer_render_test.dart
+++ b/test/mustachio/runtime_renderer_render_test.dart
@@ -478,7 +478,7 @@ World
     var foo = Foo();
     expect(
         () => renderFoo(foo, fooTemplate),
-        throwsA(const TypeMatcher<MustachioResolutionError>()
+        throwsA(const TypeMatcher<MustachioResolutionException>()
             .having((e) => e.message, 'message', contains('''
 line 1, column 8 of ${fooTemplateFile.path}: Failed to resolve 's2' as a property on any types in the context chain: Foo
   ╷
@@ -494,7 +494,7 @@ line 1, column 8 of ${fooTemplateFile.path}: Failed to resolve 's2' as a propert
     var foo = Foo();
     expect(
         () => renderFoo(foo, fooTemplate),
-        throwsA(const TypeMatcher<MustachioResolutionError>()
+        throwsA(const TypeMatcher<MustachioResolutionException>()
             .having((e) => e.message, 'message', contains('''
 line 1, column 9 of ${fooTemplateFile.path}: Failed to resolve 's2' as a property on any types in the current context
   ╷
@@ -511,7 +511,7 @@ line 1, column 9 of ${fooTemplateFile.path}: Failed to resolve 's2' as a propert
     var bar = Bar()..foo = Foo();
     expect(
         () => renderBar(bar, barTemplate),
-        throwsA(const TypeMatcher<MustachioResolutionError>().having(
+        throwsA(const TypeMatcher<MustachioResolutionException>().having(
             (e) => e.message,
             'message',
             contains("Failed to resolve 'x' on Foo while resolving [x] as a "
@@ -527,7 +527,7 @@ line 1, column 9 of ${fooTemplateFile.path}: Failed to resolve 's2' as a propert
     var bar = Bar()..foo = Foo();
     expect(
         () => renderBar(bar, barTemplate),
-        throwsA(const TypeMatcher<MustachioResolutionError>().having(
+        throwsA(const TypeMatcher<MustachioResolutionException>().having(
             (e) => e.message,
             'message',
             contains("Failed to resolve 'x' as a property on any types in the "
@@ -542,7 +542,7 @@ line 1, column 9 of ${fooTemplateFile.path}: Failed to resolve 's2' as a propert
     var foo = Foo();
     expect(
         () => renderFoo(foo, fooTemplate),
-        throwsA(const TypeMatcher<MustachioResolutionError>().having(
+        throwsA(const TypeMatcher<MustachioResolutionException>().having(
             (e) => e.message,
             'message',
             contains('Failed to resolve [length] property chain on String'))));
@@ -556,7 +556,7 @@ line 1, column 9 of ${fooTemplateFile.path}: Failed to resolve 's2' as a propert
     var foo = Foo()..s1 = 'String';
     expect(
         () => renderFoo(foo, fooTemplate),
-        throwsA(const TypeMatcher<MustachioResolutionError>().having(
+        throwsA(const TypeMatcher<MustachioResolutionException>().having(
             (e) => e.message,
             'message',
             contains('[length] is a getter on String, which is not visible to '
@@ -571,7 +571,7 @@ line 1, column 9 of ${fooTemplateFile.path}: Failed to resolve 's2' as a propert
     var foo = Foo()..s1 = 'String';
     expect(
         () => renderFoo(foo, fooTemplate),
-        throwsA(const TypeMatcher<MustachioResolutionError>().having(
+        throwsA(const TypeMatcher<MustachioResolutionException>().having(
             (e) => e.message,
             'message',
             contains('[length] is a getter on String, which is not visible to '
@@ -591,7 +591,7 @@ line 1, column 9 of ${fooTemplateFile.path}: Failed to resolve 's2' as a propert
       ..writeAsStringSync('Text {{#foo}}{{>missing.mustache}}{{/foo}}');
     expect(
         () async => await Template.parse(barTemplateFile),
-        throwsA(const TypeMatcher<MustachioResolutionError>().having(
+        throwsA(const TypeMatcher<MustachioResolutionException>().having(
             (e) => e.message,
             'message',
             allOf(

--- a/tool/mustachio/codegen_aot_compiler.dart
+++ b/tool/mustachio/codegen_aot_compiler.dart
@@ -158,8 +158,7 @@ Future<Map<_AotCompiler, String>> _deduplicateRenderers(
     String compiledLubRenderer;
     try {
       compiledLubRenderer = await lubCompiler._compileToRenderer(referenceUris);
-      // ignore: avoid_catching_errors
-    } on MustachioResolutionError {
+    } on MustachioResolutionException {
       // Oops, switching to the LUB type prevents the renderer from compiling;
       // likely the properties accessed in the partial are not all declared on
       // the LUB type.
@@ -624,7 +623,7 @@ class _BlockCompiler {
     }
     if (getter == null) {
       var contextTypes = [for (var c in _contextStack) c.type];
-      throw MustachioResolutionError(node.keySpan
+      throw MustachioResolutionException(node.keySpan
           .message("Failed to resolve '$key' as a property on any types in the "
               'context chain: $contextTypes'));
     }
@@ -642,7 +641,7 @@ class _BlockCompiler {
     for (var secondaryKey in remainingNames) {
       getter = type.lookUpGetter2(secondaryKey, type.element.library);
       if (getter == null) {
-        throw MustachioResolutionError(node.keySpan.message(
+        throw MustachioResolutionException(node.keySpan.message(
             "Failed to resolve '$secondaryKey' on ${context.type} while "
             'resolving $remainingNames as a property chain on any types in '
             'the context chain: $contextChain, after first resolving '


### PR DESCRIPTION
I think I just got this wrong when I first implemented these; each of these is non-fatal, and expected to be caught later, so they should all be exceptions. This was all caught by the `avoid_catching_errors` lint rule.



---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
