### PR TITLE
More cleanup from removal of SpecialClasses

### DIFF
--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -204,7 +204,6 @@ class PackageGraph with CommentReferable, Nameable {
   final Map<Element, ModelNode> _modelNodes = {};
 
   /// The Object class declared in the Dart SDK's 'dart:core' library.
-  // TODO(srawlins): I think nothing depends on this any longer; remove.
   late InheritingContainer objectClass;
 
   /// Populate's [_modelNodes] with elements in [resolvedLibrary].


### PR DESCRIPTION
We stopped using "special classes" and so stopped using the `addingSpecials` parameter of `_discoverLibraries`.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
