### PR TITLE
Fix enum links for exported enums

### DIFF
--- a/lib/src/model/enum.dart
+++ b/lib/src/model/enum.dart
@@ -117,9 +117,9 @@ class EnumField extends Field {
       return canonicalModelElement?.href;
     }
     assert(canonicalEnclosingContainer == enclosingElement);
-    // TODO(jcollins-g): EnumField should not depend on enclosingElement, but
-    // we sort of have to while we are half-converted to [FileStructure].
-    return '${package.baseHref}${enclosingElement.library.dirName}/${enclosingElement.fileName}';
+    assert(canonicalLibrary != null);
+    return '${package.baseHref}${canonicalLibrary!.dirName}/'
+        '${enclosingElement.fileName}';
   }
 
   @override

--- a/test/enums_test.dart
+++ b/test/enums_test.dart
@@ -8,6 +8,7 @@ import 'package:test/test.dart';
 import 'package:test_reflective_loader/test_reflective_loader.dart';
 
 import 'dartdoc_test_base.dart';
+import 'src/test_descriptor_utils.dart' as d;
 import 'src/utils.dart';
 
 void main() {
@@ -631,6 +632,23 @@ enum E {
 
   void test_value_linksToItsAnchor() async {
     var library = await bootPackageWithLibrary('enum E { one, two, three }');
+    var oneValue =
+        library.enums.named('E').publicEnumValues.named('one') as EnumField;
+    expect(oneValue.linkedName, '<a href="$linkPrefix/E.html#one">one</a>');
+    expect(oneValue.constantValue, equals(oneValue.renderedName));
+  }
+
+  void test_value_linksToItsAnchor_inExportedLib() async {
+    var library = (await bootPackageFromFiles([
+      d.file('lib/src/library.dart', '''
+enum E { one, two three }
+'''),
+      d.file('lib/enums.dart', '''
+export 'src/library.dart';
+'''),
+    ]))
+        .libraries
+        .named(libraryName);
     var oneValue =
         library.enums.named('E').publicEnumValues.named('one') as EnumField;
     expect(oneValue.linkedName, '<a href="$linkPrefix/E.html#one">one</a>');

--- a/test/src/utils.dart
+++ b/test/src/utils.dart
@@ -355,7 +355,16 @@ bool get classModifiersAllowed =>
         .allows(platformVersion);
 
 extension ModelElementIterableExtension<T extends ModelElement> on Iterable<T> {
-  T named(String name) => singleWhere((e) => e.name == name);
+  T named(String name) {
+    var elements = where((e) => e.name == name).toList();
+    if (elements.isEmpty) {
+      throw StateError("No $T elements named '$name'");
+    }
+    if (elements.length > 1) {
+      throw StateError("Too many $T elements named '$name': $elements");
+    }
+    return elements.single;
+  }
 
   T displayNamed(String displayName) =>
       singleWhere((e) => e.displayName == displayName);


### PR DESCRIPTION
Enums in exported libraries had a bad link. They must use their canonical library's path.

Fixes https://github.com/dart-lang/dartdoc/issues/3939

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
