### PR TITLE
Avoid the PackageGraph.objectClass field.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 8.3.2
+
+* Fix a LateInitializationError by not depending on PackageGraph.objectClass.
+
 ## 8.3.1
 
 * Require Dart 3.5 or later.

--- a/dartdoc_options.yaml
+++ b/dartdoc_options.yaml
@@ -1,4 +1,4 @@
 dartdoc:
   linkToSource:
     root: '.'
-    uriTemplate: 'https://github.com/dart-lang/dartdoc/blob/v8.3.1/%f%#L%l%'
+    uriTemplate: 'https://github.com/dart-lang/dartdoc/blob/v8.3.2/%f%#L%l%'

--- a/lib/src/model/mixin.dart
+++ b/lib/src/model/mixin.dart
@@ -16,10 +16,8 @@ class Mixin extends InheritingContainer {
   final MixinElement element;
 
   late final List<ParameterizedElementType> superclassConstraints = [
-    ...element.superclassConstraints
-        .map((InterfaceType i) =>
-            getTypeFor(i, library) as ParameterizedElementType)
-        .where((t) => t.modelElement != packageGraph.objectClass)
+    ...element.superclassConstraints.where((e) => !e.isDartCoreObject).map(
+        (InterfaceType i) => getTypeFor(i, library) as ParameterizedElementType)
   ];
 
   @override

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -204,6 +204,7 @@ class PackageGraph with CommentReferable, Nameable {
   final Map<Element, ModelNode> _modelNodes = {};
 
   /// The Object class declared in the Dart SDK's 'dart:core' library.
+  // TODO(srawlins): I think nothing depends on this any longer; remove.
   late InheritingContainer objectClass;
 
   /// Populate's [_modelNodes] with elements in [resolvedLibrary].

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,1 +1,1 @@
-const packageVersion = '8.3.1';
+const packageVersion = '8.3.2';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dartdoc
-version: 8.3.1
+version: 8.3.2
 description: A non-interactive HTML documentation generator for Dart source code.
 repository: https://github.com/dart-lang/dartdoc
 


### PR DESCRIPTION
Avoid the PackageGraph.objectClass field. There are sometimes LateInitializationErrors accessing it. It turns out it is not needed.

Fixes https://github.com/dart-lang/dartdoc/issues/3947

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
