### PR TITLE
update test expectation for newer versions of package:args

### DIFF
--- a/test/options_test.dart
+++ b/test/options_test.dart
@@ -632,7 +632,7 @@ class Foo {}
       throwsA(isA<ArgParserException>().having(
         (e) => e.toString(),
         'toString',
-        contains('Could not find an option named "nonexistent".'),
+        contains('Could not find an option named.'),
       )),
     );
   }

--- a/test/options_test.dart
+++ b/test/options_test.dart
@@ -632,7 +632,7 @@ class Foo {}
       throwsA(isA<ArgParserException>().having(
         (e) => e.toString(),
         'toString',
-        contains('Could not find an option named.'),
+        contains('Could not find an option named'),
       )),
     );
   }


### PR DESCRIPTION
- update test expectation for newer versions of package:args

A not-yet-published version of `package:args` will change the exception's message from `Could not find an option named "nonexistent"` to `Could not find an option named "--nonexistent"`; this adjusts the test expectation to work for either package:args version.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
