### PR TITLE
update test expectations for an upcoming version of package:args

### DIFF
--- a/lib/src/warnings.dart
+++ b/lib/src/warnings.dart
@@ -540,15 +540,17 @@ class PackageWarningCounter {
   bool get hasWarnings => _countedWarnings.isNotEmpty;
 
   /// Whether we've already warned for this combination of [element], [kind],
-  /// and [message].
-  bool hasWarning(Warnable? element, PackageWarning kind, String message) {
+  /// and [messageFragment].
+  bool hasWarning(
+      Warnable? element, PackageWarning kind, String messageFragment) {
     if (element == null) {
       return false;
     }
     final warning = _countedWarnings[element.element];
     if (warning != null) {
       final messages = warning[kind];
-      return messages != null && messages.contains(message);
+      return messages != null &&
+          messages.any((message) => message.contains(messageFragment));
     }
     return false;
   }

--- a/test/documentation_comment_test.dart
+++ b/test/documentation_comment_test.dart
@@ -451,8 +451,7 @@ Three.'''));
       libraryModel,
       hasInvalidParameterWarning(
           'The {@animation ...} directive was called with invalid '
-          'parameters. FormatException: Could not find an option named '
-          '"name".'),
+          'parameters. FormatException: Could not find an option named'),
     );
   }
 


### PR DESCRIPTION
- update test expectations for an upcoming version of package:args

A follow-up to https://github.com/dart-lang/dartdoc/pull/3901 to address one more test expectation. If we don't want to relax the way `PackageWarningCounter` works, we could just skip this test for a bit, until the next version of args is out.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
