### PR TITLE
Do not use SpecialClass to evaluate Enum or Interceptor

### DIFF
--- a/lib/src/model/inheritable.dart
+++ b/lib/src/model/inheritable.dart
@@ -114,7 +114,19 @@ mixin Inheritable on ContainerMember {
     return super.computeCanonicalEnclosingContainer();
   }
 
-  bool _isHiddenInterface(Container? c) => packageGraph.isHiddenInterface(c);
+  /// Whether [c] is a "hidden" interface.
+  ///
+  /// A hidden interface should never be considered the canonical enclosing
+  /// container of a container member.
+  ///
+  /// Add classes here if they are similar to the Dart SDK's 'Interceptor' class
+  /// in that they are to be ignored even when they are the implementers of
+  /// [Inheritable]s, and the class these inherit from should instead claim
+  /// implementation.
+  bool _isHiddenInterface(Container? c) =>
+      c != null &&
+      c.element.name == 'Interceptor' &&
+      c.element.library?.name == '_interceptors';
 
   /// A roughly ordered list of this element's enclosing container's inheritance
   /// chain.

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -706,23 +706,6 @@ class PackageGraph with CommentReferable, Nameable {
           ?.linkedName ??
       'Object';
 
-  /// The set of [Class]es which should _not_ be considered the canonical
-  /// enclosing container of any container member.
-  ///
-  /// Add classes here if they are similar to Interceptor in that they are to be
-  /// ignored even when they are the implementers of [Inheritable]s, and the
-  /// class these inherit from should instead claim implementation.
-  late final Set<Class> _inheritThrough = {
-    if (specialClasses[SpecialClass.interceptor] case var interceptor?)
-      interceptor,
-  };
-
-  /// Whether [c] is a "hidden" interface.
-  ///
-  /// A hidden interface should never be considered the canonical enclosing
-  /// container of a container member.
-  bool isHiddenInterface(Container? c) => _inheritThrough.contains(c);
-
   /// The set of [Class] objects that are similar to 'pragma' in that we should
   /// never count them as documentable annotations.
   late final Set<Class> _invisibleAnnotations = {

--- a/lib/src/special_elements.dart
+++ b/lib/src/special_elements.dart
@@ -19,11 +19,7 @@ import 'package:dartdoc/src/model/model.dart';
 enum SpecialClass {
   object('Object', 'dart.core', 'dart:core'),
 
-  interceptor('Interceptor', '_interceptors', 'dart:_interceptors'),
-
-  pragma('pragma', 'dart.core', 'dart:core'),
-
-  enum_('Enum', 'dart.core', 'dart:core');
+  pragma('pragma', 'dart.core', 'dart:core');
 
   /// The package name in which these special [ModelElement]s can be found.
   static const String _packageName = 'Dart';
@@ -43,7 +39,7 @@ enum SpecialClass {
   /// Elements which must exist in the package graph when calling
   /// [SpecialClasses.new].
   static List<SpecialClass> get _requiredSpecialClasses =>
-      [SpecialClass.enum_, SpecialClass.object];
+      [SpecialClass.object];
 
   /// Returns the path of the Dart Library where this [ModelElement] is
   /// declared, or `null` if its URI does not denote a library in the specified


### PR DESCRIPTION
Work towards https://github.com/dart-lang/dartdoc/issues/3927

Enum wasn't used. Interceptor can just be compared via name and library name.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
