### PR TITLE
Correct links to remote, canonical libraries

### DIFF
--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -751,8 +751,9 @@ class PackageGraph with CommentReferable, Nameable {
     return buffer.toString();
   }
 
-  /// Tries to find a canonical [ModelElement] for this [modelElement].  If we
-  /// know this element is related to a particular class, pass a
+  /// Tries to find a canonical [ModelElement] for [modelElement].
+  ///
+  /// If we know the element is related to a particular class, pass a
   /// [preferredClass] to disambiguate.
   ///
   /// This doesn't know anything about [PackageGraph.inheritThrough] and
@@ -795,10 +796,10 @@ class PackageGraph with CommentReferable, Nameable {
     ModelElement? canonicalModelElement;
     if (declaration != null &&
         (element is ClassMemberElement || element is PropertyAccessorElement)) {
-      modelElement = getModelForElement(declaration);
-      element = modelElement.element;
+      var declarationModelElement = getModelForElement(declaration);
+      element = declarationModelElement.element;
       canonicalModelElement = _findCanonicalModelElementForAmbiguous(
-          modelElement, library,
+          declarationModelElement, library,
           preferredClass: preferredClass as InheritingContainer?);
     } else {
       if (library != null) {

--- a/test/dartdoc_test_base.dart
+++ b/test/dartdoc_test_base.dart
@@ -39,7 +39,9 @@ abstract class DartdocTestBase {
   String get dartAsyncUrlPrefix =>
       'https://api.dart.dev/stable/3.2.0/dart-async';
 
-  String get dartCoreUrlPrefix => 'https://api.dart.dev/stable/3.2.0/dart-core';
+  String get dartSdkUrlPrefix => 'https://api.dart.dev/stable/3.2.0';
+
+  String get dartCoreUrlPrefix => '$dartSdkUrlPrefix/dart-core';
 
   String get sdkConstraint => '>=3.7.0 <4.0.0';
 

--- a/test/libraries_test.dart
+++ b/test/libraries_test.dart
@@ -194,6 +194,16 @@ class LibrariesTest extends DartdocTestBase {
     expect(library.href, '${placeholder}libraries');
   }
 
+  void test_library_containsClassWithSameNameAsDartSdk() async {
+    var library = await bootPackageWithLibrary(
+      'export "dart:io";',
+      libraryFilePath: 'lib/library.dart',
+    );
+
+    expect(library.classes.named('FileSystemEntity').linkedName,
+        '<a href="$dartSdkUrlPrefix/dart-io/FileSystemEntity-class.html">FileSystemEntity</a>');
+  }
+
   void test_publicLibrary_unnamed() async {
     var library =
         (await bootPackageFromFiles([d.file('lib/lib1.dart', 'library;')]))


### PR DESCRIPTION
Fixes https://github.com/dart-lang/dartdoc/issues/3891

In this example, the **file** package exports elements from `dart:io`. So when `--link-to-remote` is used, the canonical library for those exported elements should be `api.dart.dev`.

Also some cleaning:

* Move `_searchForCanonicalLibrary` from ModelElement to `canonicalization.dart`, keeping more canonicalization logic together.
* This allows us to make `Canonicalization` private.
* Make some comments in ModelElement doc-comments.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
