### PR TITLE
Improve mustachio deduplication strategy

### DIFF
--- a/lib/src/generator/templates.aot_renderers_for_html.dart
+++ b/lib/src/generator/templates.aot_renderers_for_html.dart
@@ -32,7 +32,6 @@ import 'package:dartdoc/src/model/method.dart';
 import 'package:dartdoc/src/model/mixin.dart';
 import 'package:dartdoc/src/model/model_element.dart';
 import 'package:dartdoc/src/model/model_function.dart';
-import 'package:dartdoc/src/model/operator.dart';
 import 'package:dartdoc/src/model/package.dart';
 import 'package:dartdoc/src/model/top_level_variable.dart';
 import 'package:dartdoc/src/model/typedef.dart';
@@ -91,7 +90,7 @@ String renderCategory(CategoryTemplateData context0) {
     var context6 = context1.publicMixinsSorted;
     for (var context7 in context6) {
       buffer.write('\n      ');
-      buffer.write(_renderCategory_partial_container_4(context7));
+      buffer.write(_renderCategory_partial_container_3(context7));
     }
     buffer.writeln();
     buffer.write('''    </dl>
@@ -166,7 +165,7 @@ String renderCategory(CategoryTemplateData context0) {
     var context16 = context1.publicEnumsSorted;
     for (var context17 in context16) {
       buffer.write('\n      ');
-      buffer.write(_renderCategory_partial_container_9(context17));
+      buffer.write(_renderCategory_partial_container_3(context17));
     }
     buffer.writeln();
     buffer.write('''    </dl>
@@ -196,7 +195,7 @@ String renderCategory(CategoryTemplateData context0) {
     var context20 = context1.publicExceptionsSorted;
     for (var context21 in context20) {
       buffer.write('\n      ');
-      buffer.write(_renderCategory_partial_container_11(context21));
+      buffer.write(_renderCategory_partial_container_3(context21));
     }
     buffer.writeln();
     buffer.write('''    </dl>
@@ -259,7 +258,8 @@ String renderClass(ClassTemplateData context0) {
   buffer.write(' ');
   buffer.write(_renderClass_partial_feature_set_2(context1));
   buffer.write(' ');
-  buffer.write(_renderClass_partial_categorization_3(context1));
+  buffer.write(
+      __renderCategory_partial_container_3_partial_categorization_0(context1));
   buffer.write('''</h1></div>''');
   buffer.writeln();
   var context2 = context0.clazz;
@@ -435,7 +435,8 @@ String renderEnum(EnumTemplateData context0) {
   buffer.write(' ');
   buffer.write(_renderEnum_partial_feature_set_2(context1));
   buffer.write(' ');
-  buffer.write(_renderEnum_partial_categorization_3(context1));
+  buffer.write(
+      __renderCategory_partial_container_3_partial_categorization_0(context1));
   buffer.writeln();
   buffer.write('''      </h1>
     </div>''');
@@ -471,7 +472,8 @@ String renderEnum(EnumTemplateData context0) {
     var context3 = context2.publicEnumValues;
     for (var context4 in context3) {
       buffer.write('\n            ');
-      buffer.write(_renderEnum_partial_constant_10(context4));
+      buffer.write(__renderClass_partial_static_constants_16_partial_constant_0(
+          context4));
     }
     buffer.writeln();
     buffer.write('''        </dl>
@@ -573,7 +575,8 @@ String renderExtension<T extends Extension>(ExtensionTemplateData<T> context0) {
   buffer.write(' ');
   buffer.write(_renderExtension_partial_feature_set_2(context1));
   buffer.write(' ');
-  buffer.write(_renderExtension_partial_categorization_3(context1));
+  buffer.write(
+      __renderCategory_partial_container_3_partial_categorization_0(context1));
   buffer.write('''</h1></div>''');
   buffer.writeln();
   var context2 = context0.extension;
@@ -658,7 +661,8 @@ String renderExtensionType<T extends ExtensionType>(
   buffer.write(' ');
   buffer.write(_renderExtensionType_partial_feature_set_2(context1));
   buffer.write(' ');
-  buffer.write(_renderExtensionType_partial_categorization_3(context1));
+  buffer.write(
+      __renderCategory_partial_container_3_partial_categorization_0(context1));
   buffer.write('''</h1></div>''');
   buffer.writeln();
   var context2 = context0.extensionType;
@@ -764,7 +768,8 @@ String renderFunction(FunctionTemplateData context0) {
   buffer.write(' ');
   buffer.write(_renderFunction_partial_feature_set_2(context1));
   buffer.write(' ');
-  buffer.write(_renderFunction_partial_categorization_3(context1));
+  buffer.write(
+      __renderCategory_partial_callable_8_partial_categorization_0(context1));
   buffer.write('''</h1></div>''');
   buffer.writeln();
   var context2 = context0.function;
@@ -773,7 +778,8 @@ String renderFunction(FunctionTemplateData context0) {
         ''');
   buffer.write(_renderFunction_partial_callable_multiline_4(context2));
   buffer.write('\n        ');
-  buffer.write(_renderFunction_partial_attributes_5(context2));
+  buffer.write(
+      __renderCategory_partial_callable_8_partial_attributes_1(context2));
   buffer.writeln();
   buffer.write('''    </section>
     ''');
@@ -805,7 +811,7 @@ String renderFunction(FunctionTemplateData context0) {
 
 String renderIndex(PackageTemplateData context0) {
   final buffer = StringBuffer();
-  buffer.write(_renderIndex_partial_head_0(context0));
+  buffer.write(_renderError_partial_head_0(context0));
   buffer.writeln();
   buffer.write('''  <div id="dartdoc-main-content" class="main-content">''');
   var context1 = context0.defaultPackage;
@@ -832,7 +838,7 @@ String renderIndex(PackageTemplateData context0) {
     var context5 = context4.publicLibrariesSorted;
     for (var context6 in context5) {
       buffer.write('\n          ');
-      buffer.write(_renderIndex_partial_library_2(context6));
+      buffer.write(_renderCategory_partial_library_2(context6));
     }
     var context7 = context3.categoriesWithPublicLibraries;
     for (var context8 in context7) {
@@ -869,7 +875,7 @@ String renderIndex(PackageTemplateData context0) {
       var context11 = context8.publicLibrariesSorted;
       for (var context12 in context11) {
         buffer.write('\n            ');
-        buffer.write(_renderIndex_partial_library_2(context12));
+        buffer.write(_renderCategory_partial_library_2(context12));
       }
     }
     buffer.writeln();
@@ -880,7 +886,7 @@ String renderIndex(PackageTemplateData context0) {
   buffer.write('''  </div> <!-- /.main-content -->
   <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
     ''');
-  buffer.write(_renderIndex_partial_search_sidebar_3(context0));
+  buffer.write(_renderError_partial_search_sidebar_1(context0));
   buffer.writeln();
   buffer.write('''    <h5 class="hidden-xs"><span class="package-name">''');
   buffer.writeEscaped(context0.self.name);
@@ -888,13 +894,13 @@ String renderIndex(PackageTemplateData context0) {
   buffer.writeEscaped(context0.self.kind.toString());
   buffer.write('''</span></h5>
     ''');
-  buffer.write(_renderIndex_partial_packages_4(context0));
+  buffer.write(_renderError_partial_packages_2(context0));
   buffer.writeln();
   buffer.write('''  </div>
   <div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">
   </div>
 ''');
-  buffer.write(_renderIndex_partial_footer_5(context0));
+  buffer.write(_renderError_partial_footer_3(context0));
   buffer.writeln();
 
   return buffer.toString();
@@ -929,7 +935,8 @@ String renderLibrary(LibraryTemplateData context0) {
   buffer.write(' ');
   buffer.write(_renderLibrary_partial_feature_set_2(context1));
   buffer.write(' ');
-  buffer.write(_renderLibrary_partial_categorization_3(context1));
+  buffer.write(
+      __renderCategory_partial_library_2_partial_categorization_0(context1));
   buffer.writeln();
   buffer.write('''      </h1>
     </div>''');
@@ -948,7 +955,7 @@ String renderLibrary(LibraryTemplateData context0) {
     var context5 = context4.publicClassesSorted;
     for (var context6 in context5) {
       buffer.write('\n          ');
-      buffer.write(_renderLibrary_partial_container_5(context6));
+      buffer.write(_renderCategory_partial_container_3(context6));
     }
     buffer.writeln();
     buffer.write('''      </dl>
@@ -965,7 +972,7 @@ String renderLibrary(LibraryTemplateData context0) {
     var context9 = context8.publicEnumsSorted;
     for (var context10 in context9) {
       buffer.write('\n          ');
-      buffer.write(_renderLibrary_partial_container_6(context10));
+      buffer.write(_renderCategory_partial_container_3(context10));
     }
     buffer.writeln();
     buffer.write('''      </dl>
@@ -982,7 +989,7 @@ String renderLibrary(LibraryTemplateData context0) {
     var context13 = context12.publicMixinsSorted;
     for (var context14 in context13) {
       buffer.write('\n          ');
-      buffer.write(_renderLibrary_partial_container_7(context14));
+      buffer.write(_renderCategory_partial_container_3(context14));
     }
     buffer.writeln();
     buffer.write('''      </dl>
@@ -1017,7 +1024,7 @@ String renderLibrary(LibraryTemplateData context0) {
     var context21 = context20.publicExtensionsSorted;
     for (var context22 in context21) {
       buffer.write('\n          ');
-      buffer.write(_renderLibrary_partial_extension_9(context22));
+      buffer.write(_renderCategory_partial_extension_5(context22));
     }
     buffer.writeln();
     buffer.write('''      </dl>
@@ -1034,7 +1041,7 @@ String renderLibrary(LibraryTemplateData context0) {
     var context25 = context24.publicConstantsSorted;
     for (var context26 in context25) {
       buffer.write('\n          ');
-      buffer.write(_renderLibrary_partial_constant_10(context26));
+      buffer.write(_renderCategory_partial_constant_6(context26));
     }
     buffer.writeln();
     buffer.write('''      </dl>
@@ -1051,7 +1058,7 @@ String renderLibrary(LibraryTemplateData context0) {
     var context29 = context28.publicPropertiesSorted;
     for (var context30 in context29) {
       buffer.write('\n          ');
-      buffer.write(_renderLibrary_partial_property_11(context30));
+      buffer.write(_renderCategory_partial_property_7(context30));
     }
     buffer.writeln();
     buffer.write('''      </dl>
@@ -1068,7 +1075,7 @@ String renderLibrary(LibraryTemplateData context0) {
     var context33 = context32.publicFunctionsSorted;
     for (var context34 in context33) {
       buffer.write('\n          ');
-      buffer.write(_renderLibrary_partial_callable_12(context34));
+      buffer.write(_renderCategory_partial_callable_8(context34));
     }
     buffer.writeln();
     buffer.write('''      </dl>
@@ -1085,7 +1092,7 @@ String renderLibrary(LibraryTemplateData context0) {
     var context37 = context36.publicTypedefsSorted;
     for (var context38 in context37) {
       buffer.write('\n          ');
-      buffer.write(_renderLibrary_partial_typedef_13(context38));
+      buffer.write(_renderCategory_partial_typedef_10(context38));
     }
     buffer.writeln();
     buffer.write('''      </dl>
@@ -1102,7 +1109,7 @@ String renderLibrary(LibraryTemplateData context0) {
     var context41 = context40.publicExceptionsSorted;
     for (var context42 in context41) {
       buffer.write('\n          ');
-      buffer.write(_renderLibrary_partial_container_14(context42));
+      buffer.write(_renderCategory_partial_container_3(context42));
     }
     buffer.writeln();
     buffer.write('''      </dl>
@@ -1202,7 +1209,9 @@ String renderMethod(MethodTemplateData context0) {
       ''');
   buffer.write(_renderMethod_partial_callable_multiline_3(context2));
   buffer.write('\n      ');
-  buffer.write(_renderMethod_partial_attributes_4(context2));
+  buffer.write(
+      ___renderClass_partial_instance_methods_12_partial_callable_0_partial_attributes_1(
+          context2));
   buffer.writeln();
   buffer.write('''    </section>
     ''');
@@ -1269,7 +1278,8 @@ String renderMixin(MixinTemplateData context0) {
   buffer.write(' ');
   buffer.write(_renderMixin_partial_feature_set_2(context1));
   buffer.write(' ');
-  buffer.write(_renderMixin_partial_categorization_3(context1));
+  buffer.write(
+      __renderCategory_partial_container_3_partial_categorization_0(context1));
   buffer.write('''</h1></div>''');
   buffer.writeln();
   var context2 = context0.mixin;
@@ -1394,7 +1404,9 @@ String renderProperty(PropertyTemplateData context0) {
     buffer.write('\n        ');
     buffer.write(_renderProperty_partial_name_summary_4(context2));
     buffer.write('\n        ');
-    buffer.write(_renderProperty_partial_attributes_5(context2));
+    buffer.write(
+        ___renderClass_partial_instance_fields_11_partial_property_0_partial_attributes_1(
+            context2));
     buffer.writeln();
     buffer.write('''      </section>
       ''');
@@ -1451,13 +1463,13 @@ String renderProperty(PropertyTemplateData context0) {
 
 String renderSearchPage(PackageTemplateData context0) {
   final buffer = StringBuffer();
-  buffer.write(_renderSearchPage_partial_head_0(context0));
+  buffer.write(_renderError_partial_head_0(context0));
   buffer.writeln();
   buffer.write('''<div id="dartdoc-main-content" class="main-content">
 </div>
 <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
   ''');
-  buffer.write(_renderSearchPage_partial_search_sidebar_1(context0));
+  buffer.write(_renderError_partial_search_sidebar_1(context0));
   buffer.writeln();
   buffer.write('''  <h5 class="hidden-xs"><span class="package-name">''');
   buffer.writeEscaped(context0.self.name);
@@ -1465,13 +1477,13 @@ String renderSearchPage(PackageTemplateData context0) {
   buffer.writeEscaped(context0.self.kind.toString());
   buffer.write('''</span></h5>
   ''');
-  buffer.write(_renderSearchPage_partial_packages_2(context0));
+  buffer.write(_renderError_partial_packages_2(context0));
   buffer.writeln();
   buffer.write('''</div>
 <div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">
 </div>
 ''');
-  buffer.write(_renderSearchPage_partial_footer_3(context0));
+  buffer.write(_renderError_partial_footer_3(context0));
   buffer.writeln();
 
   return buffer.toString();
@@ -1571,7 +1583,7 @@ String renderSidebarForContainer<T extends Documentable>(
       for (var context11 in context10) {
         buffer.write('\n          ');
         buffer.write(
-            _renderSidebarForContainer_partial_container_sidebar_item_2(
+            _renderSidebarForContainer_partial_container_sidebar_item_1(
                 context11));
       }
     }
@@ -1844,7 +1856,8 @@ String renderTopLevelProperty(TopLevelPropertyTemplateData context0) {
   buffer.write(' ');
   buffer.write(_renderTopLevelProperty_partial_feature_set_2(context1));
   buffer.write(' ');
-  buffer.write(_renderTopLevelProperty_partial_categorization_3(context1));
+  buffer.write(
+      __renderCategory_partial_constant_6_partial_categorization_0(context1));
   buffer.write('''</h1></div>
 ''');
   if (!context1.hasGetterOrSetter) {
@@ -1857,7 +1870,8 @@ String renderTopLevelProperty(TopLevelPropertyTemplateData context0) {
     buffer.write('\n          ');
     buffer.write(_renderTopLevelProperty_partial_name_summary_5(context1));
     buffer.write('\n          ');
-    buffer.write(_renderTopLevelProperty_partial_attributes_6(context1));
+    buffer.write(
+        __renderCategory_partial_constant_6_partial_attributes_1(context1));
     buffer.writeln();
     buffer.write('''        </section>
         ''');
@@ -1921,7 +1935,9 @@ String renderTypedef(TypedefTemplateData context0) {
   buffer.write(' ');
   buffer.write(_renderTypedef_partial_feature_set_2(context1));
   buffer.write(' ');
-  buffer.write(_renderTypedef_partial_categorization_3(context1));
+  buffer.write(
+      ___renderCategory_partial_typedef_10_partial_type_2_partial_categorization_0(
+          context1));
   buffer.write('''</h1></div>''');
   buffer.writeln();
   buffer.write('''    <section class="multi-line-signature">''');
@@ -1958,71 +1974,206 @@ String renderTypedef(TypedefTemplateData context0) {
   return buffer.toString();
 }
 
-String _renderCategory_partial_head_0(CategoryTemplateData context0) =>
-    _deduplicated_lib_templates__head_html(context0);
+String _deduplicated__accessor_getter(GetterSetterCombo context0) {
+  final buffer = StringBuffer();
+  var context1 = context0.getter;
+  if (context1 != null) {
+    buffer.writeln();
+    buffer.write('''  <section id="getter">
+    <section class="multi-line-signature">
+      ''');
+    buffer.write(
+        __renderTopLevelProperty_partial_accessor_getter_9_partial_annotations_0(
+            context1));
+    buffer.writeln();
+    buffer.write('''      <span class="returntype">''');
+    buffer.write(context1.modelType.returnType.linkedName);
+    buffer.write('''</span>
+      get
+      ''');
+    buffer.write(
+        __renderTopLevelProperty_partial_accessor_getter_9_partial_name_summary_1(
+            context1));
+    buffer.write('\n      ');
+    buffer.write(
+        __renderTopLevelProperty_partial_accessor_getter_9_partial_attributes_2(
+            context1));
+    buffer.writeln();
+    buffer.write('''    </section>
+    ''');
+    buffer.write(
+        __renderTopLevelProperty_partial_accessor_getter_9_partial_documentation_3(
+            context1));
+    buffer.write('\n    ');
+    buffer.write(
+        __renderTopLevelProperty_partial_accessor_getter_9_partial_source_code_4(
+            context1));
+    buffer.writeln();
+    buffer.write('''  </section>''');
+  }
+  buffer.writeln();
 
-String _renderCategory_partial_documentation_1(Category context1) =>
-    _deduplicated_lib_templates__documentation_html(context1);
+  return buffer.toString();
+}
 
-String _renderCategory_partial_library_2(Library context2) =>
-    _deduplicated_lib_templates__library_html(context2);
+String _deduplicated__accessor_setter(GetterSetterCombo context0) {
+  final buffer = StringBuffer();
+  var context1 = context0.setter;
+  if (context1 != null) {
+    buffer.writeln();
+    buffer.write('''  <section id="setter">
+    <section class="multi-line-signature">
+      ''');
+    buffer.write(
+        __renderTopLevelProperty_partial_accessor_getter_9_partial_annotations_0(
+            context1));
+    buffer.writeln();
+    buffer.write('''      set
+      <span class="name ''');
+    if (context1.isDeprecated) {
+      buffer.write('''deprecated''');
+    }
+    buffer.write('''">''');
+    buffer.writeEscaped(context1.definingCombo.name);
+    buffer.write('''</span>
+      <span class="signature">(<wbr>''');
+    buffer.write(context1.linkedParamsNoMetadata);
+    buffer.write(''')</span>
+      ''');
+    buffer.write(
+        __renderTopLevelProperty_partial_accessor_getter_9_partial_attributes_2(
+            context1));
+    buffer.writeln();
+    buffer.write('''    </section>
+    ''');
+    buffer.write(
+        __renderTopLevelProperty_partial_accessor_getter_9_partial_documentation_3(
+            context1));
+    buffer.write('\n    ');
+    buffer.write(
+        __renderTopLevelProperty_partial_accessor_getter_9_partial_source_code_4(
+            context1));
+    buffer.writeln();
+    buffer.write('''  </section>''');
+  }
+  buffer.writeln();
 
-String _renderCategory_partial_container_3(Container context2) =>
-    _deduplicated_lib_templates__container_html(context2);
+  return buffer.toString();
+}
 
-String _renderCategory_partial_container_4(Mixin context2) =>
-    _deduplicated_lib_templates__container_html(context2);
+String _deduplicated__annotations(ModelElement context0) {
+  final buffer = StringBuffer();
+  if (context0.hasAnnotations) {
+    buffer.writeln();
+    buffer.write('''  <div>
+    <ol class="annotation-list">''');
+    var context1 = context0.annotations;
+    for (var context2 in context1) {
+      buffer.writeln();
+      buffer.write('''        <li>''');
+      buffer.write(context2.linkedNameWithParameters);
+      buffer.write('''</li>''');
+    }
+    buffer.writeln();
+    buffer.write('''    </ol>
+  </div>''');
+  }
 
-String _renderCategory_partial_extension_5(Extension context2) =>
-    _deduplicated_lib_templates__extension_html(context2);
+  return buffer.toString();
+}
 
-String _renderCategory_partial_constant_6(TopLevelVariable context2) =>
-    _deduplicated_lib_templates__constant_html(context2);
+String _deduplicated__attributes(ModelElement context0) {
+  final buffer = StringBuffer();
+  if (context0.hasAttributes) {
+    buffer.write('''<div class="features">''');
+    buffer.write(context0.attributesAsString);
+    buffer.write('''</div>''');
+  }
+  buffer.writeln();
 
-String _renderCategory_partial_property_7(TopLevelVariable context2) {
+  return buffer.toString();
+}
+
+String _deduplicated__available_extensions(InheritingContainer context0) {
+  final buffer = StringBuffer();
+  if (context0.hasPotentiallyApplicableExtensions) {
+    buffer.writeln();
+    buffer.write('''  <dt>Available extensions</dt>
+  <dd><ul class="comma-separated clazz-relationships">''');
+    var context1 = context0.potentiallyApplicableExtensionsSorted;
+    for (var context2 in context1) {
+      buffer.writeln();
+      buffer.write('''      <li>''');
+      buffer.write(context2.linkedName);
+      buffer.write('''</li>''');
+    }
+    buffer.writeln();
+    buffer.write('''  </ul></dd>''');
+  }
+
+  return buffer.toString();
+}
+
+String _deduplicated__categorization(ModelElement context0) {
+  final buffer = StringBuffer();
+  if (context0.hasCategoryNames) {
+    var context1 = context0.displayedCategories;
+    for (var context2 in context1) {
+      buffer.write('\n    ');
+      buffer.write(context2!.categoryLabel);
+    }
+  }
+  buffer.writeln();
+
+  return buffer.toString();
+}
+
+String _deduplicated__constant(GetterSetterCombo context0) {
   final buffer = StringBuffer();
   buffer.write('''<dt id="''');
-  buffer.writeEscaped(context2.htmlId);
-  buffer.write('''" class="property''');
-  if (context2.isInherited) {
-    buffer.write(''' inherited''');
+  buffer.writeEscaped(context0.htmlId);
+  buffer.write('''" class="constant">''');
+  if (context0.isEnumValue) {
+    buffer.writeln();
+    buffer.write('''    <span class="name ''');
+    if (context0.isDeprecated) {
+      buffer.write('''deprecated''');
+    }
+    buffer.write('''">''');
+    buffer.write(context0.name);
+    buffer.write('''</span>''');
   }
-  buffer.write('''">
-  <span class="name">''');
-  buffer.write(context2.linkedName);
-  buffer.write('''</span>
-  <span class="signature">''');
-  buffer.write(context2.arrow);
-  buffer.write(' ');
-  buffer.write(context2.modelType.linkedName);
+  if (!context0.isEnumValue) {
+    buffer.writeln();
+    buffer.write('''    <span class="name ''');
+    if (context0.isDeprecated) {
+      buffer.write('''deprecated''');
+    }
+    buffer.write('''">''');
+    buffer.write(context0.linkedName);
+    buffer.write('''</span>''');
+  }
+  buffer.writeln();
+  buffer.write('''  <span class="signature">&#8594; const ''');
+  buffer.write(context0.modelType.linkedName);
   buffer.write('''</span>
   ''');
-  buffer.write(
-      __renderCategory_partial_property_7_partial_categorization_0(context2));
+  buffer.write(_deduplicated__categorization(context0));
   buffer.writeln();
   buffer.write('''</dt>
-<dd''');
-  if (context2.isInherited) {
-    buffer.write(''' class="inherited"''');
-  }
-  buffer.write('''>''');
-  if (context2.isProvidedByExtension) {
-    var context3 = context2.enclosingExtension;
+<dd>
+  ''');
+  buffer.write(context0.oneLineDoc);
+  buffer.write('\n  ');
+  buffer.write(_deduplicated__attributes(context0));
+  if (context0.hasConstantValueForDisplay) {
     buffer.writeln();
-    buffer.write('''      <p class="from-extension">
-        <span>Available on ''');
-    buffer.write(context3.extendedElement.linkedName);
-    buffer.write(''',
-        provided by the ''');
-    buffer.write(context3.linkedName);
-    buffer.write(''' extension</span>
-      </p>''');
+    buffer.write('''    <div>
+      <span class="signature"><code>''');
+    buffer.write(context0.constantValueTruncated);
+    buffer.write('''</code></span>
+    </div>''');
   }
-  buffer.write('\n  ');
-  buffer.write(context2.oneLineDoc);
-  buffer.write('\n  ');
-  buffer.write(
-      __renderCategory_partial_property_7_partial_attributes_1(context2));
   buffer.writeln();
   buffer.write('''</dd>
 ''');
@@ -2030,13 +2181,649 @@ String _renderCategory_partial_property_7(TopLevelVariable context2) {
   return buffer.toString();
 }
 
-String __renderCategory_partial_property_7_partial_categorization_0(
-        TopLevelVariable context2) =>
-    _deduplicated_lib_templates__categorization_html(context2);
+String _deduplicated__constructors(Constructable context0) {
+  final buffer = StringBuffer();
+  if (context0.hasPublicConstructors) {
+    buffer.writeln();
+    buffer.write('''  <section class="summary offset-anchor" id="constructors">
+    <h2>Constructors</h2>
+    <dl class="constructor-summary-list">''');
+    var context1 = context0.publicConstructorsSorted;
+    for (var context2 in context1) {
+      buffer.writeln();
+      buffer.write('''        <dt id="''');
+      buffer.writeEscaped(context2.htmlId);
+      buffer.write('''" class="callable">
+          <span class="name">''');
+      buffer.write(context2.linkedName);
+      buffer.write('''</span><span class="signature">(''');
+      buffer.write(context2.linkedParams);
+      buffer.write(''')</span>
+        </dt>
+        <dd>
+          ''');
+      buffer.write(context2.oneLineDoc);
+      if (context2.isConst) {
+        buffer.writeln();
+        buffer.write(
+            '''            <div class="constructor-modifier features">const</div>''');
+      }
+      if (context2.isFactory) {
+        buffer.writeln();
+        buffer.write(
+            '''            <div class="constructor-modifier features">factory</div>''');
+      }
+      buffer.writeln();
+      buffer.write('''        </dd>''');
+    }
+    buffer.writeln();
+    buffer.write('''    </dl>
+  </section>''');
+  }
 
-String __renderCategory_partial_property_7_partial_attributes_1(
-        TopLevelVariable context2) =>
-    _deduplicated_lib_templates__attributes_html(context2);
+  return buffer.toString();
+}
+
+String _deduplicated__container_annotations(Container context0) {
+  final buffer = StringBuffer();
+  if (context0.hasAnnotations) {
+    buffer.writeln();
+    buffer.write('''  <dt>Annotations</dt>
+  <dd>
+    <ul class="annotation-list ''');
+    buffer.writeEscaped(context0.relationshipsClass);
+    buffer.write('''">''');
+    var context1 = context0.annotations;
+    for (var context2 in context1) {
+      buffer.writeln();
+      buffer.write('''        <li>''');
+      buffer.write(context2.linkedNameWithParameters);
+      buffer.write('''</li>''');
+    }
+    buffer.writeln();
+    buffer.write('''    </ul>
+  </dd>''');
+  }
+  buffer.write('\n\n');
+
+  return buffer.toString();
+}
+
+String _deduplicated__documentation(Warnable context0) {
+  final buffer = StringBuffer();
+  if (context0.hasDocumentation) {
+    buffer.writeln();
+    buffer.write('''<section class="desc markdown">
+  ''');
+    buffer.write(context0.documentationAsHtml);
+    buffer.writeln();
+    buffer.write('''</section>''');
+  }
+  buffer.writeln();
+
+  return buffer.toString();
+}
+
+String _deduplicated__feature_set(ModelElement context0) {
+  final buffer = StringBuffer();
+  if (context0.hasFeatureSet) {
+    var context1 = context0.displayedLanguageFeatures;
+    for (var context2 in context1) {
+      buffer.write('\n    ');
+      buffer.write(context2.featureLabel);
+    }
+  }
+  buffer.writeln();
+
+  return buffer.toString();
+}
+
+String _deduplicated__footer(TemplateDataBase context0) {
+  final buffer = StringBuffer();
+  buffer.write('''</main>
+<footer>
+  <span class="no-break">
+    ''');
+  buffer.writeEscaped(context0.defaultPackage.name);
+  if (context0.hasFooterVersion) {
+    buffer.write('\n      ');
+    buffer.writeEscaped(context0.defaultPackage.version);
+  }
+  buffer.writeln();
+  buffer.write('''  </span>
+  ''');
+  buffer.write(context0.customInnerFooter);
+  buffer.writeln();
+  buffer.write('''</footer>
+''');
+  buffer.writeln();
+  buffer.writeln();
+  buffer.write('''<script src="''');
+  if (!context0.useBaseHref) {
+    buffer.write('''%%__HTMLBASE_dartdoc_internal__%%''');
+  }
+  buffer.write('''static-assets/highlight.pack.js?v1"></script>
+<script src="''');
+  if (!context0.useBaseHref) {
+    buffer.write('''%%__HTMLBASE_dartdoc_internal__%%''');
+  }
+  buffer.write('''static-assets/docs.dart.js"></script>
+''');
+  buffer.write(context0.customFooter);
+  buffer.writeln();
+  buffer.write('''</body>
+</html>
+''');
+
+  return buffer.toString();
+}
+
+String _deduplicated__head(TemplateDataBase context0) {
+  final buffer = StringBuffer();
+  buffer.write('''<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1, user-scalable=no">
+  <meta name="description" content="''');
+  buffer.writeEscaped(context0.metaDescription);
+  buffer.write('''">
+  <title>''');
+  buffer.writeEscaped(context0.title);
+  buffer.write('''</title>''');
+  var context1 = context0.relCanonicalPrefix;
+  if (context1 != null) {
+    buffer.writeln();
+    buffer.write('''  <link rel="canonical" href="''');
+    buffer.write(context0.relCanonicalPrefix);
+    buffer.write('''/''');
+    buffer.write(context0.bareHref);
+    buffer.write('''">''');
+  }
+  buffer.writeln();
+  if (context0.useBaseHref) {
+    var context2 = context0.htmlBase;
+    buffer.writeln();
+    buffer
+        .write('''  <!-- required because all the links are pseudo-absolute -->
+  <base href="''');
+    buffer.write(context0.htmlBase);
+    buffer.write('''">''');
+  }
+  buffer.write('\n\n  ');
+  buffer.writeln();
+  buffer.write('''  <link rel="preconnect" href="https://fonts.gstatic.com">
+  <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0" rel="stylesheet">
+  ''');
+  buffer.writeln();
+  buffer.write('''  <link rel="stylesheet" href="''');
+  if (!context0.useBaseHref) {
+    buffer.write('''%%__HTMLBASE_dartdoc_internal__%%''');
+  }
+  buffer.write('''static-assets/github.css?v1">
+  <link rel="stylesheet" href="''');
+  if (!context0.useBaseHref) {
+    buffer.write('''%%__HTMLBASE_dartdoc_internal__%%''');
+  }
+  buffer.write('''static-assets/styles.css?v1">
+  <link rel="icon" href="''');
+  if (!context0.useBaseHref) {
+    buffer.write('''%%__HTMLBASE_dartdoc_internal__%%''');
+  }
+  buffer.write('''static-assets/favicon.png?v1">
+  ''');
+  buffer.write(context0.customHeader);
+  buffer.writeln();
+  buffer.write('''</head>
+''');
+  buffer.writeln();
+  buffer.write('''<body data-base-href="''');
+  buffer.write(context0.htmlBase);
+  buffer.write('''" data-using-base-href="''');
+  buffer.write(context0.useBaseHref.toString());
+  buffer.write('''" class="light-theme">
+<div id="overlay-under-drawer"></div>
+<header id="title">
+  <span id="sidenav-left-toggle" class="material-symbols-outlined" role="button" tabindex="0">menu</span>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">''');
+  var context3 = context0.navLinks;
+  for (var context4 in context3) {
+    buffer.writeln();
+    buffer.write('''    <li><a href="''');
+    buffer.write(context4.href);
+    buffer.write('''">''');
+    buffer.writeEscaped(context4.breadcrumbName);
+    buffer.write('''</a></li>''');
+  }
+  var context5 = context0.navLinksWithGenerics;
+  for (var context6 in context5) {
+    buffer.writeln();
+    buffer.write('''    <li><a href="''');
+    buffer.write(context6.href);
+    buffer.write('''">''');
+    buffer.writeEscaped(context6.breadcrumbName);
+    if (context6.hasGenericParameters) {
+      buffer.write('''<span class="signature">''');
+      buffer.write(context6.genericParameters);
+      buffer.write('''</span>''');
+    }
+    buffer.write('''</a></li>''');
+  }
+  if (!context0.hasHomepage) {
+    buffer.writeln();
+    buffer.write('''    <li class="self-crumb">''');
+    buffer.write(context0.layoutTitle);
+    buffer.write('''</li>''');
+  }
+  if (context0.hasHomepage) {
+    buffer.writeln();
+    buffer.write('''    <li><a href="''');
+    buffer.write(context0.homepage);
+    buffer.write('''">''');
+    buffer.write(context0.layoutTitle);
+    buffer.write('''</a></li>''');
+  }
+  buffer.writeln();
+  buffer.write('''  </ol>
+  <div class="self-name">''');
+  buffer.writeEscaped(context0.self.name);
+  buffer.write('''</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+  <div class="toggle" id="theme-button" title="Toggle brightness">
+    <label for="theme">
+      <input type="checkbox" id="theme" value="light-theme">
+      <span id="dark-theme-button" class="material-symbols-outlined">
+        dark_mode
+      </span>
+      <span id="light-theme-button" class="material-symbols-outlined">
+        light_mode
+      </span>
+    </label>
+  </div>
+</header>
+<main>''');
+
+  return buffer.toString();
+}
+
+String _deduplicated__instance_fields(Container context0) {
+  final buffer = StringBuffer();
+  if (context0.hasAvailableInstanceFields) {
+    buffer.writeln();
+    buffer.write('''  <section
+      class="summary offset-anchor''');
+    if (context0.publicInheritedInstanceFields) {
+      buffer.write(''' inherited''');
+    }
+    buffer.write('''"
+      id="instance-properties">
+    <h2>Properties</h2>
+    <dl class="properties">''');
+    var context1 = context0.availableInstanceFieldsSorted;
+    for (var context2 in context1) {
+      buffer.write('\n        ');
+      buffer.write(__renderClass_partial_instance_fields_11_partial_property_0(
+          context2));
+    }
+    buffer.writeln();
+    buffer.write('''    </dl>
+  </section>''');
+  }
+  buffer.writeln();
+
+  return buffer.toString();
+}
+
+String _deduplicated__instance_methods(Container context0) {
+  final buffer = StringBuffer();
+  if (context0.hasAvailableInstanceMethods) {
+    buffer.writeln();
+    buffer.write('''  <section
+      class="summary offset-anchor''');
+    if (context0.publicInheritedInstanceMethods) {
+      buffer.write(''' inherited''');
+    }
+    buffer.write('''"
+      id="instance-methods">
+    <h2>Methods</h2>
+    <dl class="callables">''');
+    var context1 = context0.availableInstanceMethodsSorted;
+    for (var context2 in context1) {
+      buffer.write('\n        ');
+      buffer.write(__renderClass_partial_instance_methods_12_partial_callable_0(
+          context2));
+    }
+    buffer.writeln();
+    buffer.write('''    </dl>
+  </section>''');
+  }
+
+  return buffer.toString();
+}
+
+String _deduplicated__instance_operators(Container context0) {
+  final buffer = StringBuffer();
+  if (context0.hasAvailableInstanceOperators) {
+    buffer.writeln();
+    buffer.write('''  <section
+      class="summary offset-anchor''');
+    if (context0.publicInheritedInstanceOperators) {
+      buffer.write(''' inherited''');
+    }
+    buffer.write('''"
+      id="operators">
+    <h2>Operators</h2>
+    <dl class="callables">''');
+    var context1 = context0.availableInstanceOperatorsSorted;
+    for (var context2 in context1) {
+      buffer.write('\n        ');
+      buffer.write(__renderClass_partial_instance_methods_12_partial_callable_0(
+          context2));
+    }
+    buffer.writeln();
+    buffer.write('''    </dl>
+  </section>''');
+  }
+
+  return buffer.toString();
+}
+
+String _deduplicated__interfaces(InheritingContainer context0) {
+  final buffer = StringBuffer();
+  if (context0.hasPublicInterfaces) {
+    buffer.writeln();
+    buffer.write('''  <dt>Implemented types</dt>
+  <dd>
+    <ul class="comma-separated ''');
+    buffer.writeEscaped(context0.relationshipsClass);
+    buffer.write('''">''');
+    var context1 = context0.publicInterfaces;
+    for (var context2 in context1) {
+      buffer.writeln();
+      buffer.write('''        <li>''');
+      buffer.write(context2.linkedName);
+      buffer.write('''</li>''');
+    }
+    buffer.writeln();
+    buffer.write('''    </ul>
+  </dd>''');
+  }
+
+  return buffer.toString();
+}
+
+String _deduplicated__name_summary(ModelElement context0) {
+  final buffer = StringBuffer();
+  if (context0.isConst) {
+    buffer.write('''const ''');
+  }
+  buffer.write('''<span class="name ''');
+  if (context0.isDeprecated) {
+    buffer.write('''deprecated''');
+  }
+  buffer.write('''">''');
+  buffer.writeEscaped(context0.name);
+  buffer.write('''</span>''');
+
+  return buffer.toString();
+}
+
+String _deduplicated__packages(TemplateDataBase context0) {
+  final buffer = StringBuffer();
+  buffer.write('''<ol>''');
+  var context1 = context0.localPackages;
+  for (var context2 in context1) {
+    if (context2.isFirstPackage) {
+      if (context2.hasDocumentedCategories) {
+        buffer.writeln();
+        buffer.write('''      <li class="section-title">Topics</li>''');
+        var context3 = context2.documentedCategoriesSorted;
+        for (var context4 in context3) {
+          buffer.writeln();
+          buffer.write('''        <li>''');
+          buffer.write(context4.linkedName);
+          buffer.write('''</li>''');
+        }
+      }
+      buffer.writeln();
+      buffer.write('''      <li class="section-title">Libraries</li>''');
+    }
+    if (!context2.isFirstPackage) {
+      buffer.writeln();
+      buffer.write('''      <li class="section-title">''');
+      buffer.writeEscaped(context2.name);
+      buffer.write('''</li>''');
+    }
+    var context5 = context2.defaultCategory;
+    var context6 = context5.publicLibrariesSorted;
+    for (var context7 in context6) {
+      buffer.writeln();
+      buffer.write('''      <li>''');
+      buffer.write(context7.linkedName);
+      buffer.write('''</li>''');
+    }
+    var context8 = context2.categoriesWithPublicLibraries;
+    for (var context9 in context8) {
+      buffer.writeln();
+      buffer.write('''      <li class="section-subtitle">''');
+      buffer.writeEscaped(context9.name);
+      buffer.write('''</li>''');
+      var context10 = context9.externalItems;
+      for (var context11 in context10) {
+        buffer.writeln();
+        buffer.write('''        <li class="section-subitem">
+          <a href="''');
+        buffer.writeEscaped(context11.url);
+        buffer.write('''" target="_blank">
+            ''');
+        buffer.writeEscaped(context11.name);
+        buffer.writeln();
+        buffer.write(
+            '''            <span class="material-symbols-outlined">open_in_new</span>
+          </a>
+        </li>''');
+      }
+      var context12 = context9.publicLibrariesSorted;
+      for (var context13 in context12) {
+        buffer.writeln();
+        buffer.write('''        <li class="section-subitem">''');
+        buffer.write(context13.linkedName);
+        buffer.write('''</li>''');
+      }
+    }
+  }
+  buffer.writeln();
+  buffer.write('''</ol>
+''');
+
+  return buffer.toString();
+}
+
+String _deduplicated__search_sidebar(TemplateDataBase context0) {
+  final buffer = StringBuffer();
+  buffer.write(
+      '''<!-- The search input and breadcrumbs below are only responsively visible at low resolutions. -->
+<header id="header-search-sidebar" class="hidden-l">
+  <form class="search-sidebar" role="search">
+    <input type="text" id="search-sidebar" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+<ol class="breadcrumbs gt-separated dark hidden-l" id="sidebar-nav">''');
+  var context1 = context0.navLinks;
+  for (var context2 in context1) {
+    buffer.writeln();
+    buffer.write('''    <li><a href="''');
+    buffer.write(context2.href);
+    buffer.write('''">''');
+    buffer.writeEscaped(context2.name);
+    buffer.write('''</a></li>''');
+  }
+  var context3 = context0.navLinksWithGenerics;
+  for (var context4 in context3) {
+    buffer.writeln();
+    buffer.write('''    <li><a href="''');
+    buffer.write(context4.href);
+    buffer.write('''">''');
+    buffer.writeEscaped(context4.name);
+    if (context4.hasGenericParameters) {
+      buffer.write('''<span class="signature">''');
+      buffer.write(context4.genericParameters);
+      buffer.write('''</span>''');
+    }
+    buffer.write('''</a></li>''');
+  }
+  if (!context0.hasHomepage) {
+    buffer.writeln();
+    buffer.write('''    <li class="self-crumb">''');
+    buffer.write(context0.layoutTitle);
+    buffer.write('''</li>''');
+  }
+  if (context0.hasHomepage) {
+    buffer.writeln();
+    buffer.write('''    <li><a href="''');
+    buffer.write(context0.homepage);
+    buffer.write('''">''');
+    buffer.write(context0.layoutTitle);
+    buffer.write('''</a></li>''');
+  }
+  buffer.writeln();
+  buffer.write('''</ol>
+''');
+
+  return buffer.toString();
+}
+
+String _deduplicated__source_code(ModelElement context0) {
+  final buffer = StringBuffer();
+  if (context0.hasSourceCode) {
+    buffer.writeln();
+    buffer.write('''<section class="summary source-code" id="source">
+  <h2><span>Implementation</span></h2>
+  <pre class="language-dart"><code class="language-dart">''');
+    buffer.write(context0.sourceCode);
+    buffer.write('''</code></pre>
+</section>''');
+  }
+  buffer.writeln();
+
+  return buffer.toString();
+}
+
+String _deduplicated__source_link(ModelElement context0) {
+  final buffer = StringBuffer();
+  if (context0.hasSourceHref) {
+    buffer.writeln();
+    buffer.write(
+        '''  <div id="external-links" class="btn-group"><a title="View source code" class="source-link" href="''');
+    buffer.write(context0.sourceHref);
+    buffer.write(
+        '''"><span class="material-symbols-outlined">description</span></a></div>''');
+  }
+  buffer.writeln();
+
+  return buffer.toString();
+}
+
+String _deduplicated__static_constants(Container context0) {
+  final buffer = StringBuffer();
+  buffer.writeln();
+  if (context0.hasPublicConstantFields) {
+    buffer.writeln();
+    buffer.write('''  <section class="summary offset-anchor" id="constants">
+    <h2>Constants</h2>
+    <dl class="properties">''');
+    var context1 = context0.publicConstantFieldsSorted;
+    for (var context2 in context1) {
+      buffer.write('\n        ');
+      buffer.write(__renderClass_partial_static_constants_16_partial_constant_0(
+          context2));
+    }
+    buffer.writeln();
+    buffer.write('''    </dl>
+  </section>''');
+  }
+
+  return buffer.toString();
+}
+
+String _deduplicated__static_methods(Container context0) {
+  final buffer = StringBuffer();
+  if (context0.hasPublicStaticMethods) {
+    buffer.writeln();
+    buffer
+        .write('''  <section class="summary offset-anchor" id="static-methods">
+    <h2>Static Methods</h2>
+    <dl class="callables">''');
+    var context1 = context0.publicStaticMethodsSorted;
+    for (var context2 in context1) {
+      buffer.write('\n        ');
+      buffer.write(__renderClass_partial_instance_methods_12_partial_callable_0(
+          context2));
+    }
+    buffer.writeln();
+    buffer.write('''    </dl>
+  </section>''');
+  }
+
+  return buffer.toString();
+}
+
+String _deduplicated__static_properties(Container context0) {
+  final buffer = StringBuffer();
+  if (context0.hasPublicVariableStaticFields) {
+    buffer.writeln();
+    buffer.write(
+        '''  <section class="summary offset-anchor" id="static-properties">
+    <h2>Static Properties</h2>
+    <dl class="properties">''');
+    var context1 = context0.publicVariableStaticFieldsSorted;
+    for (var context2 in context1) {
+      buffer.write('\n        ');
+      buffer.write(__renderClass_partial_instance_fields_11_partial_property_0(
+          context2));
+    }
+    buffer.writeln();
+    buffer.write('''    </dl>
+  </section>''');
+  }
+
+  return buffer.toString();
+}
+
+String _deduplicated__super_chain(InheritingContainer context0) {
+  final buffer = StringBuffer();
+  if (context0.hasPublicSuperChainReversed) {
+    buffer.writeln();
+    buffer.write('''  <dt>Inheritance</dt>
+  <dd>
+    <ul class="gt-separated dark ''');
+    buffer.writeEscaped(context0.relationshipsClass);
+    buffer.write('''">
+      <li>''');
+    buffer.write(context0.linkedObjectType);
+    buffer.write('''</li>''');
+    var context1 = context0.publicSuperChainReversed;
+    for (var context2 in context1) {
+      buffer.writeln();
+      buffer.write('''        <li>''');
+      buffer.write(context2.linkedName);
+      buffer.write('''</li>''');
+    }
+    buffer.writeln();
+    buffer.write('''      <li>''');
+    buffer.write(context0.name);
+    buffer.write('''</li>
+    </ul>
+  </dd>''');
+  }
+  buffer.writeln();
+
+  return buffer.toString();
+}
 
 String _renderCategory_partial_callable_8(ModelFunctionTyped context2) {
   final buffer = StringBuffer();
@@ -2096,29 +2883,154 @@ String _renderCategory_partial_callable_8(ModelFunctionTyped context2) {
   return buffer.toString();
 }
 
-String __renderCategory_partial_callable_8_partial_categorization_0(
-        ModelFunctionTyped context2) =>
-    _deduplicated_lib_templates__categorization_html(context2);
+String _renderCategory_partial_constant_6(TopLevelVariable context2) =>
+    _deduplicated__constant(context2);
 
-String __renderCategory_partial_callable_8_partial_attributes_1(
-        ModelFunctionTyped context2) =>
-    _deduplicated_lib_templates__attributes_html(context2);
+String _renderCategory_partial_container_3(Container context2) {
+  final buffer = StringBuffer();
+  buffer.write('''<dt id="''');
+  buffer.writeEscaped(context2.htmlId);
+  buffer.write('''">
+  <span class="name ''');
+  if (context2.isDeprecated) {
+    buffer.write('''deprecated''');
+  }
+  buffer.write('''">''');
+  buffer.write(context2.linkedName);
+  buffer.write(context2.linkedGenericParameters);
+  buffer.write('''</span> ''');
+  buffer.write(
+      __renderCategory_partial_container_3_partial_categorization_0(context2));
+  buffer.writeln();
+  buffer.write('''</dt>
+<dd>
+  ''');
+  buffer.write(context2.oneLineDoc);
+  buffer.writeln();
+  buffer.write('''</dd>
+''');
 
-String _renderCategory_partial_container_9(Enum context2) =>
-    _deduplicated_lib_templates__container_html(context2);
+  return buffer.toString();
+}
 
-String _renderCategory_partial_typedef_10(Typedef context2) =>
-    _deduplicated_lib_templates__typedef_html(context2);
+String _renderCategory_partial_documentation_1(Category context1) =>
+    _deduplicated__documentation(context1);
 
-String _renderCategory_partial_container_11(Class context2) =>
-    _deduplicated_lib_templates__container_html(context2);
+String _renderCategory_partial_extension_5(Extension context2) {
+  final buffer = StringBuffer();
+  buffer.write('''<dt id="''');
+  buffer.writeEscaped(context2.htmlId);
+  buffer.write('''">
+  <span class="name ''');
+  if (context2.isDeprecated) {
+    buffer.write('''deprecated''');
+  }
+  buffer.write('''">''');
+  buffer.write(context2.linkedName);
+  buffer.write('''</span>
+  on ''');
+  buffer.write(context2.extendedElement.linkedName);
+  buffer.write('\n  ');
+  buffer.write(
+      __renderCategory_partial_container_3_partial_categorization_0(context2));
+  buffer.writeln();
+  buffer.write('''</dt>
+<dd>
+  ''');
+  buffer.write(context2.oneLineDoc);
+  buffer.writeln();
+  buffer.write('''</dd>
+''');
+
+  return buffer.toString();
+}
+
+String _renderCategory_partial_footer_15(CategoryTemplateData context0) =>
+    _deduplicated__footer(context0);
+
+String _renderCategory_partial_head_0(CategoryTemplateData context0) =>
+    _deduplicated__head(context0);
+
+String _renderCategory_partial_library_2(Library context2) {
+  final buffer = StringBuffer();
+  buffer.write('''<dt id="''');
+  buffer.writeEscaped(context2.htmlId);
+  buffer.write('''">
+  <span class="name">''');
+  buffer.write(context2.linkedName);
+  buffer.write('''</span> ''');
+  buffer.write(
+      __renderCategory_partial_library_2_partial_categorization_0(context2));
+  buffer.writeln();
+  buffer.write('''</dt>
+<dd>''');
+  if (context2.isDocumented) {
+    buffer.write(context2.oneLineDoc);
+  }
+  buffer.writeln();
+  buffer.write('''</dd>
+''');
+
+  return buffer.toString();
+}
+
+String _renderCategory_partial_packages_13(CategoryTemplateData context0) =>
+    _deduplicated__packages(context0);
+
+String _renderCategory_partial_property_7(TopLevelVariable context2) {
+  final buffer = StringBuffer();
+  buffer.write('''<dt id="''');
+  buffer.writeEscaped(context2.htmlId);
+  buffer.write('''" class="property''');
+  if (context2.isInherited) {
+    buffer.write(''' inherited''');
+  }
+  buffer.write('''">
+  <span class="name">''');
+  buffer.write(context2.linkedName);
+  buffer.write('''</span>
+  <span class="signature">''');
+  buffer.write(context2.arrow);
+  buffer.write(' ');
+  buffer.write(context2.modelType.linkedName);
+  buffer.write('''</span>
+  ''');
+  buffer.write(
+      __renderCategory_partial_constant_6_partial_categorization_0(context2));
+  buffer.writeln();
+  buffer.write('''</dt>
+<dd''');
+  if (context2.isInherited) {
+    buffer.write(''' class="inherited"''');
+  }
+  buffer.write('''>''');
+  if (context2.isProvidedByExtension) {
+    var context3 = context2.enclosingExtension;
+    buffer.writeln();
+    buffer.write('''      <p class="from-extension">
+        <span>Available on ''');
+    buffer.write(context3.extendedElement.linkedName);
+    buffer.write(''',
+        provided by the ''');
+    buffer.write(context3.linkedName);
+    buffer.write(''' extension</span>
+      </p>''');
+  }
+  buffer.write('\n  ');
+  buffer.write(context2.oneLineDoc);
+  buffer.write('\n  ');
+  buffer.write(
+      __renderCategory_partial_constant_6_partial_attributes_1(context2));
+  buffer.writeln();
+  buffer.write('''</dd>
+''');
+
+  return buffer.toString();
+}
 
 String _renderCategory_partial_search_sidebar_12(
         CategoryTemplateData context0) =>
-    _deduplicated_lib_templates__search_sidebar_html(context0);
-
-String _renderCategory_partial_packages_13(CategoryTemplateData context0) =>
-    _deduplicated_lib_templates__packages_html(context0);
+    _deduplicated__search_sidebar(context0);
 
 String _renderCategory_partial_sidebar_for_category_14(
     CategoryTemplateData context0) {
@@ -2306,29 +3218,90 @@ String _renderCategory_partial_sidebar_for_category_14(
   return buffer.toString();
 }
 
-String _renderCategory_partial_footer_15(CategoryTemplateData context0) =>
-    _deduplicated_lib_templates__footer_html(context0);
+String _renderCategory_partial_typedef_10(Typedef context2) {
+  final buffer = StringBuffer();
+  if (context2.isCallable) {
+    var context3 = context2.asCallable;
+    buffer.writeln();
+    buffer.write('''  <dt id="''');
+    buffer.writeEscaped(context3.htmlId);
+    buffer.write('''" class="callable''');
+    if (context3.isInherited) {
+      buffer.write(''' inherited''');
+    }
+    buffer.write('''">
+    <span class="name''');
+    if (context3.isDeprecated) {
+      buffer.write(''' deprecated''');
+    }
+    buffer.write('''">''');
+    buffer.write(context3.linkedName);
+    buffer.write('''</span>''');
+    buffer.write(context3.linkedGenericParameters);
+    buffer.write('''<span class="signature">
+      <span class="returntype parameter">= ''');
+    buffer.write(context3.modelType.linkedName);
+    buffer.write('''</span>
+    </span>
+    ''');
+    buffer.write(
+        __renderCategory_partial_typedef_10_partial_categorization_0(context3));
+    buffer.writeln();
+    buffer.write('''  </dt>
+  <dd''');
+    if (context3.isInherited) {
+      buffer.write(''' class="inherited"''');
+    }
+    buffer.write('''>
+    ''');
+    buffer.write(context3.oneLineDoc);
+    buffer.write('\n    ');
+    buffer.write(
+        __renderCategory_partial_typedef_10_partial_attributes_1(context3));
+    buffer.writeln();
+    buffer.write('''  </dd>''');
+  }
+  if (!context2.isCallable) {
+    buffer.write('\n  ');
+    buffer.write(__renderCategory_partial_typedef_10_partial_type_2(context2));
+  }
+  buffer.writeln();
 
-String _renderClass_partial_head_0(ClassTemplateData context0) =>
-    _deduplicated_lib_templates__head_html(context0);
+  return buffer.toString();
+}
 
-String _renderClass_partial_source_link_1(Class context1) =>
-    _deduplicated_lib_templates__source_link_html(context1);
+String _renderClass_partial_available_extensions_8(Class context1) =>
+    _deduplicated__available_extensions(context1);
 
-String _renderClass_partial_feature_set_2(Class context1) =>
-    _deduplicated_lib_templates__feature_set_html(context1);
+String _renderClass_partial_constructors_10(Class context1) =>
+    _deduplicated__constructors(context1);
 
-String _renderClass_partial_categorization_3(Class context1) =>
-    _deduplicated_lib_templates__categorization_html(context1);
+String _renderClass_partial_container_annotations_9(Class context1) =>
+    _deduplicated__container_annotations(context1);
 
 String _renderClass_partial_documentation_4(Class context1) =>
-    _deduplicated_lib_templates__documentation_html(context1);
+    _deduplicated__documentation(context1);
 
-String _renderClass_partial_super_chain_5(Class context1) =>
-    _deduplicated_lib_templates__super_chain_html(context1);
+String _renderClass_partial_feature_set_2(Class context1) =>
+    _deduplicated__feature_set(context1);
+
+String _renderClass_partial_footer_18(ClassTemplateData context0) =>
+    _deduplicated__footer(context0);
+
+String _renderClass_partial_head_0(ClassTemplateData context0) =>
+    _deduplicated__head(context0);
+
+String _renderClass_partial_instance_fields_11(Class context1) =>
+    _deduplicated__instance_fields(context1);
+
+String _renderClass_partial_instance_methods_12(Class context1) =>
+    _deduplicated__instance_methods(context1);
+
+String _renderClass_partial_instance_operators_13(Class context1) =>
+    _deduplicated__instance_operators(context1);
 
 String _renderClass_partial_interfaces_6(Class context1) =>
-    _deduplicated_lib_templates__interfaces_html(context1);
+    _deduplicated__interfaces(context1);
 
 String _renderClass_partial_mixed_in_types_7(Class context1) {
   final buffer = StringBuffer();
@@ -2354,84 +3327,78 @@ String _renderClass_partial_mixed_in_types_7(Class context1) {
   return buffer.toString();
 }
 
-String _renderClass_partial_available_extensions_8(Class context1) =>
-    _deduplicated_lib_templates__available_extensions_html(context1);
+String _renderClass_partial_search_sidebar_17(ClassTemplateData context0) =>
+    _deduplicated__search_sidebar(context0);
 
-String _renderClass_partial_container_annotations_9(Class context1) =>
-    _deduplicated_lib_templates__container_annotations_html(context1);
-
-String _renderClass_partial_constructors_10(Class context1) =>
-    _deduplicated_lib_templates__constructors_html(context1);
-
-String _renderClass_partial_instance_fields_11(Class context1) =>
-    _deduplicated_lib_templates__instance_fields_html(context1);
-
-String _renderClass_partial_instance_methods_12(Class context1) =>
-    _deduplicated_lib_templates__instance_methods_html(context1);
-
-String _renderClass_partial_instance_operators_13(Class context1) =>
-    _deduplicated_lib_templates__instance_operators_html(context1);
-
-String _renderClass_partial_static_properties_14(Class context1) =>
-    _deduplicated_lib_templates__static_properties_html(context1);
-
-String _renderClass_partial_static_methods_15(Class context1) =>
-    _deduplicated_lib_templates__static_methods_html(context1);
+String _renderClass_partial_source_link_1(Class context1) =>
+    _deduplicated__source_link(context1);
 
 String _renderClass_partial_static_constants_16(Class context1) =>
-    _deduplicated_lib_templates__static_constants_html(context1);
+    _deduplicated__static_constants(context1);
 
-String _renderClass_partial_search_sidebar_17(ClassTemplateData context0) =>
-    _deduplicated_lib_templates__search_sidebar_html(context0);
+String _renderClass_partial_static_methods_15(Class context1) =>
+    _deduplicated__static_methods(context1);
 
-String _renderClass_partial_footer_18(ClassTemplateData context0) =>
-    _deduplicated_lib_templates__footer_html(context0);
+String _renderClass_partial_static_properties_14(Class context1) =>
+    _deduplicated__static_properties(context1);
 
-String _renderConstructor_partial_head_0(ConstructorTemplateData context0) =>
-    _deduplicated_lib_templates__head_html(context0);
-
-String _renderConstructor_partial_source_link_1(Constructor context1) =>
-    _deduplicated_lib_templates__source_link_html(context1);
-
-String _renderConstructor_partial_feature_set_2(Constructor context1) =>
-    _deduplicated_lib_templates__feature_set_html(context1);
+String _renderClass_partial_super_chain_5(Class context1) =>
+    _deduplicated__super_chain(context1);
 
 String _renderConstructor_partial_annotations_3(Constructor context1) =>
-    _deduplicated_lib_templates__annotations_html(context1);
+    _deduplicated__annotations(context1);
 
 String _renderConstructor_partial_documentation_4(Constructor context1) =>
-    _deduplicated_lib_templates__documentation_html(context1);
+    _deduplicated__documentation(context1);
 
-String _renderConstructor_partial_source_code_5(Constructor context1) =>
-    _deduplicated_lib_templates__source_code_html(context1);
+String _renderConstructor_partial_feature_set_2(Constructor context1) =>
+    _deduplicated__feature_set(context1);
+
+String _renderConstructor_partial_footer_7(ConstructorTemplateData context0) =>
+    _deduplicated__footer(context0);
+
+String _renderConstructor_partial_head_0(ConstructorTemplateData context0) =>
+    _deduplicated__head(context0);
 
 String _renderConstructor_partial_search_sidebar_6(
         ConstructorTemplateData context0) =>
-    _deduplicated_lib_templates__search_sidebar_html(context0);
+    _deduplicated__search_sidebar(context0);
 
-String _renderConstructor_partial_footer_7(ConstructorTemplateData context0) =>
-    _deduplicated_lib_templates__footer_html(context0);
+String _renderConstructor_partial_source_code_5(Constructor context1) =>
+    _deduplicated__source_code(context1);
 
-String _renderEnum_partial_head_0(EnumTemplateData context0) =>
-    _deduplicated_lib_templates__head_html(context0);
+String _renderConstructor_partial_source_link_1(Constructor context1) =>
+    _deduplicated__source_link(context1);
 
-String _renderEnum_partial_source_link_1(Enum context1) =>
-    _deduplicated_lib_templates__source_link_html(context1);
+String _renderEnum_partial_available_extensions_8(Enum context1) =>
+    _deduplicated__available_extensions(context1);
 
-String _renderEnum_partial_feature_set_2(Enum context1) =>
-    _deduplicated_lib_templates__feature_set_html(context1);
-
-String _renderEnum_partial_categorization_3(Enum context1) =>
-    _deduplicated_lib_templates__categorization_html(context1);
+String _renderEnum_partial_container_annotations_9(Enum context1) =>
+    _deduplicated__container_annotations(context1);
 
 String _renderEnum_partial_documentation_4(Enum context1) =>
-    _deduplicated_lib_templates__documentation_html(context1);
+    _deduplicated__documentation(context1);
 
-String _renderEnum_partial_super_chain_5(Enum context1) =>
-    _deduplicated_lib_templates__super_chain_html(context1);
+String _renderEnum_partial_feature_set_2(Enum context1) =>
+    _deduplicated__feature_set(context1);
+
+String _renderEnum_partial_footer_18(EnumTemplateData context0) =>
+    _deduplicated__footer(context0);
+
+String _renderEnum_partial_head_0(EnumTemplateData context0) =>
+    _deduplicated__head(context0);
+
+String _renderEnum_partial_instance_fields_11(Enum context1) =>
+    _deduplicated__instance_fields(context1);
+
+String _renderEnum_partial_instance_methods_12(Enum context1) =>
+    _deduplicated__instance_methods(context1);
+
+String _renderEnum_partial_instance_operators_13(Enum context1) =>
+    _deduplicated__instance_operators(context1);
 
 String _renderEnum_partial_interfaces_6(Enum context1) =>
-    _deduplicated_lib_templates__interfaces_html(context1);
+    _deduplicated__interfaces(context1);
 
 String _renderEnum_partial_mixed_in_types_7(Enum context1) {
   final buffer = StringBuffer();
@@ -2457,167 +3424,134 @@ String _renderEnum_partial_mixed_in_types_7(Enum context1) {
   return buffer.toString();
 }
 
-String _renderEnum_partial_available_extensions_8(Enum context1) =>
-    _deduplicated_lib_templates__available_extensions_html(context1);
+String _renderEnum_partial_search_sidebar_17(EnumTemplateData context0) =>
+    _deduplicated__search_sidebar(context0);
 
-String _renderEnum_partial_container_annotations_9(Enum context1) =>
-    _deduplicated_lib_templates__container_annotations_html(context1);
-
-String _renderEnum_partial_constant_10(Field context2) =>
-    _deduplicated_lib_templates__constant_html(context2);
-
-String _renderEnum_partial_instance_fields_11(Enum context1) =>
-    _deduplicated_lib_templates__instance_fields_html(context1);
-
-String _renderEnum_partial_instance_methods_12(Enum context1) =>
-    _deduplicated_lib_templates__instance_methods_html(context1);
-
-String _renderEnum_partial_instance_operators_13(Enum context1) =>
-    _deduplicated_lib_templates__instance_operators_html(context1);
-
-String _renderEnum_partial_static_properties_14(Enum context1) =>
-    _deduplicated_lib_templates__static_properties_html(context1);
-
-String _renderEnum_partial_static_methods_15(Enum context1) =>
-    _deduplicated_lib_templates__static_methods_html(context1);
+String _renderEnum_partial_source_link_1(Enum context1) =>
+    _deduplicated__source_link(context1);
 
 String _renderEnum_partial_static_constants_16(Enum context1) =>
-    _deduplicated_lib_templates__static_constants_html(context1);
+    _deduplicated__static_constants(context1);
 
-String _renderEnum_partial_search_sidebar_17(EnumTemplateData context0) =>
-    _deduplicated_lib_templates__search_sidebar_html(context0);
+String _renderEnum_partial_static_methods_15(Enum context1) =>
+    _deduplicated__static_methods(context1);
 
-String _renderEnum_partial_footer_18(EnumTemplateData context0) =>
-    _deduplicated_lib_templates__footer_html(context0);
+String _renderEnum_partial_static_properties_14(Enum context1) =>
+    _deduplicated__static_properties(context1);
 
-String _renderError_partial_head_0(PackageTemplateData context0) =>
-    _deduplicated_lib_templates__head_html(context0);
-
-String _renderError_partial_search_sidebar_1(PackageTemplateData context0) =>
-    _deduplicated_lib_templates__search_sidebar_html(context0);
-
-String _renderError_partial_packages_2(PackageTemplateData context0) =>
-    _deduplicated_lib_templates__packages_html(context0);
+String _renderEnum_partial_super_chain_5(Enum context1) =>
+    _deduplicated__super_chain(context1);
 
 String _renderError_partial_footer_3(PackageTemplateData context0) =>
-    _deduplicated_lib_templates__footer_html(context0);
+    _deduplicated__footer(context0);
 
-String _renderExtension_partial_head_0<T extends Extension>(
-        ExtensionTemplateData<T> context0) =>
-    _deduplicated_lib_templates__head_html(context0);
+String _renderError_partial_head_0(PackageTemplateData context0) =>
+    _deduplicated__head(context0);
 
-String _renderExtension_partial_source_link_1(Extension context1) =>
-    _deduplicated_lib_templates__source_link_html(context1);
+String _renderError_partial_packages_2(PackageTemplateData context0) =>
+    _deduplicated__packages(context0);
 
-String _renderExtension_partial_feature_set_2(Extension context1) =>
-    _deduplicated_lib_templates__feature_set_html(context1);
-
-String _renderExtension_partial_categorization_3(Extension context1) =>
-    _deduplicated_lib_templates__categorization_html(context1);
-
-String _renderExtension_partial_documentation_4(Extension context1) =>
-    _deduplicated_lib_templates__documentation_html(context1);
-
-String _renderExtension_partial_container_annotations_5(Extension context1) =>
-    _deduplicated_lib_templates__container_annotations_html(context1);
-
-String _renderExtension_partial_instance_fields_6(Extension context1) =>
-    _deduplicated_lib_templates__instance_fields_html(context1);
-
-String _renderExtension_partial_instance_methods_7(Extension context1) =>
-    _deduplicated_lib_templates__instance_methods_html(context1);
-
-String _renderExtension_partial_instance_operators_8(Extension context1) =>
-    _deduplicated_lib_templates__instance_operators_html(context1);
-
-String _renderExtension_partial_static_properties_9(Extension context1) =>
-    _deduplicated_lib_templates__static_properties_html(context1);
-
-String _renderExtension_partial_static_methods_10(Extension context1) =>
-    _deduplicated_lib_templates__static_methods_html(context1);
-
-String _renderExtension_partial_static_constants_11(Extension context1) =>
-    _deduplicated_lib_templates__static_constants_html(context1);
-
-String _renderExtension_partial_search_sidebar_12<T extends Extension>(
-        ExtensionTemplateData<T> context0) =>
-    _deduplicated_lib_templates__search_sidebar_html(context0);
-
-String _renderExtension_partial_footer_13<T extends Extension>(
-        ExtensionTemplateData<T> context0) =>
-    _deduplicated_lib_templates__footer_html(context0);
-
-String _renderExtensionType_partial_head_0<T extends ExtensionType>(
-        ExtensionTypeTemplateData<T> context0) =>
-    _deduplicated_lib_templates__head_html(context0);
-
-String _renderExtensionType_partial_source_link_1(ExtensionType context1) =>
-    _deduplicated_lib_templates__source_link_html(context1);
-
-String _renderExtensionType_partial_feature_set_2(ExtensionType context1) =>
-    _deduplicated_lib_templates__feature_set_html(context1);
-
-String _renderExtensionType_partial_categorization_3(ExtensionType context1) =>
-    _deduplicated_lib_templates__categorization_html(context1);
-
-String _renderExtensionType_partial_documentation_4(ExtensionType context1) =>
-    _deduplicated_lib_templates__documentation_html(context1);
-
-String _renderExtensionType_partial_interfaces_5(ExtensionType context1) =>
-    _deduplicated_lib_templates__interfaces_html(context1);
+String _renderError_partial_search_sidebar_1(PackageTemplateData context0) =>
+    _deduplicated__search_sidebar(context0);
 
 String _renderExtensionType_partial_available_extensions_6(
         ExtensionType context1) =>
-    _deduplicated_lib_templates__available_extensions_html(context1);
+    _deduplicated__available_extensions(context1);
+
+String _renderExtensionType_partial_constructors_8(ExtensionType context1) =>
+    _deduplicated__constructors(context1);
 
 String _renderExtensionType_partial_container_annotations_7(
         ExtensionType context1) =>
-    _deduplicated_lib_templates__container_annotations_html(context1);
+    _deduplicated__container_annotations(context1);
 
-String _renderExtensionType_partial_constructors_8(ExtensionType context1) =>
-    _deduplicated_lib_templates__constructors_html(context1);
+String _renderExtensionType_partial_documentation_4(ExtensionType context1) =>
+    _deduplicated__documentation(context1);
 
-String _renderExtensionType_partial_instance_fields_9(ExtensionType context1) =>
-    _deduplicated_lib_templates__instance_fields_html(context1);
-
-String _renderExtensionType_partial_instance_methods_10(
-        ExtensionType context1) =>
-    _deduplicated_lib_templates__instance_methods_html(context1);
-
-String _renderExtensionType_partial_instance_operators_11(
-        ExtensionType context1) =>
-    _deduplicated_lib_templates__instance_operators_html(context1);
-
-String _renderExtensionType_partial_static_properties_12(
-        ExtensionType context1) =>
-    _deduplicated_lib_templates__static_properties_html(context1);
-
-String _renderExtensionType_partial_static_methods_13(ExtensionType context1) =>
-    _deduplicated_lib_templates__static_methods_html(context1);
-
-String _renderExtensionType_partial_static_constants_14(
-        ExtensionType context1) =>
-    _deduplicated_lib_templates__static_constants_html(context1);
-
-String _renderExtensionType_partial_search_sidebar_15<T extends ExtensionType>(
-        ExtensionTypeTemplateData<T> context0) =>
-    _deduplicated_lib_templates__search_sidebar_html(context0);
+String _renderExtensionType_partial_feature_set_2(ExtensionType context1) =>
+    _deduplicated__feature_set(context1);
 
 String _renderExtensionType_partial_footer_16<T extends ExtensionType>(
         ExtensionTypeTemplateData<T> context0) =>
-    _deduplicated_lib_templates__footer_html(context0);
+    _deduplicated__footer(context0);
 
-String _renderFunction_partial_head_0(FunctionTemplateData context0) =>
-    _deduplicated_lib_templates__head_html(context0);
+String _renderExtensionType_partial_head_0<T extends ExtensionType>(
+        ExtensionTypeTemplateData<T> context0) =>
+    _deduplicated__head(context0);
 
-String _renderFunction_partial_source_link_1(ModelFunction context1) =>
-    _deduplicated_lib_templates__source_link_html(context1);
+String _renderExtensionType_partial_instance_fields_9(ExtensionType context1) =>
+    _deduplicated__instance_fields(context1);
 
-String _renderFunction_partial_feature_set_2(ModelFunction context1) =>
-    _deduplicated_lib_templates__feature_set_html(context1);
+String _renderExtensionType_partial_instance_methods_10(
+        ExtensionType context1) =>
+    _deduplicated__instance_methods(context1);
 
-String _renderFunction_partial_categorization_3(ModelFunction context1) =>
-    _deduplicated_lib_templates__categorization_html(context1);
+String _renderExtensionType_partial_instance_operators_11(
+        ExtensionType context1) =>
+    _deduplicated__instance_operators(context1);
+
+String _renderExtensionType_partial_interfaces_5(ExtensionType context1) =>
+    _deduplicated__interfaces(context1);
+
+String _renderExtensionType_partial_search_sidebar_15<T extends ExtensionType>(
+        ExtensionTypeTemplateData<T> context0) =>
+    _deduplicated__search_sidebar(context0);
+
+String _renderExtensionType_partial_source_link_1(ExtensionType context1) =>
+    _deduplicated__source_link(context1);
+
+String _renderExtensionType_partial_static_constants_14(
+        ExtensionType context1) =>
+    _deduplicated__static_constants(context1);
+
+String _renderExtensionType_partial_static_methods_13(ExtensionType context1) =>
+    _deduplicated__static_methods(context1);
+
+String _renderExtensionType_partial_static_properties_12(
+        ExtensionType context1) =>
+    _deduplicated__static_properties(context1);
+
+String _renderExtension_partial_container_annotations_5(Extension context1) =>
+    _deduplicated__container_annotations(context1);
+
+String _renderExtension_partial_documentation_4(Extension context1) =>
+    _deduplicated__documentation(context1);
+
+String _renderExtension_partial_feature_set_2(Extension context1) =>
+    _deduplicated__feature_set(context1);
+
+String _renderExtension_partial_footer_13<T extends Extension>(
+        ExtensionTemplateData<T> context0) =>
+    _deduplicated__footer(context0);
+
+String _renderExtension_partial_head_0<T extends Extension>(
+        ExtensionTemplateData<T> context0) =>
+    _deduplicated__head(context0);
+
+String _renderExtension_partial_instance_fields_6(Extension context1) =>
+    _deduplicated__instance_fields(context1);
+
+String _renderExtension_partial_instance_methods_7(Extension context1) =>
+    _deduplicated__instance_methods(context1);
+
+String _renderExtension_partial_instance_operators_8(Extension context1) =>
+    _deduplicated__instance_operators(context1);
+
+String _renderExtension_partial_search_sidebar_12<T extends Extension>(
+        ExtensionTemplateData<T> context0) =>
+    _deduplicated__search_sidebar(context0);
+
+String _renderExtension_partial_source_link_1(Extension context1) =>
+    _deduplicated__source_link(context1);
+
+String _renderExtension_partial_static_constants_11(Extension context1) =>
+    _deduplicated__static_constants(context1);
+
+String _renderExtension_partial_static_methods_10(Extension context1) =>
+    _deduplicated__static_methods(context1);
+
+String _renderExtension_partial_static_properties_9(Extension context1) =>
+    _deduplicated__static_properties(context1);
 
 String _renderFunction_partial_callable_multiline_4(ModelFunction context1) {
   final buffer = StringBuffer();
@@ -2643,71 +3577,33 @@ String _renderFunction_partial_callable_multiline_4(ModelFunction context1) {
   return buffer.toString();
 }
 
-String __renderFunction_partial_callable_multiline_4_partial_annotations_0(
-        ModelFunction context1) =>
-    _deduplicated_lib_templates__annotations_html(context1);
-
-String __renderFunction_partial_callable_multiline_4_partial_name_summary_1(
-        ModelFunction context1) =>
-    _deduplicated_lib_templates__name_summary_html(context1);
-
-String _renderFunction_partial_attributes_5(ModelFunction context1) =>
-    _deduplicated_lib_templates__attributes_html(context1);
-
 String _renderFunction_partial_documentation_6(ModelFunction context1) =>
-    _deduplicated_lib_templates__documentation_html(context1);
+    _deduplicated__documentation(context1);
 
-String _renderFunction_partial_source_code_7(ModelFunction context1) =>
-    _deduplicated_lib_templates__source_code_html(context1);
+String _renderFunction_partial_feature_set_2(ModelFunction context1) =>
+    _deduplicated__feature_set(context1);
+
+String _renderFunction_partial_footer_9(FunctionTemplateData context0) =>
+    _deduplicated__footer(context0);
+
+String _renderFunction_partial_head_0(FunctionTemplateData context0) =>
+    _deduplicated__head(context0);
 
 String _renderFunction_partial_search_sidebar_8(
         FunctionTemplateData context0) =>
-    _deduplicated_lib_templates__search_sidebar_html(context0);
+    _deduplicated__search_sidebar(context0);
 
-String _renderFunction_partial_footer_9(FunctionTemplateData context0) =>
-    _deduplicated_lib_templates__footer_html(context0);
+String _renderFunction_partial_source_code_7(ModelFunction context1) =>
+    _deduplicated__source_code(context1);
 
-String _renderIndex_partial_head_0(PackageTemplateData context0) =>
-    _deduplicated_lib_templates__head_html(context0);
+String _renderFunction_partial_source_link_1(ModelFunction context1) =>
+    _deduplicated__source_link(context1);
 
 String _renderIndex_partial_documentation_1(Package context1) =>
-    _deduplicated_lib_templates__documentation_html(context1);
-
-String _renderIndex_partial_library_2(Library context3) =>
-    _deduplicated_lib_templates__library_html(context3);
-
-String _renderIndex_partial_search_sidebar_3(PackageTemplateData context0) =>
-    _deduplicated_lib_templates__search_sidebar_html(context0);
-
-String _renderIndex_partial_packages_4(PackageTemplateData context0) =>
-    _deduplicated_lib_templates__packages_html(context0);
-
-String _renderIndex_partial_footer_5(PackageTemplateData context0) =>
-    _deduplicated_lib_templates__footer_html(context0);
-
-String _renderLibrary_partial_head_0(LibraryTemplateData context0) =>
-    _deduplicated_lib_templates__head_html(context0);
-
-String _renderLibrary_partial_source_link_1(Library context1) =>
-    _deduplicated_lib_templates__source_link_html(context1);
-
-String _renderLibrary_partial_feature_set_2(Library context1) =>
-    _deduplicated_lib_templates__feature_set_html(context1);
-
-String _renderLibrary_partial_categorization_3(Library context1) =>
-    _deduplicated_lib_templates__categorization_html(context1);
+    _deduplicated__documentation(context1);
 
 String _renderLibrary_partial_documentation_4(Library context1) =>
-    _deduplicated_lib_templates__documentation_html(context1);
-
-String _renderLibrary_partial_container_5(Container context3) =>
-    _deduplicated_lib_templates__container_html(context3);
-
-String _renderLibrary_partial_container_6(Enum context3) =>
-    _deduplicated_lib_templates__container_html(context3);
-
-String _renderLibrary_partial_container_7(Mixin context3) =>
-    _deduplicated_lib_templates__container_html(context3);
+    _deduplicated__documentation(context1);
 
 String _renderLibrary_partial_extension_type_8(ExtensionType context3) {
   final buffer = StringBuffer();
@@ -2722,8 +3618,7 @@ String _renderLibrary_partial_extension_type_8(ExtensionType context3) {
   buffer.write(context3.linkedName);
   buffer.write('''</span> ''');
   buffer.write(
-      __renderLibrary_partial_extension_type_8_partial_categorization_0(
-          context3));
+      __renderCategory_partial_container_3_partial_categorization_0(context3));
   buffer.writeln();
   buffer.write('''</dt>
 <dd>
@@ -2736,164 +3631,23 @@ String _renderLibrary_partial_extension_type_8(ExtensionType context3) {
   return buffer.toString();
 }
 
-String __renderLibrary_partial_extension_type_8_partial_categorization_0(
-        ExtensionType context3) =>
-    _deduplicated_lib_templates__categorization_html(context3);
-
-String _renderLibrary_partial_extension_9(Extension context3) =>
-    _deduplicated_lib_templates__extension_html(context3);
-
-String _renderLibrary_partial_constant_10(TopLevelVariable context3) =>
-    _deduplicated_lib_templates__constant_html(context3);
-
-String _renderLibrary_partial_property_11(TopLevelVariable context3) {
-  final buffer = StringBuffer();
-  buffer.write('''<dt id="''');
-  buffer.writeEscaped(context3.htmlId);
-  buffer.write('''" class="property''');
-  if (context3.isInherited) {
-    buffer.write(''' inherited''');
-  }
-  buffer.write('''">
-  <span class="name">''');
-  buffer.write(context3.linkedName);
-  buffer.write('''</span>
-  <span class="signature">''');
-  buffer.write(context3.arrow);
-  buffer.write(' ');
-  buffer.write(context3.modelType.linkedName);
-  buffer.write('''</span>
-  ''');
-  buffer.write(
-      __renderLibrary_partial_property_11_partial_categorization_0(context3));
-  buffer.writeln();
-  buffer.write('''</dt>
-<dd''');
-  if (context3.isInherited) {
-    buffer.write(''' class="inherited"''');
-  }
-  buffer.write('''>''');
-  if (context3.isProvidedByExtension) {
-    var context4 = context3.enclosingExtension;
-    buffer.writeln();
-    buffer.write('''      <p class="from-extension">
-        <span>Available on ''');
-    buffer.write(context4.extendedElement.linkedName);
-    buffer.write(''',
-        provided by the ''');
-    buffer.write(context4.linkedName);
-    buffer.write(''' extension</span>
-      </p>''');
-  }
-  buffer.write('\n  ');
-  buffer.write(context3.oneLineDoc);
-  buffer.write('\n  ');
-  buffer.write(
-      __renderLibrary_partial_property_11_partial_attributes_1(context3));
-  buffer.writeln();
-  buffer.write('''</dd>
-''');
-
-  return buffer.toString();
-}
-
-String __renderLibrary_partial_property_11_partial_categorization_0(
-        TopLevelVariable context3) =>
-    _deduplicated_lib_templates__categorization_html(context3);
-
-String __renderLibrary_partial_property_11_partial_attributes_1(
-        TopLevelVariable context3) =>
-    _deduplicated_lib_templates__attributes_html(context3);
-
-String _renderLibrary_partial_callable_12(ModelFunctionTyped context3) {
-  final buffer = StringBuffer();
-  buffer.write('''<dt id="''');
-  buffer.writeEscaped(context3.htmlId);
-  buffer.write('''" class="callable''');
-  if (context3.isInherited) {
-    buffer.write(''' inherited''');
-  }
-  buffer.write('''">
-  <span class="name''');
-  if (context3.isDeprecated) {
-    buffer.write(''' deprecated''');
-  }
-  buffer.write('''">''');
-  buffer.write(context3.linkedName);
-  buffer.write('''</span>''');
-  buffer.write(context3.linkedGenericParameters);
-  buffer.write('''<span class="signature">(<wbr>''');
-  buffer.write(context3.linkedParamsNoMetadata);
-  buffer.write(''')
-    <span class="returntype parameter">&#8594; ''');
-  buffer.write(context3.modelType.returnType.linkedName);
-  buffer.write('''</span>
-  </span>
-  ''');
-  buffer.write(
-      __renderLibrary_partial_callable_12_partial_categorization_0(context3));
-  buffer.writeln();
-  buffer.write('''</dt>
-<dd''');
-  if (context3.isInherited) {
-    buffer.write(''' class="inherited"''');
-  }
-  buffer.write('''>''');
-  if (context3.isProvidedByExtension) {
-    var context4 = context3.enclosingExtension;
-    buffer.writeln();
-    buffer.write('''      <p class="from-extension">
-        <span>Available on ''');
-    buffer.write(context4.extendedElement.linkedName);
-    buffer.write(''',
-        provided by the ''');
-    buffer.write(context4.linkedName);
-    buffer.write(''' extension</span>
-      </p>''');
-  }
-  buffer.write('\n  ');
-  buffer.write(context3.oneLineDoc);
-  buffer.write('\n  ');
-  buffer.write(
-      __renderLibrary_partial_callable_12_partial_attributes_1(context3));
-  buffer.writeln();
-  buffer.write('''</dd>
-''');
-
-  return buffer.toString();
-}
-
-String __renderLibrary_partial_callable_12_partial_categorization_0(
-        ModelFunctionTyped context3) =>
-    _deduplicated_lib_templates__categorization_html(context3);
-
-String __renderLibrary_partial_callable_12_partial_attributes_1(
-        ModelFunctionTyped context3) =>
-    _deduplicated_lib_templates__attributes_html(context3);
-
-String _renderLibrary_partial_typedef_13(Typedef context3) =>
-    _deduplicated_lib_templates__typedef_html(context3);
-
-String _renderLibrary_partial_container_14(Class context3) =>
-    _deduplicated_lib_templates__container_html(context3);
-
-String _renderLibrary_partial_search_sidebar_15(LibraryTemplateData context0) =>
-    _deduplicated_lib_templates__search_sidebar_html(context0);
-
-String _renderLibrary_partial_packages_16(LibraryTemplateData context0) =>
-    _deduplicated_lib_templates__packages_html(context0);
+String _renderLibrary_partial_feature_set_2(Library context1) =>
+    _deduplicated__feature_set(context1);
 
 String _renderLibrary_partial_footer_17(LibraryTemplateData context0) =>
-    _deduplicated_lib_templates__footer_html(context0);
+    _deduplicated__footer(context0);
 
-String _renderMethod_partial_head_0(MethodTemplateData context0) =>
-    _deduplicated_lib_templates__head_html(context0);
+String _renderLibrary_partial_head_0(LibraryTemplateData context0) =>
+    _deduplicated__head(context0);
 
-String _renderMethod_partial_source_link_1(Method context1) =>
-    _deduplicated_lib_templates__source_link_html(context1);
+String _renderLibrary_partial_packages_16(LibraryTemplateData context0) =>
+    _deduplicated__packages(context0);
 
-String _renderMethod_partial_feature_set_2(Method context1) =>
-    _deduplicated_lib_templates__feature_set_html(context1);
+String _renderLibrary_partial_search_sidebar_15(LibraryTemplateData context0) =>
+    _deduplicated__search_sidebar(context0);
+
+String _renderLibrary_partial_source_link_1(Library context1) =>
+    _deduplicated__source_link(context1);
 
 String _renderMethod_partial_callable_multiline_3(Method context1) {
   final buffer = StringBuffer();
@@ -2919,129 +3673,108 @@ String _renderMethod_partial_callable_multiline_3(Method context1) {
   return buffer.toString();
 }
 
-String __renderMethod_partial_callable_multiline_3_partial_annotations_0(
-        Method context1) =>
-    _deduplicated_lib_templates__annotations_html(context1);
-
-String __renderMethod_partial_callable_multiline_3_partial_name_summary_1(
-        Method context1) =>
-    _deduplicated_lib_templates__name_summary_html(context1);
-
-String _renderMethod_partial_attributes_4(Method context1) =>
-    _deduplicated_lib_templates__attributes_html(context1);
-
 String _renderMethod_partial_documentation_5(Method context1) =>
-    _deduplicated_lib_templates__documentation_html(context1);
+    _deduplicated__documentation(context1);
 
-String _renderMethod_partial_source_code_6(Method context1) =>
-    _deduplicated_lib_templates__source_code_html(context1);
-
-String _renderMethod_partial_search_sidebar_7(MethodTemplateData context0) =>
-    _deduplicated_lib_templates__search_sidebar_html(context0);
+String _renderMethod_partial_feature_set_2(Method context1) =>
+    _deduplicated__feature_set(context1);
 
 String _renderMethod_partial_footer_8(MethodTemplateData context0) =>
-    _deduplicated_lib_templates__footer_html(context0);
+    _deduplicated__footer(context0);
 
-String _renderMixin_partial_head_0(MixinTemplateData context0) =>
-    _deduplicated_lib_templates__head_html(context0);
+String _renderMethod_partial_head_0(MethodTemplateData context0) =>
+    _deduplicated__head(context0);
 
-String _renderMixin_partial_source_link_1(Mixin context1) =>
-    _deduplicated_lib_templates__source_link_html(context1);
+String _renderMethod_partial_search_sidebar_7(MethodTemplateData context0) =>
+    _deduplicated__search_sidebar(context0);
 
-String _renderMixin_partial_feature_set_2(Mixin context1) =>
-    _deduplicated_lib_templates__feature_set_html(context1);
+String _renderMethod_partial_source_code_6(Method context1) =>
+    _deduplicated__source_code(context1);
 
-String _renderMixin_partial_categorization_3(Mixin context1) =>
-    _deduplicated_lib_templates__categorization_html(context1);
-
-String _renderMixin_partial_documentation_4(Mixin context1) =>
-    _deduplicated_lib_templates__documentation_html(context1);
-
-String _renderMixin_partial_super_chain_5(Mixin context1) =>
-    _deduplicated_lib_templates__super_chain_html(context1);
-
-String _renderMixin_partial_interfaces_6(Mixin context1) =>
-    _deduplicated_lib_templates__interfaces_html(context1);
-
-String _renderMixin_partial_available_extensions_7(Mixin context1) =>
-    _deduplicated_lib_templates__available_extensions_html(context1);
+String _renderMethod_partial_source_link_1(Method context1) =>
+    _deduplicated__source_link(context1);
 
 String _renderMixin_partial_annotations_8(Mixin context1) =>
-    _deduplicated_lib_templates__annotations_html(context1);
+    _deduplicated__annotations(context1);
 
-String _renderMixin_partial_instance_fields_9(Mixin context1) =>
-    _deduplicated_lib_templates__instance_fields_html(context1);
+String _renderMixin_partial_available_extensions_7(Mixin context1) =>
+    _deduplicated__available_extensions(context1);
 
-String _renderMixin_partial_instance_methods_10(Mixin context1) =>
-    _deduplicated_lib_templates__instance_methods_html(context1);
+String _renderMixin_partial_documentation_4(Mixin context1) =>
+    _deduplicated__documentation(context1);
 
-String _renderMixin_partial_instance_operators_11(Mixin context1) =>
-    _deduplicated_lib_templates__instance_operators_html(context1);
-
-String _renderMixin_partial_static_properties_12(Mixin context1) =>
-    _deduplicated_lib_templates__static_properties_html(context1);
-
-String _renderMixin_partial_static_methods_13(Mixin context1) =>
-    _deduplicated_lib_templates__static_methods_html(context1);
-
-String _renderMixin_partial_static_constants_14(Mixin context1) =>
-    _deduplicated_lib_templates__static_constants_html(context1);
-
-String _renderMixin_partial_search_sidebar_15(MixinTemplateData context0) =>
-    _deduplicated_lib_templates__search_sidebar_html(context0);
+String _renderMixin_partial_feature_set_2(Mixin context1) =>
+    _deduplicated__feature_set(context1);
 
 String _renderMixin_partial_footer_16(MixinTemplateData context0) =>
-    _deduplicated_lib_templates__footer_html(context0);
+    _deduplicated__footer(context0);
 
-String _renderProperty_partial_head_0(PropertyTemplateData context0) =>
-    _deduplicated_lib_templates__head_html(context0);
+String _renderMixin_partial_head_0(MixinTemplateData context0) =>
+    _deduplicated__head(context0);
 
-String _renderProperty_partial_source_link_1(Field context1) =>
-    _deduplicated_lib_templates__source_link_html(context1);
+String _renderMixin_partial_instance_fields_9(Mixin context1) =>
+    _deduplicated__instance_fields(context1);
 
-String _renderProperty_partial_feature_set_2(Field context1) =>
-    _deduplicated_lib_templates__feature_set_html(context1);
+String _renderMixin_partial_instance_methods_10(Mixin context1) =>
+    _deduplicated__instance_methods(context1);
 
-String _renderProperty_partial_annotations_3(Field context1) =>
-    _deduplicated_lib_templates__annotations_html(context1);
+String _renderMixin_partial_instance_operators_11(Mixin context1) =>
+    _deduplicated__instance_operators(context1);
 
-String _renderProperty_partial_name_summary_4(Field context1) =>
-    _deduplicated_lib_templates__name_summary_html(context1);
+String _renderMixin_partial_interfaces_6(Mixin context1) =>
+    _deduplicated__interfaces(context1);
 
-String _renderProperty_partial_attributes_5(Field context1) =>
-    _deduplicated_lib_templates__attributes_html(context1);
+String _renderMixin_partial_search_sidebar_15(MixinTemplateData context0) =>
+    _deduplicated__search_sidebar(context0);
 
-String _renderProperty_partial_documentation_6(Field context1) =>
-    _deduplicated_lib_templates__documentation_html(context1);
+String _renderMixin_partial_source_link_1(Mixin context1) =>
+    _deduplicated__source_link(context1);
 
-String _renderProperty_partial_source_code_7(Field context1) =>
-    _deduplicated_lib_templates__source_code_html(context1);
+String _renderMixin_partial_static_constants_14(Mixin context1) =>
+    _deduplicated__static_constants(context1);
+
+String _renderMixin_partial_static_methods_13(Mixin context1) =>
+    _deduplicated__static_methods(context1);
+
+String _renderMixin_partial_static_properties_12(Mixin context1) =>
+    _deduplicated__static_properties(context1);
+
+String _renderMixin_partial_super_chain_5(Mixin context1) =>
+    _deduplicated__super_chain(context1);
 
 String _renderProperty_partial_accessor_getter_8(Field context1) =>
-    _deduplicated_lib_templates__accessor_getter_html(context1);
+    _deduplicated__accessor_getter(context1);
 
 String _renderProperty_partial_accessor_setter_9(Field context1) =>
-    _deduplicated_lib_templates__accessor_setter_html(context1);
+    _deduplicated__accessor_setter(context1);
+
+String _renderProperty_partial_annotations_3(Field context1) =>
+    _deduplicated__annotations(context1);
+
+String _renderProperty_partial_documentation_6(Field context1) =>
+    _deduplicated__documentation(context1);
+
+String _renderProperty_partial_feature_set_2(Field context1) =>
+    _deduplicated__feature_set(context1);
+
+String _renderProperty_partial_footer_11(PropertyTemplateData context0) =>
+    _deduplicated__footer(context0);
+
+String _renderProperty_partial_head_0(PropertyTemplateData context0) =>
+    _deduplicated__head(context0);
+
+String _renderProperty_partial_name_summary_4(Field context1) =>
+    _deduplicated__name_summary(context1);
 
 String _renderProperty_partial_search_sidebar_10(
         PropertyTemplateData context0) =>
-    _deduplicated_lib_templates__search_sidebar_html(context0);
+    _deduplicated__search_sidebar(context0);
 
-String _renderProperty_partial_footer_11(PropertyTemplateData context0) =>
-    _deduplicated_lib_templates__footer_html(context0);
+String _renderProperty_partial_source_code_7(Field context1) =>
+    _deduplicated__source_code(context1);
 
-String _renderSearchPage_partial_head_0(PackageTemplateData context0) =>
-    _deduplicated_lib_templates__head_html(context0);
-
-String _renderSearchPage_partial_search_sidebar_1(
-        PackageTemplateData context0) =>
-    _deduplicated_lib_templates__search_sidebar_html(context0);
-
-String _renderSearchPage_partial_packages_2(PackageTemplateData context0) =>
-    _deduplicated_lib_templates__packages_html(context0);
-
-String _renderSearchPage_partial_footer_3(PackageTemplateData context0) =>
-    _deduplicated_lib_templates__footer_html(context0);
+String _renderProperty_partial_source_link_1(Field context1) =>
+    _deduplicated__source_link(context1);
 
 String _renderSidebarForContainer_partial_container_sidebar_item_0(
     Field context2) {
@@ -3097,96 +3830,70 @@ String _renderSidebarForContainer_partial_container_sidebar_item_1(
   return buffer.toString();
 }
 
-String _renderSidebarForContainer_partial_container_sidebar_item_2(
-    Operator context2) {
-  final buffer = StringBuffer();
-  buffer.writeln();
-  buffer.write('''
-<li''');
-  if (context2.isInherited) {
-    buffer.write(''' class="inherited"''');
-  }
-  buffer.write('''>
-  ''');
-  buffer.write(context2.linkedName);
-  if (context2.isProvidedByExtension) {
-    var context3 = context2.enclosingExtension;
-    buffer.writeln();
-    buffer.write('''      <sup
-          class="muted"
-          title="Available on ''');
-    buffer.writeEscaped(context3.extendedElement.nameWithGenericsPlain);
-    buffer.write('''">(ext)</sup>''');
-  }
-  buffer.writeln();
-  buffer.write('''</li>''');
-
-  return buffer.toString();
-}
-
-String _renderTopLevelProperty_partial_head_0(
-        TopLevelPropertyTemplateData context0) =>
-    _deduplicated_lib_templates__head_html(context0);
-
-String _renderTopLevelProperty_partial_source_link_1(
-        TopLevelVariable context1) =>
-    _deduplicated_lib_templates__source_link_html(context1);
-
-String _renderTopLevelProperty_partial_feature_set_2(
-        TopLevelVariable context1) =>
-    _deduplicated_lib_templates__feature_set_html(context1);
-
-String _renderTopLevelProperty_partial_categorization_3(
-        TopLevelVariable context1) =>
-    _deduplicated_lib_templates__categorization_html(context1);
-
-String _renderTopLevelProperty_partial_annotations_4(
-        TopLevelVariable context1) =>
-    _deduplicated_lib_templates__annotations_html(context1);
-
-String _renderTopLevelProperty_partial_name_summary_5(
-        TopLevelVariable context1) =>
-    _deduplicated_lib_templates__name_summary_html(context1);
-
-String _renderTopLevelProperty_partial_attributes_6(
-        TopLevelVariable context1) =>
-    _deduplicated_lib_templates__attributes_html(context1);
-
-String _renderTopLevelProperty_partial_documentation_7(
-        TopLevelVariable context1) =>
-    _deduplicated_lib_templates__documentation_html(context1);
-
-String _renderTopLevelProperty_partial_source_code_8(
-        TopLevelVariable context1) =>
-    _deduplicated_lib_templates__source_code_html(context1);
-
 String _renderTopLevelProperty_partial_accessor_getter_9(
         TopLevelVariable context1) =>
-    _deduplicated_lib_templates__accessor_getter_html(context1);
+    _deduplicated__accessor_getter(context1);
 
 String _renderTopLevelProperty_partial_accessor_setter_10(
         TopLevelVariable context1) =>
-    _deduplicated_lib_templates__accessor_setter_html(context1);
+    _deduplicated__accessor_setter(context1);
 
-String _renderTopLevelProperty_partial_search_sidebar_11(
-        TopLevelPropertyTemplateData context0) =>
-    _deduplicated_lib_templates__search_sidebar_html(context0);
+String _renderTopLevelProperty_partial_annotations_4(
+        TopLevelVariable context1) =>
+    _deduplicated__annotations(context1);
+
+String _renderTopLevelProperty_partial_documentation_7(
+        TopLevelVariable context1) =>
+    _deduplicated__documentation(context1);
+
+String _renderTopLevelProperty_partial_feature_set_2(
+        TopLevelVariable context1) =>
+    _deduplicated__feature_set(context1);
 
 String _renderTopLevelProperty_partial_footer_12(
         TopLevelPropertyTemplateData context0) =>
-    _deduplicated_lib_templates__footer_html(context0);
+    _deduplicated__footer(context0);
 
-String _renderTypedef_partial_head_0(TypedefTemplateData context0) =>
-    _deduplicated_lib_templates__head_html(context0);
+String _renderTopLevelProperty_partial_head_0(
+        TopLevelPropertyTemplateData context0) =>
+    _deduplicated__head(context0);
 
-String _renderTypedef_partial_source_link_1(Typedef context1) =>
-    _deduplicated_lib_templates__source_link_html(context1);
+String _renderTopLevelProperty_partial_name_summary_5(
+        TopLevelVariable context1) =>
+    _deduplicated__name_summary(context1);
+
+String _renderTopLevelProperty_partial_search_sidebar_11(
+        TopLevelPropertyTemplateData context0) =>
+    _deduplicated__search_sidebar(context0);
+
+String _renderTopLevelProperty_partial_source_code_8(
+        TopLevelVariable context1) =>
+    _deduplicated__source_code(context1);
+
+String _renderTopLevelProperty_partial_source_link_1(
+        TopLevelVariable context1) =>
+    _deduplicated__source_link(context1);
+
+String _renderTypedef_partial_documentation_5(Typedef context1) =>
+    _deduplicated__documentation(context1);
 
 String _renderTypedef_partial_feature_set_2(Typedef context1) =>
-    _deduplicated_lib_templates__feature_set_html(context1);
+    _deduplicated__feature_set(context1);
 
-String _renderTypedef_partial_categorization_3(Typedef context1) =>
-    _deduplicated_lib_templates__categorization_html(context1);
+String _renderTypedef_partial_footer_8(TypedefTemplateData context0) =>
+    _deduplicated__footer(context0);
+
+String _renderTypedef_partial_head_0(TypedefTemplateData context0) =>
+    _deduplicated__head(context0);
+
+String _renderTypedef_partial_search_sidebar_7(TypedefTemplateData context0) =>
+    _deduplicated__search_sidebar(context0);
+
+String _renderTypedef_partial_source_code_6(Typedef context1) =>
+    _deduplicated__source_code(context1);
+
+String _renderTypedef_partial_source_link_1(Typedef context1) =>
+    _deduplicated__source_link(context1);
 
 String _renderTypedef_partial_typedef_multiline_4(Typedef context1) {
   final buffer = StringBuffer();
@@ -3234,6 +3941,257 @@ String _renderTypedef_partial_typedef_multiline_4(Typedef context1) {
   return buffer.toString();
 }
 
+String __renderCategory_partial_callable_8_partial_attributes_1(
+        ModelFunctionTyped context2) =>
+    _deduplicated__attributes(context2);
+
+String __renderCategory_partial_callable_8_partial_categorization_0(
+        ModelFunctionTyped context2) =>
+    _deduplicated__categorization(context2);
+
+String __renderCategory_partial_constant_6_partial_attributes_1(
+        TopLevelVariable context2) =>
+    _deduplicated__attributes(context2);
+
+String __renderCategory_partial_constant_6_partial_categorization_0(
+        TopLevelVariable context2) =>
+    _deduplicated__categorization(context2);
+
+String __renderCategory_partial_container_3_partial_categorization_0(
+        Container context2) =>
+    _deduplicated__categorization(context2);
+
+String __renderCategory_partial_library_2_partial_categorization_0(
+        Library context2) =>
+    _deduplicated__categorization(context2);
+
+String __renderCategory_partial_typedef_10_partial_attributes_1(
+        FunctionTypedef context3) =>
+    _deduplicated__attributes(context3);
+
+String __renderCategory_partial_typedef_10_partial_categorization_0(
+        FunctionTypedef context3) =>
+    _deduplicated__categorization(context3);
+
+String __renderCategory_partial_typedef_10_partial_type_2(Typedef context2) {
+  final buffer = StringBuffer();
+  buffer.write('''<dt id="''');
+  buffer.writeEscaped(context2.htmlId);
+  buffer.write('''" class="''');
+  if (context2.isInherited) {
+    buffer.write(''' inherited''');
+  }
+  buffer.write('''">
+  <span class="name''');
+  if (context2.isDeprecated) {
+    buffer.write(''' deprecated''');
+  }
+  buffer.write('''">''');
+  buffer.write(context2.linkedName);
+  buffer.write('''</span>''');
+  buffer.write(context2.linkedGenericParameters);
+  buffer.writeln();
+  buffer.write('''    = ''');
+  buffer.write(context2.modelType.linkedName);
+  buffer.writeln();
+  buffer.write('''  </span>
+  ''');
+  buffer.write(
+      ___renderCategory_partial_typedef_10_partial_type_2_partial_categorization_0(
+          context2));
+  buffer.writeln();
+  buffer.write('''</dt>
+<dd''');
+  if (context2.isInherited) {
+    buffer.write(''' class="inherited"''');
+  }
+  buffer.write('''>
+  ''');
+  buffer.write(context2.oneLineDoc);
+  buffer.write('\n  ');
+  buffer.write(
+      ___renderCategory_partial_typedef_10_partial_type_2_partial_attributes_1(
+          context2));
+  buffer.writeln();
+  buffer.write('''</dd>
+''');
+
+  return buffer.toString();
+}
+
+String __renderClass_partial_instance_fields_11_partial_property_0(
+    Field context2) {
+  final buffer = StringBuffer();
+  buffer.write('''<dt id="''');
+  buffer.writeEscaped(context2.htmlId);
+  buffer.write('''" class="property''');
+  if (context2.isInherited) {
+    buffer.write(''' inherited''');
+  }
+  buffer.write('''">
+  <span class="name">''');
+  buffer.write(context2.linkedName);
+  buffer.write('''</span>
+  <span class="signature">''');
+  buffer.write(context2.arrow);
+  buffer.write(' ');
+  buffer.write(context2.modelType.linkedName);
+  buffer.write('''</span>
+  ''');
+  buffer.write(
+      ___renderClass_partial_instance_fields_11_partial_property_0_partial_categorization_0(
+          context2));
+  buffer.writeln();
+  buffer.write('''</dt>
+<dd''');
+  if (context2.isInherited) {
+    buffer.write(''' class="inherited"''');
+  }
+  buffer.write('''>''');
+  if (context2.isProvidedByExtension) {
+    var context3 = context2.enclosingExtension;
+    buffer.writeln();
+    buffer.write('''      <p class="from-extension">
+        <span>Available on ''');
+    buffer.write(context3.extendedElement.linkedName);
+    buffer.write(''',
+        provided by the ''');
+    buffer.write(context3.linkedName);
+    buffer.write(''' extension</span>
+      </p>''');
+  }
+  buffer.write('\n  ');
+  buffer.write(context2.oneLineDoc);
+  buffer.write('\n  ');
+  buffer.write(
+      ___renderClass_partial_instance_fields_11_partial_property_0_partial_attributes_1(
+          context2));
+  buffer.writeln();
+  buffer.write('''</dd>
+''');
+
+  return buffer.toString();
+}
+
+String __renderClass_partial_instance_methods_12_partial_callable_0(
+    Method context2) {
+  final buffer = StringBuffer();
+  buffer.write('''<dt id="''');
+  buffer.writeEscaped(context2.htmlId);
+  buffer.write('''" class="callable''');
+  if (context2.isInherited) {
+    buffer.write(''' inherited''');
+  }
+  buffer.write('''">
+  <span class="name''');
+  if (context2.isDeprecated) {
+    buffer.write(''' deprecated''');
+  }
+  buffer.write('''">''');
+  buffer.write(context2.linkedName);
+  buffer.write('''</span>''');
+  buffer.write(context2.linkedGenericParameters);
+  buffer.write('''<span class="signature">(<wbr>''');
+  buffer.write(context2.linkedParamsNoMetadata);
+  buffer.write(''')
+    <span class="returntype parameter">&#8594; ''');
+  buffer.write(context2.modelType.returnType.linkedName);
+  buffer.write('''</span>
+  </span>
+  ''');
+  buffer.write(
+      ___renderClass_partial_instance_methods_12_partial_callable_0_partial_categorization_0(
+          context2));
+  buffer.writeln();
+  buffer.write('''</dt>
+<dd''');
+  if (context2.isInherited) {
+    buffer.write(''' class="inherited"''');
+  }
+  buffer.write('''>''');
+  if (context2.isProvidedByExtension) {
+    var context3 = context2.enclosingExtension;
+    buffer.writeln();
+    buffer.write('''      <p class="from-extension">
+        <span>Available on ''');
+    buffer.write(context3.extendedElement.linkedName);
+    buffer.write(''',
+        provided by the ''');
+    buffer.write(context3.linkedName);
+    buffer.write(''' extension</span>
+      </p>''');
+  }
+  buffer.write('\n  ');
+  buffer.write(context2.oneLineDoc);
+  buffer.write('\n  ');
+  buffer.write(
+      ___renderClass_partial_instance_methods_12_partial_callable_0_partial_attributes_1(
+          context2));
+  buffer.writeln();
+  buffer.write('''</dd>
+''');
+
+  return buffer.toString();
+}
+
+String __renderClass_partial_static_constants_16_partial_constant_0(
+        Field context2) =>
+    _deduplicated__constant(context2);
+
+String __renderFunction_partial_callable_multiline_4_partial_annotations_0(
+        ModelFunction context1) =>
+    _deduplicated__annotations(context1);
+
+String __renderFunction_partial_callable_multiline_4_partial_name_summary_1(
+        ModelFunction context1) =>
+    _deduplicated__name_summary(context1);
+
+String __renderMethod_partial_callable_multiline_3_partial_annotations_0(
+        Method context1) =>
+    _deduplicated__annotations(context1);
+
+String __renderMethod_partial_callable_multiline_3_partial_name_summary_1(
+        Method context1) =>
+    _deduplicated__name_summary(context1);
+
+String __renderProperty_partial_accessor_getter_8_partial_annotations_0(
+        ContainerAccessor context2) =>
+    _deduplicated__annotations(context2);
+
+String __renderProperty_partial_accessor_getter_8_partial_attributes_2(
+        ContainerAccessor context2) =>
+    _deduplicated__attributes(context2);
+
+String __renderProperty_partial_accessor_getter_8_partial_documentation_3(
+        ContainerAccessor context2) =>
+    _deduplicated__documentation(context2);
+
+String __renderProperty_partial_accessor_getter_8_partial_source_code_4(
+        ContainerAccessor context2) =>
+    _deduplicated__source_code(context2);
+
+String __renderTopLevelProperty_partial_accessor_getter_9_partial_annotations_0(
+        Accessor context2) =>
+    _deduplicated__annotations(context2);
+
+String __renderTopLevelProperty_partial_accessor_getter_9_partial_attributes_2(
+        Accessor context2) =>
+    _deduplicated__attributes(context2);
+
+String
+    __renderTopLevelProperty_partial_accessor_getter_9_partial_documentation_3(
+            Accessor context2) =>
+        _deduplicated__documentation(context2);
+
+String
+    __renderTopLevelProperty_partial_accessor_getter_9_partial_name_summary_1(
+            Accessor context2) =>
+        _deduplicated__name_summary(context2);
+
+String __renderTopLevelProperty_partial_accessor_getter_9_partial_source_code_4(
+        Accessor context2) =>
+    _deduplicated__source_code(context2);
+
 String __renderTypedef_partial_typedef_multiline_4_partial_type_multiline_0(
     Typedef context1) {
   final buffer = StringBuffer();
@@ -3265,1962 +4223,39 @@ String __renderTypedef_partial_typedef_multiline_4_partial_type_multiline_0(
   return buffer.toString();
 }
 
+String ___renderCategory_partial_typedef_10_partial_type_2_partial_attributes_1(
+        Typedef context2) =>
+    _deduplicated__attributes(context2);
+
+String
+    ___renderCategory_partial_typedef_10_partial_type_2_partial_categorization_0(
+            Typedef context2) =>
+        _deduplicated__categorization(context2);
+
+String
+    ___renderClass_partial_instance_fields_11_partial_property_0_partial_attributes_1(
+            Field context2) =>
+        _deduplicated__attributes(context2);
+
+String
+    ___renderClass_partial_instance_fields_11_partial_property_0_partial_categorization_0(
+            Field context2) =>
+        _deduplicated__categorization(context2);
+
+String
+    ___renderClass_partial_instance_methods_12_partial_callable_0_partial_attributes_1(
+            Method context2) =>
+        _deduplicated__attributes(context2);
+
+String
+    ___renderClass_partial_instance_methods_12_partial_callable_0_partial_categorization_0(
+            Method context2) =>
+        _deduplicated__categorization(context2);
+
 String
     ___renderTypedef_partial_typedef_multiline_4_partial_type_multiline_0_partial_name_summary_0(
             Typedef context1) =>
-        _deduplicated_lib_templates__name_summary_html(context1);
-
-String _renderTypedef_partial_documentation_5(Typedef context1) =>
-    _deduplicated_lib_templates__documentation_html(context1);
-
-String _renderTypedef_partial_source_code_6(Typedef context1) =>
-    _deduplicated_lib_templates__source_code_html(context1);
-
-String _renderTypedef_partial_search_sidebar_7(TypedefTemplateData context0) =>
-    _deduplicated_lib_templates__search_sidebar_html(context0);
-
-String _renderTypedef_partial_footer_8(TypedefTemplateData context0) =>
-    _deduplicated_lib_templates__footer_html(context0);
-
-String _deduplicated_lib_templates__head_html(TemplateDataBase context0) {
-  final buffer = StringBuffer();
-  buffer.write('''<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1, user-scalable=no">
-  <meta name="description" content="''');
-  buffer.writeEscaped(context0.metaDescription);
-  buffer.write('''">
-  <title>''');
-  buffer.writeEscaped(context0.title);
-  buffer.write('''</title>''');
-  var context1 = context0.relCanonicalPrefix;
-  if (context1 != null) {
-    buffer.writeln();
-    buffer.write('''  <link rel="canonical" href="''');
-    buffer.write(context0.relCanonicalPrefix);
-    buffer.write('''/''');
-    buffer.write(context0.bareHref);
-    buffer.write('''">''');
-  }
-  buffer.writeln();
-  if (context0.useBaseHref) {
-    var context2 = context0.htmlBase;
-    buffer.writeln();
-    buffer
-        .write('''  <!-- required because all the links are pseudo-absolute -->
-  <base href="''');
-    buffer.write(context0.htmlBase);
-    buffer.write('''">''');
-  }
-  buffer.write('\n\n  ');
-  buffer.writeln();
-  buffer.write('''  <link rel="preconnect" href="https://fonts.gstatic.com">
-  <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0" rel="stylesheet">
-  ''');
-  buffer.writeln();
-  buffer.write('''  <link rel="stylesheet" href="''');
-  if (!context0.useBaseHref) {
-    buffer.write('''%%__HTMLBASE_dartdoc_internal__%%''');
-  }
-  buffer.write('''static-assets/github.css?v1">
-  <link rel="stylesheet" href="''');
-  if (!context0.useBaseHref) {
-    buffer.write('''%%__HTMLBASE_dartdoc_internal__%%''');
-  }
-  buffer.write('''static-assets/styles.css?v1">
-  <link rel="icon" href="''');
-  if (!context0.useBaseHref) {
-    buffer.write('''%%__HTMLBASE_dartdoc_internal__%%''');
-  }
-  buffer.write('''static-assets/favicon.png?v1">
-  ''');
-  buffer.write(context0.customHeader);
-  buffer.writeln();
-  buffer.write('''</head>
-''');
-  buffer.writeln();
-  buffer.write('''<body data-base-href="''');
-  buffer.write(context0.htmlBase);
-  buffer.write('''" data-using-base-href="''');
-  buffer.write(context0.useBaseHref.toString());
-  buffer.write('''" class="light-theme">
-<div id="overlay-under-drawer"></div>
-<header id="title">
-  <span id="sidenav-left-toggle" class="material-symbols-outlined" role="button" tabindex="0">menu</span>
-  <ol class="breadcrumbs gt-separated dark hidden-xs">''');
-  var context3 = context0.navLinks;
-  for (var context4 in context3) {
-    buffer.writeln();
-    buffer.write('''    <li><a href="''');
-    buffer.write(context4.href);
-    buffer.write('''">''');
-    buffer.writeEscaped(context4.breadcrumbName);
-    buffer.write('''</a></li>''');
-  }
-  var context5 = context0.navLinksWithGenerics;
-  for (var context6 in context5) {
-    buffer.writeln();
-    buffer.write('''    <li><a href="''');
-    buffer.write(context6.href);
-    buffer.write('''">''');
-    buffer.writeEscaped(context6.breadcrumbName);
-    if (context6.hasGenericParameters) {
-      buffer.write('''<span class="signature">''');
-      buffer.write(context6.genericParameters);
-      buffer.write('''</span>''');
-    }
-    buffer.write('''</a></li>''');
-  }
-  if (!context0.hasHomepage) {
-    buffer.writeln();
-    buffer.write('''    <li class="self-crumb">''');
-    buffer.write(context0.layoutTitle);
-    buffer.write('''</li>''');
-  }
-  if (context0.hasHomepage) {
-    buffer.writeln();
-    buffer.write('''    <li><a href="''');
-    buffer.write(context0.homepage);
-    buffer.write('''">''');
-    buffer.write(context0.layoutTitle);
-    buffer.write('''</a></li>''');
-  }
-  buffer.writeln();
-  buffer.write('''  </ol>
-  <div class="self-name">''');
-  buffer.writeEscaped(context0.self.name);
-  buffer.write('''</div>
-  <form class="search navbar-right" role="search">
-    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
-  </form>
-  <div class="toggle" id="theme-button" title="Toggle brightness">
-    <label for="theme">
-      <input type="checkbox" id="theme" value="light-theme">
-      <span id="dark-theme-button" class="material-symbols-outlined">
-        dark_mode
-      </span>
-      <span id="light-theme-button" class="material-symbols-outlined">
-        light_mode
-      </span>
-    </label>
-  </div>
-</header>
-<main>''');
-
-  return buffer.toString();
-}
-
-String _deduplicated_lib_templates__documentation_html(Warnable context0) {
-  final buffer = StringBuffer();
-  if (context0.hasDocumentation) {
-    buffer.writeln();
-    buffer.write('''<section class="desc markdown">
-  ''');
-    buffer.write(context0.documentationAsHtml);
-    buffer.writeln();
-    buffer.write('''</section>''');
-  }
-  buffer.writeln();
-
-  return buffer.toString();
-}
-
-String _deduplicated_lib_templates__library_html(Library context0) {
-  final buffer = StringBuffer();
-  buffer.write('''<dt id="''');
-  buffer.writeEscaped(context0.htmlId);
-  buffer.write('''">
-  <span class="name">''');
-  buffer.write(context0.linkedName);
-  buffer.write('''</span> ''');
-  buffer.write(
-      __deduplicated_lib_templates__library_html_partial_categorization_0(
-          context0));
-  buffer.writeln();
-  buffer.write('''</dt>
-<dd>''');
-  if (context0.isDocumented) {
-    buffer.write(context0.oneLineDoc);
-  }
-  buffer.writeln();
-  buffer.write('''</dd>
-''');
-
-  return buffer.toString();
-}
-
-String __deduplicated_lib_templates__library_html_partial_categorization_0(
-    Library context0) {
-  final buffer = StringBuffer();
-  if (context0.hasCategoryNames) {
-    var context1 = context0.displayedCategories;
-    for (var context2 in context1) {
-      buffer.write('\n    ');
-      buffer.write(context2.categoryLabel);
-    }
-  }
-  buffer.writeln();
-
-  return buffer.toString();
-}
-
-String _deduplicated_lib_templates__categorization_html(ModelElement context0) {
-  final buffer = StringBuffer();
-  if (context0.hasCategoryNames) {
-    var context1 = context0.displayedCategories;
-    for (var context2 in context1) {
-      buffer.write('\n    ');
-      buffer.write(context2!.categoryLabel);
-    }
-  }
-  buffer.writeln();
-
-  return buffer.toString();
-}
-
-String _deduplicated_lib_templates__container_html(Container context0) {
-  final buffer = StringBuffer();
-  buffer.write('''<dt id="''');
-  buffer.writeEscaped(context0.htmlId);
-  buffer.write('''">
-  <span class="name ''');
-  if (context0.isDeprecated) {
-    buffer.write('''deprecated''');
-  }
-  buffer.write('''">''');
-  buffer.write(context0.linkedName);
-  buffer.write(context0.linkedGenericParameters);
-  buffer.write('''</span> ''');
-  buffer.write(
-      __deduplicated_lib_templates__container_html_partial_categorization_0(
-          context0));
-  buffer.writeln();
-  buffer.write('''</dt>
-<dd>
-  ''');
-  buffer.write(context0.oneLineDoc);
-  buffer.writeln();
-  buffer.write('''</dd>
-''');
-
-  return buffer.toString();
-}
-
-String __deduplicated_lib_templates__container_html_partial_categorization_0(
-    Container context0) {
-  final buffer = StringBuffer();
-  if (context0.hasCategoryNames) {
-    var context1 = context0.displayedCategories;
-    for (var context2 in context1) {
-      buffer.write('\n    ');
-      buffer.write(context2.categoryLabel);
-    }
-  }
-  buffer.writeln();
-
-  return buffer.toString();
-}
-
-String _deduplicated_lib_templates__extension_html(Extension context0) {
-  final buffer = StringBuffer();
-  buffer.write('''<dt id="''');
-  buffer.writeEscaped(context0.htmlId);
-  buffer.write('''">
-  <span class="name ''');
-  if (context0.isDeprecated) {
-    buffer.write('''deprecated''');
-  }
-  buffer.write('''">''');
-  buffer.write(context0.linkedName);
-  buffer.write('''</span>
-  on ''');
-  buffer.write(context0.extendedElement.linkedName);
-  buffer.write('\n  ');
-  buffer.write(
-      __deduplicated_lib_templates__extension_html_partial_categorization_0(
-          context0));
-  buffer.writeln();
-  buffer.write('''</dt>
-<dd>
-  ''');
-  buffer.write(context0.oneLineDoc);
-  buffer.writeln();
-  buffer.write('''</dd>
-''');
-
-  return buffer.toString();
-}
-
-String __deduplicated_lib_templates__extension_html_partial_categorization_0(
-    Extension context0) {
-  final buffer = StringBuffer();
-  if (context0.hasCategoryNames) {
-    var context1 = context0.displayedCategories;
-    for (var context2 in context1) {
-      buffer.write('\n    ');
-      buffer.write(context2.categoryLabel);
-    }
-  }
-  buffer.writeln();
-
-  return buffer.toString();
-}
-
-String _deduplicated_lib_templates__constant_html(GetterSetterCombo context0) {
-  final buffer = StringBuffer();
-  buffer.write('''<dt id="''');
-  buffer.writeEscaped(context0.htmlId);
-  buffer.write('''" class="constant">''');
-  if (context0.isEnumValue) {
-    buffer.writeln();
-    buffer.write('''    <span class="name ''');
-    if (context0.isDeprecated) {
-      buffer.write('''deprecated''');
-    }
-    buffer.write('''">''');
-    buffer.write(context0.name);
-    buffer.write('''</span>''');
-  }
-  if (!context0.isEnumValue) {
-    buffer.writeln();
-    buffer.write('''    <span class="name ''');
-    if (context0.isDeprecated) {
-      buffer.write('''deprecated''');
-    }
-    buffer.write('''">''');
-    buffer.write(context0.linkedName);
-    buffer.write('''</span>''');
-  }
-  buffer.writeln();
-  buffer.write('''  <span class="signature">&#8594; const ''');
-  buffer.write(context0.modelType.linkedName);
-  buffer.write('''</span>
-  ''');
-  buffer.write(
-      __deduplicated_lib_templates__constant_html_partial_categorization_0(
-          context0));
-  buffer.writeln();
-  buffer.write('''</dt>
-<dd>
-  ''');
-  buffer.write(context0.oneLineDoc);
-  buffer.write('\n  ');
-  buffer.write(__deduplicated_lib_templates__constant_html_partial_attributes_1(
-      context0));
-  if (context0.hasConstantValueForDisplay) {
-    buffer.writeln();
-    buffer.write('''    <div>
-      <span class="signature"><code>''');
-    buffer.write(context0.constantValueTruncated);
-    buffer.write('''</code></span>
-    </div>''');
-  }
-  buffer.writeln();
-  buffer.write('''</dd>
-''');
-
-  return buffer.toString();
-}
-
-String __deduplicated_lib_templates__constant_html_partial_categorization_0(
-    GetterSetterCombo context0) {
-  final buffer = StringBuffer();
-  if (context0.hasCategoryNames) {
-    var context1 = context0.displayedCategories;
-    for (var context2 in context1) {
-      buffer.write('\n    ');
-      buffer.write(context2!.categoryLabel);
-    }
-  }
-  buffer.writeln();
-
-  return buffer.toString();
-}
-
-String __deduplicated_lib_templates__constant_html_partial_attributes_1(
-    GetterSetterCombo context0) {
-  final buffer = StringBuffer();
-  if (context0.hasAttributes) {
-    buffer.write('''<div class="features">''');
-    buffer.write(context0.attributesAsString);
-    buffer.write('''</div>''');
-  }
-  buffer.writeln();
-
-  return buffer.toString();
-}
-
-String _deduplicated_lib_templates__attributes_html(ModelElement context0) {
-  final buffer = StringBuffer();
-  if (context0.hasAttributes) {
-    buffer.write('''<div class="features">''');
-    buffer.write(context0.attributesAsString);
-    buffer.write('''</div>''');
-  }
-  buffer.writeln();
-
-  return buffer.toString();
-}
-
-String _deduplicated_lib_templates__typedef_html(Typedef context0) {
-  final buffer = StringBuffer();
-  if (context0.isCallable) {
-    var context1 = context0.asCallable;
-    buffer.writeln();
-    buffer.write('''  <dt id="''');
-    buffer.writeEscaped(context1.htmlId);
-    buffer.write('''" class="callable''');
-    if (context1.isInherited) {
-      buffer.write(''' inherited''');
-    }
-    buffer.write('''">
-    <span class="name''');
-    if (context1.isDeprecated) {
-      buffer.write(''' deprecated''');
-    }
-    buffer.write('''">''');
-    buffer.write(context1.linkedName);
-    buffer.write('''</span>''');
-    buffer.write(context1.linkedGenericParameters);
-    buffer.write('''<span class="signature">
-      <span class="returntype parameter">= ''');
-    buffer.write(context1.modelType.linkedName);
-    buffer.write('''</span>
-    </span>
-    ''');
-    buffer.write(
-        __deduplicated_lib_templates__typedef_html_partial_categorization_0(
-            context1));
-    buffer.writeln();
-    buffer.write('''  </dt>
-  <dd''');
-    if (context1.isInherited) {
-      buffer.write(''' class="inherited"''');
-    }
-    buffer.write('''>
-    ''');
-    buffer.write(context1.oneLineDoc);
-    buffer.write('\n    ');
-    buffer.write(
-        __deduplicated_lib_templates__typedef_html_partial_attributes_1(
-            context1));
-    buffer.writeln();
-    buffer.write('''  </dd>''');
-  }
-  if (!context0.isCallable) {
-    buffer.write('\n  ');
-    buffer.write(
-        __deduplicated_lib_templates__typedef_html_partial_type_2(context0));
-  }
-  buffer.writeln();
-
-  return buffer.toString();
-}
-
-String __deduplicated_lib_templates__typedef_html_partial_categorization_0(
-    FunctionTypedef context1) {
-  final buffer = StringBuffer();
-  if (context1.hasCategoryNames) {
-    var context2 = context1.displayedCategories;
-    for (var context3 in context2) {
-      buffer.write('\n    ');
-      buffer.write(context3.categoryLabel);
-    }
-  }
-  buffer.writeln();
-
-  return buffer.toString();
-}
-
-String __deduplicated_lib_templates__typedef_html_partial_attributes_1(
-    FunctionTypedef context1) {
-  final buffer = StringBuffer();
-  if (context1.hasAttributes) {
-    buffer.write('''<div class="features">''');
-    buffer.write(context1.attributesAsString);
-    buffer.write('''</div>''');
-  }
-  buffer.writeln();
-
-  return buffer.toString();
-}
-
-String __deduplicated_lib_templates__typedef_html_partial_type_2(
-    Typedef context0) {
-  final buffer = StringBuffer();
-  buffer.write('''<dt id="''');
-  buffer.writeEscaped(context0.htmlId);
-  buffer.write('''" class="''');
-  if (context0.isInherited) {
-    buffer.write(''' inherited''');
-  }
-  buffer.write('''">
-  <span class="name''');
-  if (context0.isDeprecated) {
-    buffer.write(''' deprecated''');
-  }
-  buffer.write('''">''');
-  buffer.write(context0.linkedName);
-  buffer.write('''</span>''');
-  buffer.write(context0.linkedGenericParameters);
-  buffer.writeln();
-  buffer.write('''    = ''');
-  buffer.write(context0.modelType.linkedName);
-  buffer.writeln();
-  buffer.write('''  </span>
-  ''');
-  buffer.write(
-      ___deduplicated_lib_templates__typedef_html_partial_type_2_partial_categorization_0(
-          context0));
-  buffer.writeln();
-  buffer.write('''</dt>
-<dd''');
-  if (context0.isInherited) {
-    buffer.write(''' class="inherited"''');
-  }
-  buffer.write('''>
-  ''');
-  buffer.write(context0.oneLineDoc);
-  buffer.write('\n  ');
-  buffer.write(
-      ___deduplicated_lib_templates__typedef_html_partial_type_2_partial_attributes_1(
-          context0));
-  buffer.writeln();
-  buffer.write('''</dd>
-''');
-
-  return buffer.toString();
-}
-
-String
-    ___deduplicated_lib_templates__typedef_html_partial_type_2_partial_categorization_0(
-        Typedef context0) {
-  final buffer = StringBuffer();
-  if (context0.hasCategoryNames) {
-    var context1 = context0.displayedCategories;
-    for (var context2 in context1) {
-      buffer.write('\n    ');
-      buffer.write(context2.categoryLabel);
-    }
-  }
-  buffer.writeln();
-
-  return buffer.toString();
-}
-
-String
-    ___deduplicated_lib_templates__typedef_html_partial_type_2_partial_attributes_1(
-        Typedef context0) {
-  final buffer = StringBuffer();
-  if (context0.hasAttributes) {
-    buffer.write('''<div class="features">''');
-    buffer.write(context0.attributesAsString);
-    buffer.write('''</div>''');
-  }
-  buffer.writeln();
-
-  return buffer.toString();
-}
-
-String _deduplicated_lib_templates__type_html(Typedef context0) {
-  final buffer = StringBuffer();
-  buffer.write('''<dt id="''');
-  buffer.writeEscaped(context0.htmlId);
-  buffer.write('''" class="''');
-  if (context0.isInherited) {
-    buffer.write(''' inherited''');
-  }
-  buffer.write('''">
-  <span class="name''');
-  if (context0.isDeprecated) {
-    buffer.write(''' deprecated''');
-  }
-  buffer.write('''">''');
-  buffer.write(context0.linkedName);
-  buffer.write('''</span>''');
-  buffer.write(context0.linkedGenericParameters);
-  buffer.writeln();
-  buffer.write('''    = ''');
-  buffer.write(context0.modelType.linkedName);
-  buffer.writeln();
-  buffer.write('''  </span>
-  ''');
-  buffer.write(__deduplicated_lib_templates__type_html_partial_categorization_0(
-      context0));
-  buffer.writeln();
-  buffer.write('''</dt>
-<dd''');
-  if (context0.isInherited) {
-    buffer.write(''' class="inherited"''');
-  }
-  buffer.write('''>
-  ''');
-  buffer.write(context0.oneLineDoc);
-  buffer.write('\n  ');
-  buffer.write(
-      __deduplicated_lib_templates__type_html_partial_attributes_1(context0));
-  buffer.writeln();
-  buffer.write('''</dd>
-''');
-
-  return buffer.toString();
-}
-
-String __deduplicated_lib_templates__type_html_partial_categorization_0(
-    Typedef context0) {
-  final buffer = StringBuffer();
-  if (context0.hasCategoryNames) {
-    var context1 = context0.displayedCategories;
-    for (var context2 in context1) {
-      buffer.write('\n    ');
-      buffer.write(context2.categoryLabel);
-    }
-  }
-  buffer.writeln();
-
-  return buffer.toString();
-}
-
-String __deduplicated_lib_templates__type_html_partial_attributes_1(
-    Typedef context0) {
-  final buffer = StringBuffer();
-  if (context0.hasAttributes) {
-    buffer.write('''<div class="features">''');
-    buffer.write(context0.attributesAsString);
-    buffer.write('''</div>''');
-  }
-  buffer.writeln();
-
-  return buffer.toString();
-}
-
-String _deduplicated_lib_templates__search_sidebar_html(
-    TemplateDataBase context0) {
-  final buffer = StringBuffer();
-  buffer.write(
-      '''<!-- The search input and breadcrumbs below are only responsively visible at low resolutions. -->
-<header id="header-search-sidebar" class="hidden-l">
-  <form class="search-sidebar" role="search">
-    <input type="text" id="search-sidebar" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
-  </form>
-</header>
-<ol class="breadcrumbs gt-separated dark hidden-l" id="sidebar-nav">''');
-  var context1 = context0.navLinks;
-  for (var context2 in context1) {
-    buffer.writeln();
-    buffer.write('''    <li><a href="''');
-    buffer.write(context2.href);
-    buffer.write('''">''');
-    buffer.writeEscaped(context2.name);
-    buffer.write('''</a></li>''');
-  }
-  var context3 = context0.navLinksWithGenerics;
-  for (var context4 in context3) {
-    buffer.writeln();
-    buffer.write('''    <li><a href="''');
-    buffer.write(context4.href);
-    buffer.write('''">''');
-    buffer.writeEscaped(context4.name);
-    if (context4.hasGenericParameters) {
-      buffer.write('''<span class="signature">''');
-      buffer.write(context4.genericParameters);
-      buffer.write('''</span>''');
-    }
-    buffer.write('''</a></li>''');
-  }
-  if (!context0.hasHomepage) {
-    buffer.writeln();
-    buffer.write('''    <li class="self-crumb">''');
-    buffer.write(context0.layoutTitle);
-    buffer.write('''</li>''');
-  }
-  if (context0.hasHomepage) {
-    buffer.writeln();
-    buffer.write('''    <li><a href="''');
-    buffer.write(context0.homepage);
-    buffer.write('''">''');
-    buffer.write(context0.layoutTitle);
-    buffer.write('''</a></li>''');
-  }
-  buffer.writeln();
-  buffer.write('''</ol>
-''');
-
-  return buffer.toString();
-}
-
-String _deduplicated_lib_templates__packages_html(TemplateDataBase context0) {
-  final buffer = StringBuffer();
-  buffer.write('''<ol>''');
-  var context1 = context0.localPackages;
-  for (var context2 in context1) {
-    if (context2.isFirstPackage) {
-      if (context2.hasDocumentedCategories) {
-        buffer.writeln();
-        buffer.write('''      <li class="section-title">Topics</li>''');
-        var context3 = context2.documentedCategoriesSorted;
-        for (var context4 in context3) {
-          buffer.writeln();
-          buffer.write('''        <li>''');
-          buffer.write(context4.linkedName);
-          buffer.write('''</li>''');
-        }
-      }
-      buffer.writeln();
-      buffer.write('''      <li class="section-title">Libraries</li>''');
-    }
-    if (!context2.isFirstPackage) {
-      buffer.writeln();
-      buffer.write('''      <li class="section-title">''');
-      buffer.writeEscaped(context2.name);
-      buffer.write('''</li>''');
-    }
-    var context5 = context2.defaultCategory;
-    var context6 = context5.publicLibrariesSorted;
-    for (var context7 in context6) {
-      buffer.writeln();
-      buffer.write('''      <li>''');
-      buffer.write(context7.linkedName);
-      buffer.write('''</li>''');
-    }
-    var context8 = context2.categoriesWithPublicLibraries;
-    for (var context9 in context8) {
-      buffer.writeln();
-      buffer.write('''      <li class="section-subtitle">''');
-      buffer.writeEscaped(context9.name);
-      buffer.write('''</li>''');
-      var context10 = context9.externalItems;
-      for (var context11 in context10) {
-        buffer.writeln();
-        buffer.write('''        <li class="section-subitem">
-          <a href="''');
-        buffer.writeEscaped(context11.url);
-        buffer.write('''" target="_blank">
-            ''');
-        buffer.writeEscaped(context11.name);
-        buffer.writeln();
-        buffer.write(
-            '''            <span class="material-symbols-outlined">open_in_new</span>
-          </a>
-        </li>''');
-      }
-      var context12 = context9.publicLibrariesSorted;
-      for (var context13 in context12) {
-        buffer.writeln();
-        buffer.write('''        <li class="section-subitem">''');
-        buffer.write(context13.linkedName);
-        buffer.write('''</li>''');
-      }
-    }
-  }
-  buffer.writeln();
-  buffer.write('''</ol>
-''');
-
-  return buffer.toString();
-}
-
-String _deduplicated_lib_templates__footer_html(TemplateDataBase context0) {
-  final buffer = StringBuffer();
-  buffer.write('''</main>
-<footer>
-  <span class="no-break">
-    ''');
-  buffer.writeEscaped(context0.defaultPackage.name);
-  if (context0.hasFooterVersion) {
-    buffer.write('\n      ');
-    buffer.writeEscaped(context0.defaultPackage.version);
-  }
-  buffer.writeln();
-  buffer.write('''  </span>
-  ''');
-  buffer.write(context0.customInnerFooter);
-  buffer.writeln();
-  buffer.write('''</footer>
-''');
-  buffer.writeln();
-  buffer.writeln();
-  buffer.write('''<script src="''');
-  if (!context0.useBaseHref) {
-    buffer.write('''%%__HTMLBASE_dartdoc_internal__%%''');
-  }
-  buffer.write('''static-assets/highlight.pack.js?v1"></script>
-<script src="''');
-  if (!context0.useBaseHref) {
-    buffer.write('''%%__HTMLBASE_dartdoc_internal__%%''');
-  }
-  buffer.write('''static-assets/docs.dart.js"></script>
-''');
-  buffer.write(context0.customFooter);
-  buffer.writeln();
-  buffer.write('''</body>
-</html>
-''');
-
-  return buffer.toString();
-}
-
-String _deduplicated_lib_templates__source_link_html(ModelElement context0) {
-  final buffer = StringBuffer();
-  if (context0.hasSourceHref) {
-    buffer.writeln();
-    buffer.write(
-        '''  <div id="external-links" class="btn-group"><a title="View source code" class="source-link" href="''');
-    buffer.write(context0.sourceHref);
-    buffer.write(
-        '''"><span class="material-symbols-outlined">description</span></a></div>''');
-  }
-  buffer.writeln();
-
-  return buffer.toString();
-}
-
-String _deduplicated_lib_templates__feature_set_html(ModelElement context0) {
-  final buffer = StringBuffer();
-  if (context0.hasFeatureSet) {
-    var context1 = context0.displayedLanguageFeatures;
-    for (var context2 in context1) {
-      buffer.write('\n    ');
-      buffer.write(context2.featureLabel);
-    }
-  }
-  buffer.writeln();
-
-  return buffer.toString();
-}
-
-String _deduplicated_lib_templates__super_chain_html(
-    InheritingContainer context0) {
-  final buffer = StringBuffer();
-  if (context0.hasPublicSuperChainReversed) {
-    buffer.writeln();
-    buffer.write('''  <dt>Inheritance</dt>
-  <dd>
-    <ul class="gt-separated dark ''');
-    buffer.writeEscaped(context0.relationshipsClass);
-    buffer.write('''">
-      <li>''');
-    buffer.write(context0.linkedObjectType);
-    buffer.write('''</li>''');
-    var context1 = context0.publicSuperChainReversed;
-    for (var context2 in context1) {
-      buffer.writeln();
-      buffer.write('''        <li>''');
-      buffer.write(context2.linkedName);
-      buffer.write('''</li>''');
-    }
-    buffer.writeln();
-    buffer.write('''      <li>''');
-    buffer.write(context0.name);
-    buffer.write('''</li>
-    </ul>
-  </dd>''');
-  }
-  buffer.writeln();
-
-  return buffer.toString();
-}
-
-String _deduplicated_lib_templates__interfaces_html(
-    InheritingContainer context0) {
-  final buffer = StringBuffer();
-  if (context0.hasPublicInterfaces) {
-    buffer.writeln();
-    buffer.write('''  <dt>Implemented types</dt>
-  <dd>
-    <ul class="comma-separated ''');
-    buffer.writeEscaped(context0.relationshipsClass);
-    buffer.write('''">''');
-    var context1 = context0.publicInterfaces;
-    for (var context2 in context1) {
-      buffer.writeln();
-      buffer.write('''        <li>''');
-      buffer.write(context2.linkedName);
-      buffer.write('''</li>''');
-    }
-    buffer.writeln();
-    buffer.write('''    </ul>
-  </dd>''');
-  }
-
-  return buffer.toString();
-}
-
-String _deduplicated_lib_templates__available_extensions_html(
-    InheritingContainer context0) {
-  final buffer = StringBuffer();
-  if (context0.hasPotentiallyApplicableExtensions) {
-    buffer.writeln();
-    buffer.write('''  <dt>Available extensions</dt>
-  <dd><ul class="comma-separated clazz-relationships">''');
-    var context1 = context0.potentiallyApplicableExtensionsSorted;
-    for (var context2 in context1) {
-      buffer.writeln();
-      buffer.write('''      <li>''');
-      buffer.write(context2.linkedName);
-      buffer.write('''</li>''');
-    }
-    buffer.writeln();
-    buffer.write('''  </ul></dd>''');
-  }
-
-  return buffer.toString();
-}
-
-String _deduplicated_lib_templates__container_annotations_html(
-    Container context0) {
-  final buffer = StringBuffer();
-  if (context0.hasAnnotations) {
-    buffer.writeln();
-    buffer.write('''  <dt>Annotations</dt>
-  <dd>
-    <ul class="annotation-list ''');
-    buffer.writeEscaped(context0.relationshipsClass);
-    buffer.write('''">''');
-    var context1 = context0.annotations;
-    for (var context2 in context1) {
-      buffer.writeln();
-      buffer.write('''        <li>''');
-      buffer.write(context2.linkedNameWithParameters);
-      buffer.write('''</li>''');
-    }
-    buffer.writeln();
-    buffer.write('''    </ul>
-  </dd>''');
-  }
-  buffer.write('\n\n');
-
-  return buffer.toString();
-}
-
-String _deduplicated_lib_templates__constructors_html(Constructable context0) {
-  final buffer = StringBuffer();
-  if (context0.hasPublicConstructors) {
-    buffer.writeln();
-    buffer.write('''  <section class="summary offset-anchor" id="constructors">
-    <h2>Constructors</h2>
-    <dl class="constructor-summary-list">''');
-    var context1 = context0.publicConstructorsSorted;
-    for (var context2 in context1) {
-      buffer.writeln();
-      buffer.write('''        <dt id="''');
-      buffer.writeEscaped(context2.htmlId);
-      buffer.write('''" class="callable">
-          <span class="name">''');
-      buffer.write(context2.linkedName);
-      buffer.write('''</span><span class="signature">(''');
-      buffer.write(context2.linkedParams);
-      buffer.write(''')</span>
-        </dt>
-        <dd>
-          ''');
-      buffer.write(context2.oneLineDoc);
-      if (context2.isConst) {
-        buffer.writeln();
-        buffer.write(
-            '''            <div class="constructor-modifier features">const</div>''');
-      }
-      if (context2.isFactory) {
-        buffer.writeln();
-        buffer.write(
-            '''            <div class="constructor-modifier features">factory</div>''');
-      }
-      buffer.writeln();
-      buffer.write('''        </dd>''');
-    }
-    buffer.writeln();
-    buffer.write('''    </dl>
-  </section>''');
-  }
-
-  return buffer.toString();
-}
-
-String _deduplicated_lib_templates__instance_fields_html(Container context0) {
-  final buffer = StringBuffer();
-  if (context0.hasAvailableInstanceFields) {
-    buffer.writeln();
-    buffer.write('''  <section
-      class="summary offset-anchor''');
-    if (context0.publicInheritedInstanceFields) {
-      buffer.write(''' inherited''');
-    }
-    buffer.write('''"
-      id="instance-properties">
-    <h2>Properties</h2>
-    <dl class="properties">''');
-    var context1 = context0.availableInstanceFieldsSorted;
-    for (var context2 in context1) {
-      buffer.write('\n        ');
-      buffer.write(
-          __deduplicated_lib_templates__instance_fields_html_partial_property_0(
-              context2));
-    }
-    buffer.writeln();
-    buffer.write('''    </dl>
-  </section>''');
-  }
-  buffer.writeln();
-
-  return buffer.toString();
-}
-
-String __deduplicated_lib_templates__instance_fields_html_partial_property_0(
-    Field context1) {
-  final buffer = StringBuffer();
-  buffer.write('''<dt id="''');
-  buffer.writeEscaped(context1.htmlId);
-  buffer.write('''" class="property''');
-  if (context1.isInherited) {
-    buffer.write(''' inherited''');
-  }
-  buffer.write('''">
-  <span class="name">''');
-  buffer.write(context1.linkedName);
-  buffer.write('''</span>
-  <span class="signature">''');
-  buffer.write(context1.arrow);
-  buffer.write(' ');
-  buffer.write(context1.modelType.linkedName);
-  buffer.write('''</span>
-  ''');
-  buffer.write(
-      ___deduplicated_lib_templates__instance_fields_html_partial_property_0_partial_categorization_0(
-          context1));
-  buffer.writeln();
-  buffer.write('''</dt>
-<dd''');
-  if (context1.isInherited) {
-    buffer.write(''' class="inherited"''');
-  }
-  buffer.write('''>''');
-  if (context1.isProvidedByExtension) {
-    var context2 = context1.enclosingExtension;
-    buffer.writeln();
-    buffer.write('''      <p class="from-extension">
-        <span>Available on ''');
-    buffer.write(context2.extendedElement.linkedName);
-    buffer.write(''',
-        provided by the ''');
-    buffer.write(context2.linkedName);
-    buffer.write(''' extension</span>
-      </p>''');
-  }
-  buffer.write('\n  ');
-  buffer.write(context1.oneLineDoc);
-  buffer.write('\n  ');
-  buffer.write(
-      ___deduplicated_lib_templates__instance_fields_html_partial_property_0_partial_attributes_1(
-          context1));
-  buffer.writeln();
-  buffer.write('''</dd>
-''');
-
-  return buffer.toString();
-}
-
-String
-    ___deduplicated_lib_templates__instance_fields_html_partial_property_0_partial_categorization_0(
-        Field context1) {
-  final buffer = StringBuffer();
-  if (context1.hasCategoryNames) {
-    var context2 = context1.displayedCategories;
-    for (var context3 in context2) {
-      buffer.write('\n    ');
-      buffer.write(context3!.categoryLabel);
-    }
-  }
-  buffer.writeln();
-
-  return buffer.toString();
-}
-
-String
-    ___deduplicated_lib_templates__instance_fields_html_partial_property_0_partial_attributes_1(
-        Field context1) {
-  final buffer = StringBuffer();
-  if (context1.hasAttributes) {
-    buffer.write('''<div class="features">''');
-    buffer.write(context1.attributesAsString);
-    buffer.write('''</div>''');
-  }
-  buffer.writeln();
-
-  return buffer.toString();
-}
-
-String _deduplicated_lib_templates__instance_methods_html(Container context0) {
-  final buffer = StringBuffer();
-  if (context0.hasAvailableInstanceMethods) {
-    buffer.writeln();
-    buffer.write('''  <section
-      class="summary offset-anchor''');
-    if (context0.publicInheritedInstanceMethods) {
-      buffer.write(''' inherited''');
-    }
-    buffer.write('''"
-      id="instance-methods">
-    <h2>Methods</h2>
-    <dl class="callables">''');
-    var context1 = context0.availableInstanceMethodsSorted;
-    for (var context2 in context1) {
-      buffer.write('\n        ');
-      buffer.write(
-          __deduplicated_lib_templates__instance_methods_html_partial_callable_0(
-              context2));
-    }
-    buffer.writeln();
-    buffer.write('''    </dl>
-  </section>''');
-  }
-
-  return buffer.toString();
-}
-
-String __deduplicated_lib_templates__instance_methods_html_partial_callable_0(
-    Method context1) {
-  final buffer = StringBuffer();
-  buffer.write('''<dt id="''');
-  buffer.writeEscaped(context1.htmlId);
-  buffer.write('''" class="callable''');
-  if (context1.isInherited) {
-    buffer.write(''' inherited''');
-  }
-  buffer.write('''">
-  <span class="name''');
-  if (context1.isDeprecated) {
-    buffer.write(''' deprecated''');
-  }
-  buffer.write('''">''');
-  buffer.write(context1.linkedName);
-  buffer.write('''</span>''');
-  buffer.write(context1.linkedGenericParameters);
-  buffer.write('''<span class="signature">(<wbr>''');
-  buffer.write(context1.linkedParamsNoMetadata);
-  buffer.write(''')
-    <span class="returntype parameter">&#8594; ''');
-  buffer.write(context1.modelType.returnType.linkedName);
-  buffer.write('''</span>
-  </span>
-  ''');
-  buffer.write(
-      ___deduplicated_lib_templates__instance_methods_html_partial_callable_0_partial_categorization_0(
-          context1));
-  buffer.writeln();
-  buffer.write('''</dt>
-<dd''');
-  if (context1.isInherited) {
-    buffer.write(''' class="inherited"''');
-  }
-  buffer.write('''>''');
-  if (context1.isProvidedByExtension) {
-    var context2 = context1.enclosingExtension;
-    buffer.writeln();
-    buffer.write('''      <p class="from-extension">
-        <span>Available on ''');
-    buffer.write(context2.extendedElement.linkedName);
-    buffer.write(''',
-        provided by the ''');
-    buffer.write(context2.linkedName);
-    buffer.write(''' extension</span>
-      </p>''');
-  }
-  buffer.write('\n  ');
-  buffer.write(context1.oneLineDoc);
-  buffer.write('\n  ');
-  buffer.write(
-      ___deduplicated_lib_templates__instance_methods_html_partial_callable_0_partial_attributes_1(
-          context1));
-  buffer.writeln();
-  buffer.write('''</dd>
-''');
-
-  return buffer.toString();
-}
-
-String
-    ___deduplicated_lib_templates__instance_methods_html_partial_callable_0_partial_categorization_0(
-        Method context1) {
-  final buffer = StringBuffer();
-  if (context1.hasCategoryNames) {
-    var context2 = context1.displayedCategories;
-    for (var context3 in context2) {
-      buffer.write('\n    ');
-      buffer.write(context3!.categoryLabel);
-    }
-  }
-  buffer.writeln();
-
-  return buffer.toString();
-}
-
-String
-    ___deduplicated_lib_templates__instance_methods_html_partial_callable_0_partial_attributes_1(
-        Method context1) {
-  final buffer = StringBuffer();
-  if (context1.hasAttributes) {
-    buffer.write('''<div class="features">''');
-    buffer.write(context1.attributesAsString);
-    buffer.write('''</div>''');
-  }
-  buffer.writeln();
-
-  return buffer.toString();
-}
-
-String _deduplicated_lib_templates__instance_operators_html(
-    Container context0) {
-  final buffer = StringBuffer();
-  if (context0.hasAvailableInstanceOperators) {
-    buffer.writeln();
-    buffer.write('''  <section
-      class="summary offset-anchor''');
-    if (context0.publicInheritedInstanceOperators) {
-      buffer.write(''' inherited''');
-    }
-    buffer.write('''"
-      id="operators">
-    <h2>Operators</h2>
-    <dl class="callables">''');
-    var context1 = context0.availableInstanceOperatorsSorted;
-    for (var context2 in context1) {
-      buffer.write('\n        ');
-      buffer.write(
-          __deduplicated_lib_templates__instance_operators_html_partial_callable_0(
-              context2));
-    }
-    buffer.writeln();
-    buffer.write('''    </dl>
-  </section>''');
-  }
-
-  return buffer.toString();
-}
-
-String __deduplicated_lib_templates__instance_operators_html_partial_callable_0(
-    Operator context1) {
-  final buffer = StringBuffer();
-  buffer.write('''<dt id="''');
-  buffer.writeEscaped(context1.htmlId);
-  buffer.write('''" class="callable''');
-  if (context1.isInherited) {
-    buffer.write(''' inherited''');
-  }
-  buffer.write('''">
-  <span class="name''');
-  if (context1.isDeprecated) {
-    buffer.write(''' deprecated''');
-  }
-  buffer.write('''">''');
-  buffer.write(context1.linkedName);
-  buffer.write('''</span>''');
-  buffer.write(context1.linkedGenericParameters);
-  buffer.write('''<span class="signature">(<wbr>''');
-  buffer.write(context1.linkedParamsNoMetadata);
-  buffer.write(''')
-    <span class="returntype parameter">&#8594; ''');
-  buffer.write(context1.modelType.returnType.linkedName);
-  buffer.write('''</span>
-  </span>
-  ''');
-  buffer.write(
-      ___deduplicated_lib_templates__instance_operators_html_partial_callable_0_partial_categorization_0(
-          context1));
-  buffer.writeln();
-  buffer.write('''</dt>
-<dd''');
-  if (context1.isInherited) {
-    buffer.write(''' class="inherited"''');
-  }
-  buffer.write('''>''');
-  if (context1.isProvidedByExtension) {
-    var context2 = context1.enclosingExtension;
-    buffer.writeln();
-    buffer.write('''      <p class="from-extension">
-        <span>Available on ''');
-    buffer.write(context2.extendedElement.linkedName);
-    buffer.write(''',
-        provided by the ''');
-    buffer.write(context2.linkedName);
-    buffer.write(''' extension</span>
-      </p>''');
-  }
-  buffer.write('\n  ');
-  buffer.write(context1.oneLineDoc);
-  buffer.write('\n  ');
-  buffer.write(
-      ___deduplicated_lib_templates__instance_operators_html_partial_callable_0_partial_attributes_1(
-          context1));
-  buffer.writeln();
-  buffer.write('''</dd>
-''');
-
-  return buffer.toString();
-}
-
-String
-    ___deduplicated_lib_templates__instance_operators_html_partial_callable_0_partial_categorization_0(
-        Operator context1) {
-  final buffer = StringBuffer();
-  if (context1.hasCategoryNames) {
-    var context2 = context1.displayedCategories;
-    for (var context3 in context2) {
-      buffer.write('\n    ');
-      buffer.write(context3!.categoryLabel);
-    }
-  }
-  buffer.writeln();
-
-  return buffer.toString();
-}
-
-String
-    ___deduplicated_lib_templates__instance_operators_html_partial_callable_0_partial_attributes_1(
-        Operator context1) {
-  final buffer = StringBuffer();
-  if (context1.hasAttributes) {
-    buffer.write('''<div class="features">''');
-    buffer.write(context1.attributesAsString);
-    buffer.write('''</div>''');
-  }
-  buffer.writeln();
-
-  return buffer.toString();
-}
-
-String _deduplicated_lib_templates__static_properties_html(Container context0) {
-  final buffer = StringBuffer();
-  if (context0.hasPublicVariableStaticFields) {
-    buffer.writeln();
-    buffer.write(
-        '''  <section class="summary offset-anchor" id="static-properties">
-    <h2>Static Properties</h2>
-    <dl class="properties">''');
-    var context1 = context0.publicVariableStaticFieldsSorted;
-    for (var context2 in context1) {
-      buffer.write('\n        ');
-      buffer.write(
-          __deduplicated_lib_templates__static_properties_html_partial_property_0(
-              context2));
-    }
-    buffer.writeln();
-    buffer.write('''    </dl>
-  </section>''');
-  }
-
-  return buffer.toString();
-}
-
-String __deduplicated_lib_templates__static_properties_html_partial_property_0(
-    Field context1) {
-  final buffer = StringBuffer();
-  buffer.write('''<dt id="''');
-  buffer.writeEscaped(context1.htmlId);
-  buffer.write('''" class="property''');
-  if (context1.isInherited) {
-    buffer.write(''' inherited''');
-  }
-  buffer.write('''">
-  <span class="name">''');
-  buffer.write(context1.linkedName);
-  buffer.write('''</span>
-  <span class="signature">''');
-  buffer.write(context1.arrow);
-  buffer.write(' ');
-  buffer.write(context1.modelType.linkedName);
-  buffer.write('''</span>
-  ''');
-  buffer.write(
-      ___deduplicated_lib_templates__static_properties_html_partial_property_0_partial_categorization_0(
-          context1));
-  buffer.writeln();
-  buffer.write('''</dt>
-<dd''');
-  if (context1.isInherited) {
-    buffer.write(''' class="inherited"''');
-  }
-  buffer.write('''>''');
-  if (context1.isProvidedByExtension) {
-    var context2 = context1.enclosingExtension;
-    buffer.writeln();
-    buffer.write('''      <p class="from-extension">
-        <span>Available on ''');
-    buffer.write(context2.extendedElement.linkedName);
-    buffer.write(''',
-        provided by the ''');
-    buffer.write(context2.linkedName);
-    buffer.write(''' extension</span>
-      </p>''');
-  }
-  buffer.write('\n  ');
-  buffer.write(context1.oneLineDoc);
-  buffer.write('\n  ');
-  buffer.write(
-      ___deduplicated_lib_templates__static_properties_html_partial_property_0_partial_attributes_1(
-          context1));
-  buffer.writeln();
-  buffer.write('''</dd>
-''');
-
-  return buffer.toString();
-}
-
-String
-    ___deduplicated_lib_templates__static_properties_html_partial_property_0_partial_categorization_0(
-        Field context1) {
-  final buffer = StringBuffer();
-  if (context1.hasCategoryNames) {
-    var context2 = context1.displayedCategories;
-    for (var context3 in context2) {
-      buffer.write('\n    ');
-      buffer.write(context3!.categoryLabel);
-    }
-  }
-  buffer.writeln();
-
-  return buffer.toString();
-}
-
-String
-    ___deduplicated_lib_templates__static_properties_html_partial_property_0_partial_attributes_1(
-        Field context1) {
-  final buffer = StringBuffer();
-  if (context1.hasAttributes) {
-    buffer.write('''<div class="features">''');
-    buffer.write(context1.attributesAsString);
-    buffer.write('''</div>''');
-  }
-  buffer.writeln();
-
-  return buffer.toString();
-}
-
-String _deduplicated_lib_templates__static_methods_html(Container context0) {
-  final buffer = StringBuffer();
-  if (context0.hasPublicStaticMethods) {
-    buffer.writeln();
-    buffer
-        .write('''  <section class="summary offset-anchor" id="static-methods">
-    <h2>Static Methods</h2>
-    <dl class="callables">''');
-    var context1 = context0.publicStaticMethodsSorted;
-    for (var context2 in context1) {
-      buffer.write('\n        ');
-      buffer.write(
-          __deduplicated_lib_templates__static_methods_html_partial_callable_0(
-              context2));
-    }
-    buffer.writeln();
-    buffer.write('''    </dl>
-  </section>''');
-  }
-
-  return buffer.toString();
-}
-
-String __deduplicated_lib_templates__static_methods_html_partial_callable_0(
-    Method context1) {
-  final buffer = StringBuffer();
-  buffer.write('''<dt id="''');
-  buffer.writeEscaped(context1.htmlId);
-  buffer.write('''" class="callable''');
-  if (context1.isInherited) {
-    buffer.write(''' inherited''');
-  }
-  buffer.write('''">
-  <span class="name''');
-  if (context1.isDeprecated) {
-    buffer.write(''' deprecated''');
-  }
-  buffer.write('''">''');
-  buffer.write(context1.linkedName);
-  buffer.write('''</span>''');
-  buffer.write(context1.linkedGenericParameters);
-  buffer.write('''<span class="signature">(<wbr>''');
-  buffer.write(context1.linkedParamsNoMetadata);
-  buffer.write(''')
-    <span class="returntype parameter">&#8594; ''');
-  buffer.write(context1.modelType.returnType.linkedName);
-  buffer.write('''</span>
-  </span>
-  ''');
-  buffer.write(
-      ___deduplicated_lib_templates__static_methods_html_partial_callable_0_partial_categorization_0(
-          context1));
-  buffer.writeln();
-  buffer.write('''</dt>
-<dd''');
-  if (context1.isInherited) {
-    buffer.write(''' class="inherited"''');
-  }
-  buffer.write('''>''');
-  if (context1.isProvidedByExtension) {
-    var context2 = context1.enclosingExtension;
-    buffer.writeln();
-    buffer.write('''      <p class="from-extension">
-        <span>Available on ''');
-    buffer.write(context2.extendedElement.linkedName);
-    buffer.write(''',
-        provided by the ''');
-    buffer.write(context2.linkedName);
-    buffer.write(''' extension</span>
-      </p>''');
-  }
-  buffer.write('\n  ');
-  buffer.write(context1.oneLineDoc);
-  buffer.write('\n  ');
-  buffer.write(
-      ___deduplicated_lib_templates__static_methods_html_partial_callable_0_partial_attributes_1(
-          context1));
-  buffer.writeln();
-  buffer.write('''</dd>
-''');
-
-  return buffer.toString();
-}
-
-String
-    ___deduplicated_lib_templates__static_methods_html_partial_callable_0_partial_categorization_0(
-        Method context1) {
-  final buffer = StringBuffer();
-  if (context1.hasCategoryNames) {
-    var context2 = context1.displayedCategories;
-    for (var context3 in context2) {
-      buffer.write('\n    ');
-      buffer.write(context3!.categoryLabel);
-    }
-  }
-  buffer.writeln();
-
-  return buffer.toString();
-}
-
-String
-    ___deduplicated_lib_templates__static_methods_html_partial_callable_0_partial_attributes_1(
-        Method context1) {
-  final buffer = StringBuffer();
-  if (context1.hasAttributes) {
-    buffer.write('''<div class="features">''');
-    buffer.write(context1.attributesAsString);
-    buffer.write('''</div>''');
-  }
-  buffer.writeln();
-
-  return buffer.toString();
-}
-
-String _deduplicated_lib_templates__static_constants_html(Container context0) {
-  final buffer = StringBuffer();
-  buffer.writeln();
-  if (context0.hasPublicConstantFields) {
-    buffer.writeln();
-    buffer.write('''  <section class="summary offset-anchor" id="constants">
-    <h2>Constants</h2>
-    <dl class="properties">''');
-    var context1 = context0.publicConstantFieldsSorted;
-    for (var context2 in context1) {
-      buffer.write('\n        ');
-      buffer.write(
-          __deduplicated_lib_templates__static_constants_html_partial_constant_0(
-              context2));
-    }
-    buffer.writeln();
-    buffer.write('''    </dl>
-  </section>''');
-  }
-
-  return buffer.toString();
-}
-
-String __deduplicated_lib_templates__static_constants_html_partial_constant_0(
-    Field context1) {
-  final buffer = StringBuffer();
-  buffer.write('''<dt id="''');
-  buffer.writeEscaped(context1.htmlId);
-  buffer.write('''" class="constant">''');
-  if (context1.isEnumValue) {
-    buffer.writeln();
-    buffer.write('''    <span class="name ''');
-    if (context1.isDeprecated) {
-      buffer.write('''deprecated''');
-    }
-    buffer.write('''">''');
-    buffer.write(context1.name);
-    buffer.write('''</span>''');
-  }
-  if (!context1.isEnumValue) {
-    buffer.writeln();
-    buffer.write('''    <span class="name ''');
-    if (context1.isDeprecated) {
-      buffer.write('''deprecated''');
-    }
-    buffer.write('''">''');
-    buffer.write(context1.linkedName);
-    buffer.write('''</span>''');
-  }
-  buffer.writeln();
-  buffer.write('''  <span class="signature">&#8594; const ''');
-  buffer.write(context1.modelType.linkedName);
-  buffer.write('''</span>
-  ''');
-  buffer.write(
-      ___deduplicated_lib_templates__static_constants_html_partial_constant_0_partial_categorization_0(
-          context1));
-  buffer.writeln();
-  buffer.write('''</dt>
-<dd>
-  ''');
-  buffer.write(context1.oneLineDoc);
-  buffer.write('\n  ');
-  buffer.write(
-      ___deduplicated_lib_templates__static_constants_html_partial_constant_0_partial_attributes_1(
-          context1));
-  if (context1.hasConstantValueForDisplay) {
-    buffer.writeln();
-    buffer.write('''    <div>
-      <span class="signature"><code>''');
-    buffer.write(context1.constantValueTruncated);
-    buffer.write('''</code></span>
-    </div>''');
-  }
-  buffer.writeln();
-  buffer.write('''</dd>
-''');
-
-  return buffer.toString();
-}
-
-String
-    ___deduplicated_lib_templates__static_constants_html_partial_constant_0_partial_categorization_0(
-        Field context1) {
-  final buffer = StringBuffer();
-  if (context1.hasCategoryNames) {
-    var context2 = context1.displayedCategories;
-    for (var context3 in context2) {
-      buffer.write('\n    ');
-      buffer.write(context3!.categoryLabel);
-    }
-  }
-  buffer.writeln();
-
-  return buffer.toString();
-}
-
-String
-    ___deduplicated_lib_templates__static_constants_html_partial_constant_0_partial_attributes_1(
-        Field context1) {
-  final buffer = StringBuffer();
-  if (context1.hasAttributes) {
-    buffer.write('''<div class="features">''');
-    buffer.write(context1.attributesAsString);
-    buffer.write('''</div>''');
-  }
-  buffer.writeln();
-
-  return buffer.toString();
-}
-
-String _deduplicated_lib_templates__annotations_html(ModelElement context0) {
-  final buffer = StringBuffer();
-  if (context0.hasAnnotations) {
-    buffer.writeln();
-    buffer.write('''  <div>
-    <ol class="annotation-list">''');
-    var context1 = context0.annotations;
-    for (var context2 in context1) {
-      buffer.writeln();
-      buffer.write('''        <li>''');
-      buffer.write(context2.linkedNameWithParameters);
-      buffer.write('''</li>''');
-    }
-    buffer.writeln();
-    buffer.write('''    </ol>
-  </div>''');
-  }
-
-  return buffer.toString();
-}
-
-String _deduplicated_lib_templates__source_code_html(ModelElement context0) {
-  final buffer = StringBuffer();
-  if (context0.hasSourceCode) {
-    buffer.writeln();
-    buffer.write('''<section class="summary source-code" id="source">
-  <h2><span>Implementation</span></h2>
-  <pre class="language-dart"><code class="language-dart">''');
-    buffer.write(context0.sourceCode);
-    buffer.write('''</code></pre>
-</section>''');
-  }
-  buffer.writeln();
-
-  return buffer.toString();
-}
-
-String _deduplicated_lib_templates__name_summary_html(ModelElement context0) {
-  final buffer = StringBuffer();
-  if (context0.isConst) {
-    buffer.write('''const ''');
-  }
-  buffer.write('''<span class="name ''');
-  if (context0.isDeprecated) {
-    buffer.write('''deprecated''');
-  }
-  buffer.write('''">''');
-  buffer.writeEscaped(context0.name);
-  buffer.write('''</span>''');
-
-  return buffer.toString();
-}
-
-String _deduplicated_lib_templates__accessor_getter_html(
-    GetterSetterCombo context0) {
-  final buffer = StringBuffer();
-  var context1 = context0.getter;
-  if (context1 != null) {
-    buffer.writeln();
-    buffer.write('''  <section id="getter">
-    <section class="multi-line-signature">
-      ''');
-    buffer.write(
-        __deduplicated_lib_templates__accessor_getter_html_partial_annotations_0(
-            context1));
-    buffer.writeln();
-    buffer.write('''      <span class="returntype">''');
-    buffer.write(context1.modelType.returnType.linkedName);
-    buffer.write('''</span>
-      get
-      ''');
-    buffer.write(
-        __deduplicated_lib_templates__accessor_getter_html_partial_name_summary_1(
-            context1));
-    buffer.write('\n      ');
-    buffer.write(
-        __deduplicated_lib_templates__accessor_getter_html_partial_attributes_2(
-            context1));
-    buffer.writeln();
-    buffer.write('''    </section>
-    ''');
-    buffer.write(
-        __deduplicated_lib_templates__accessor_getter_html_partial_documentation_3(
-            context1));
-    buffer.write('\n    ');
-    buffer.write(
-        __deduplicated_lib_templates__accessor_getter_html_partial_source_code_4(
-            context1));
-    buffer.writeln();
-    buffer.write('''  </section>''');
-  }
-  buffer.writeln();
-
-  return buffer.toString();
-}
-
-String __deduplicated_lib_templates__accessor_getter_html_partial_annotations_0(
-    Accessor context1) {
-  final buffer = StringBuffer();
-  if (context1.hasAnnotations) {
-    buffer.writeln();
-    buffer.write('''  <div>
-    <ol class="annotation-list">''');
-    var context2 = context1.annotations;
-    for (var context3 in context2) {
-      buffer.writeln();
-      buffer.write('''        <li>''');
-      buffer.write(context3.linkedNameWithParameters);
-      buffer.write('''</li>''');
-    }
-    buffer.writeln();
-    buffer.write('''    </ol>
-  </div>''');
-  }
-
-  return buffer.toString();
-}
-
-String
-    __deduplicated_lib_templates__accessor_getter_html_partial_name_summary_1(
-        Accessor context1) {
-  final buffer = StringBuffer();
-  if (context1.isConst) {
-    buffer.write('''const ''');
-  }
-  buffer.write('''<span class="name ''');
-  if (context1.isDeprecated) {
-    buffer.write('''deprecated''');
-  }
-  buffer.write('''">''');
-  buffer.writeEscaped(context1.name);
-  buffer.write('''</span>''');
-
-  return buffer.toString();
-}
-
-String __deduplicated_lib_templates__accessor_getter_html_partial_attributes_2(
-    Accessor context1) {
-  final buffer = StringBuffer();
-  if (context1.hasAttributes) {
-    buffer.write('''<div class="features">''');
-    buffer.write(context1.attributesAsString);
-    buffer.write('''</div>''');
-  }
-  buffer.writeln();
-
-  return buffer.toString();
-}
-
-String
-    __deduplicated_lib_templates__accessor_getter_html_partial_documentation_3(
-        Accessor context1) {
-  final buffer = StringBuffer();
-  if (context1.hasDocumentation) {
-    buffer.writeln();
-    buffer.write('''<section class="desc markdown">
-  ''');
-    buffer.write(context1.documentationAsHtml);
-    buffer.writeln();
-    buffer.write('''</section>''');
-  }
-  buffer.writeln();
-
-  return buffer.toString();
-}
-
-String __deduplicated_lib_templates__accessor_getter_html_partial_source_code_4(
-    Accessor context1) {
-  final buffer = StringBuffer();
-  if (context1.hasSourceCode) {
-    buffer.writeln();
-    buffer.write('''<section class="summary source-code" id="source">
-  <h2><span>Implementation</span></h2>
-  <pre class="language-dart"><code class="language-dart">''');
-    buffer.write(context1.sourceCode);
-    buffer.write('''</code></pre>
-</section>''');
-  }
-  buffer.writeln();
-
-  return buffer.toString();
-}
-
-String _deduplicated_lib_templates__accessor_setter_html(
-    GetterSetterCombo context0) {
-  final buffer = StringBuffer();
-  var context1 = context0.setter;
-  if (context1 != null) {
-    buffer.writeln();
-    buffer.write('''  <section id="setter">
-    <section class="multi-line-signature">
-      ''');
-    buffer.write(
-        __deduplicated_lib_templates__accessor_setter_html_partial_annotations_0(
-            context1));
-    buffer.writeln();
-    buffer.write('''      set
-      <span class="name ''');
-    if (context1.isDeprecated) {
-      buffer.write('''deprecated''');
-    }
-    buffer.write('''">''');
-    buffer.writeEscaped(context1.definingCombo.name);
-    buffer.write('''</span>
-      <span class="signature">(<wbr>''');
-    buffer.write(context1.linkedParamsNoMetadata);
-    buffer.write(''')</span>
-      ''');
-    buffer.write(
-        __deduplicated_lib_templates__accessor_setter_html_partial_attributes_1(
-            context1));
-    buffer.writeln();
-    buffer.write('''    </section>
-    ''');
-    buffer.write(
-        __deduplicated_lib_templates__accessor_setter_html_partial_documentation_2(
-            context1));
-    buffer.write('\n    ');
-    buffer.write(
-        __deduplicated_lib_templates__accessor_setter_html_partial_source_code_3(
-            context1));
-    buffer.writeln();
-    buffer.write('''  </section>''');
-  }
-  buffer.writeln();
-
-  return buffer.toString();
-}
-
-String __deduplicated_lib_templates__accessor_setter_html_partial_annotations_0(
-    Accessor context1) {
-  final buffer = StringBuffer();
-  if (context1.hasAnnotations) {
-    buffer.writeln();
-    buffer.write('''  <div>
-    <ol class="annotation-list">''');
-    var context2 = context1.annotations;
-    for (var context3 in context2) {
-      buffer.writeln();
-      buffer.write('''        <li>''');
-      buffer.write(context3.linkedNameWithParameters);
-      buffer.write('''</li>''');
-    }
-    buffer.writeln();
-    buffer.write('''    </ol>
-  </div>''');
-  }
-
-  return buffer.toString();
-}
-
-String __deduplicated_lib_templates__accessor_setter_html_partial_attributes_1(
-    Accessor context1) {
-  final buffer = StringBuffer();
-  if (context1.hasAttributes) {
-    buffer.write('''<div class="features">''');
-    buffer.write(context1.attributesAsString);
-    buffer.write('''</div>''');
-  }
-  buffer.writeln();
-
-  return buffer.toString();
-}
-
-String
-    __deduplicated_lib_templates__accessor_setter_html_partial_documentation_2(
-        Accessor context1) {
-  final buffer = StringBuffer();
-  if (context1.hasDocumentation) {
-    buffer.writeln();
-    buffer.write('''<section class="desc markdown">
-  ''');
-    buffer.write(context1.documentationAsHtml);
-    buffer.writeln();
-    buffer.write('''</section>''');
-  }
-  buffer.writeln();
-
-  return buffer.toString();
-}
-
-String __deduplicated_lib_templates__accessor_setter_html_partial_source_code_3(
-    Accessor context1) {
-  final buffer = StringBuffer();
-  if (context1.hasSourceCode) {
-    buffer.writeln();
-    buffer.write('''<section class="summary source-code" id="source">
-  <h2><span>Implementation</span></h2>
-  <pre class="language-dart"><code class="language-dart">''');
-    buffer.write(context1.sourceCode);
-    buffer.write('''</code></pre>
-</section>''');
-  }
-  buffer.writeln();
-
-  return buffer.toString();
-}
+        _deduplicated__name_summary(context1);
 
 extension on StringBuffer {
   void writeEscaped(String? value) {

--- a/test/mustachio/aot_compiler_builder_test.dart
+++ b/test/mustachio/aot_compiler_builder_test.dart
@@ -147,17 +147,17 @@ import 'annotations.dart';
     var generatedContent = await File(aotRenderersForHtmlPath).readAsString();
     expect(
       generatedContent,
-      contains('String _renderFoo_partial_base_0(Foo context0) =>\n'
-          '    _deduplicated_lib_templates__base_html(context0);\n'),
+      contains('String _renderFoo_partial_base_0(Foo context0) => '
+          '_deduplicated__base(context0);\n'),
     );
     expect(
       generatedContent,
-      contains('String _renderBar_partial_base_0(Bar context0) =>\n'
-          '    _deduplicated_lib_templates__base_html(context0);\n'),
+      contains('String _renderBar_partial_base_0(Bar context0) => '
+          '_deduplicated__base(context0);\n'),
     );
     expect(
       generatedContent,
-      contains('String _deduplicated_lib_templates__base_html('),
+      contains('String _deduplicated__base(Base context0)'),
     );
   });
 
@@ -200,17 +200,17 @@ import 'annotations.dart';
     var generatedContent = await File(aotRenderersForHtmlPath).readAsString();
     expect(
       generatedContent,
-      contains('String _renderFoo_partial_base_0(A context1) =>\n'
-          '    _deduplicated_lib_templates__base_html(context1);\n'),
+      contains('String _renderFoo_partial_base_0(A context1) => '
+          '_deduplicated__base(context1);\n'),
     );
     expect(
       generatedContent,
-      contains('String _renderFoo_partial_base_1(B context1) =>\n'
-          '    _deduplicated_lib_templates__base_html(context1);\n'),
+      contains('String _renderFoo_partial_base_1(B context1) => '
+          '_deduplicated__base(context1);\n'),
     );
     expect(
       generatedContent,
-      contains('String _deduplicated_lib_templates__base_html(Base context0)'),
+      contains('String _deduplicated__base(Base context0)'),
     );
   });
 

--- a/test/mustachio/foo.aot_renderers_for_html.dart
+++ b/test/mustachio/foo.aot_renderers_for_html.dart
@@ -16,6 +16,18 @@ import 'dart:convert';
 
 import 'foo.dart';
 
+String renderBar() {
+  final buffer = StringBuffer();
+
+  return buffer.toString();
+}
+
+String renderBaz() {
+  final buffer = StringBuffer();
+
+  return buffer.toString();
+}
+
 String renderFoo(Foo context0) {
   final buffer = StringBuffer();
   buffer.write('''<div>
@@ -55,18 +67,6 @@ String renderFoo(Foo context0) {
   }
   buffer.writeln();
   buffer.write('''</div>''');
-
-  return buffer.toString();
-}
-
-String renderBar() {
-  final buffer = StringBuffer();
-
-  return buffer.toString();
-}
-
-String renderBaz() {
-  final buffer = StringBuffer();
 
   return buffer.toString();
 }

--- a/test/mustachio/runtime_renderer_render_test.dart
+++ b/test/mustachio/runtime_renderer_render_test.dart
@@ -10,6 +10,7 @@ import 'package:analyzer/file_system/memory_file_system.dart';
 import 'package:dartdoc/src/mustachio/renderer_base.dart';
 import 'package:path/path.dart' as path show Context;
 import 'package:test/test.dart';
+
 import 'foo.dart';
 import 'foo.runtime_renderers.dart';
 


### PR DESCRIPTION
Currently mustachio has a very rudimentary deduplication strategy that leaves a fair number of unused partial render functions dangling in the generated code. This is because we delete a partial renderer function without taking great care about what partial functions it might have rendered, and which maybe are no longer rendered. This occurs particularly with deduplicated renderer functions that then don't become used any more.

This change introduces a renderer cache and a more formal 'reference-counting' strategy to know if a renderer becomes unused. Tracking all renderer functions (and the compilers that compiled them, and the used context stacks determined by compilers) in one place makes it possible to have a more accurate understanding of what renderer functions become unused through the deduplication process.

The new strategy is documented pretty well in this change, in the README.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
