### PR TITLE
Reduce use of generators in finding files to document

### DIFF
--- a/lib/src/model/package_builder.dart
+++ b/lib/src/model/package_builder.dart
@@ -222,13 +222,8 @@ class PubPackageBuilder implements PackageBuilder {
   /// Uses [processedLibraries] to prevent calling [addLibrary] more than once
   /// with the same [LibraryElement]. Adds each [LibraryElement] found to
   /// [processedLibraries].
-  ///
-  /// [addingSpecials] indicates that only [SpecialClass]es are being resolved
-  /// in this round.
-  Future<void> _discoverLibraries(
-      void Function(DartDocResolvedLibrary) addLibrary,
-      Set<LibraryElement> processedLibraries,
-      Set<String> files) async {
+  Future<void> _discoverLibraries(PackageGraph uninitializedPackageGraph,
+      Set<LibraryElement> processedLibraries, Set<String> files) async {
     files = {...files};
     // Discover Dart libraries in a loop. In each iteration of the loop, we take
     // a set of files (starting with the ones passed into the function), resolve
@@ -283,7 +278,7 @@ class PubPackageBuilder implements PackageBuilder {
         if (processedLibraries.contains(resolvedLibrary.element)) {
           continue;
         }
-        addLibrary(resolvedLibrary);
+        uninitializedPackageGraph.addLibraryToGraph(resolvedLibrary);
         processedLibraries.add(resolvedLibrary.element);
       }
       files.addAll(newFiles);
@@ -300,17 +295,13 @@ class PubPackageBuilder implements PackageBuilder {
       // (so we can generate the right hyperlinks), it's vital that we add all
       // libraries in dependent packages. So if the analyzer discovers some
       // files in a package we haven't seen yet, add files for that package.
-      for (var meta in packages.difference(knownPackages)) {
-        if (meta.isSdk) {
+      for (var packageMeta in packages.difference(knownPackages)) {
+        if (packageMeta.isSdk) {
           if (!_skipUnreachableSdkLibraries) {
             files.addAll(_sdkFilesToDocument);
           }
         } else {
-          files.addAll(await _findFilesToDocumentInPackage(
-            meta.dir.path,
-            includeDependencies: false,
-            filterExcludes: false,
-          ).toList());
+          files.addAll(_findFilesToDocumentInPackage({packageMeta.dir.path}));
         }
       }
       knownPackages.addAll(packages);
@@ -320,40 +311,19 @@ class PubPackageBuilder implements PackageBuilder {
 
   /// Returns all top level library files in the 'lib/' directory of the given
   /// package root directory.
-  ///
-  /// If [includeDependencies], then all top level library files in the 'lib/'
-  /// directory of every package in [basePackageDir]'s package config are also
-  /// included.
-  Stream<String> _findFilesToDocumentInPackage(
-    String basePackageDir, {
-    required bool includeDependencies,
-    required bool filterExcludes,
-  }) async* {
-    var packageDirs = {basePackageDir};
-
-    if (includeDependencies) {
-      var packageConfig = (await _packageConfigProvider
-          .findPackageConfig(_resourceProvider.getFolder(basePackageDir)))!;
-      for (var package in packageConfig.packages) {
-        if (filterExcludes && _config.exclude.contains(package.name)) {
-          continue;
-        }
-        packageDirs.add(_pathContext.dirname(
-            _pathContext.fromUri(packageConfig[package.name]!.packageUriRoot)));
-      }
-    }
-
+  List<String> _findFilesToDocumentInPackage(Set<String> packageRoots) {
     var sep = _pathContext.separator;
     var packagesWithSeparators = '${sep}packages$sep';
-    for (var packageDir in packageDirs) {
-      var packageLibDir = _pathContext.join(packageDir, 'lib');
+    var filesToDocument = <String>[];
+    for (var packageRoot in packageRoots) {
+      var packageLibDir = _pathContext.join(packageRoot, 'lib');
       var packageLibSrcDir = _pathContext.join(packageLibDir, 'src');
       var packageDirContainsPackages =
-          packageDir.contains(packagesWithSeparators);
+          packageRoot.contains(packagesWithSeparators);
       // To avoid analyzing package files twice, only files with paths not
       // containing '/packages/' will be added. The only exception is if the
       // file to analyze already has a '/packages/' in its path.
-      for (var filePath in _listDir(packageDir, const {})) {
+      for (var filePath in _listDir(packageRoot, const {})) {
         if (!filePath.endsWith('.dart')) continue;
         if (!packageDirContainsPackages &&
             filePath.contains(packagesWithSeparators)) {
@@ -368,9 +338,10 @@ class PubPackageBuilder implements PackageBuilder {
           continue;
         }
 
-        yield filePath;
+        filesToDocument.add(filePath);
       }
     }
+    return filesToDocument;
   }
 
   /// Lists the files in [directory].
@@ -378,19 +349,20 @@ class PubPackageBuilder implements PackageBuilder {
   /// Excludes files and directories beginning with `.`.
   ///
   /// The returned paths are guaranteed to begin with [directory].
-  Iterable<String> _listDir(
-      String directory, Set<String> listedDirectories) sync* {
+  List<String> _listDir(String directory, Set<String> listedDirectories) {
     // Avoid recursive symlinks.
     var resolvedPath =
         _resourceProvider.getFolder(directory).resolveSymbolicLinksSync().path;
     if (listedDirectories.contains(resolvedPath)) {
-      return;
+      return const [];
     }
 
     listedDirectories = {
       ...listedDirectories,
       resolvedPath,
     };
+
+    var dirs = <String>[];
 
     for (var resource
         in _packageDirList(_resourceProvider.getFolder(directory))) {
@@ -400,13 +372,15 @@ class PubPackageBuilder implements PackageBuilder {
       }
 
       if (resource is File) {
-        yield resource.path;
+        dirs.add(resource.path);
         continue;
       }
       if (resource is Folder) {
-        yield* _listDir(resource.path, listedDirectories);
+        dirs.addAll(_listDir(resource.path, listedDirectories));
       }
     }
+
+    return dirs;
   }
 
   /// Calculates 'includeExternal' based on a list of files.
@@ -429,22 +403,45 @@ class PubPackageBuilder implements PackageBuilder {
   /// This takes into account the 'auto-include-dependencies' option, the
   /// 'exclude' option, and the 'include-external' option.
   Future<Set<String>> _getFilesToDocument() async {
-    var files = _config.topLevelPackageMeta.isSdk
-        ? _sdkFilesToDocument
-        : await _findFilesToDocumentInPackage(
-            _config.inputDir,
-            includeDependencies: _config.autoIncludeDependencies,
-            filterExcludes: true,
-          ).toList();
-    var externals = _includedExternalsFrom(files);
-    if (externals.isNotEmpty) {
-      includeExternalsWasSpecified = true;
+    if (_config.topLevelPackageMeta.isSdk) {
+      return _sdkFilesToDocument
+          .map((s) => _pathContext.absolute(_resourceProvider.getFile(s).path))
+          .toSet();
+    } else {
+      var packagesToDocument = await _findPackagesToDocument(
+        _config.inputDir,
+      );
+      var files = _findFilesToDocumentInPackage(packagesToDocument).toList();
+      var externals = _includedExternalsFrom(files);
+      if (externals.isNotEmpty) {
+        includeExternalsWasSpecified = true;
+        files = [...files, ...externals];
+      }
+      return {
+        ...files.map(
+            (s) => _pathContext.absolute(_resourceProvider.getFile(s).path)),
+        ..._embedderSdkFiles,
+      };
     }
-    files = [...files, ...externals];
+  }
+
+  /// Returns a set of package roots that are to be documented.
+  ///
+  /// If `_config.autoIncludeDependencies` is `true`, then every package in
+  /// [basePackageRoot]'s package config is included.
+  Future<Set<String>> _findPackagesToDocument(String basePackageRoot) async {
+    if (!_config.autoIncludeDependencies) {
+      return {basePackageRoot};
+    }
+
+    var packageConfig = (await _packageConfigProvider
+        .findPackageConfig(_resourceProvider.getFolder(basePackageRoot)))!;
     return {
-      ...files
-          .map((s) => _pathContext.absolute(_resourceProvider.getFile(s).path)),
-      ..._embedderSdkFiles,
+      basePackageRoot,
+      for (var package in packageConfig.packages)
+        if (!_config.exclude.contains(package.name))
+          _pathContext.dirname(_pathContext
+              .fromUri(packageConfig[package.name]!.packageUriRoot)),
     };
   }
 
@@ -472,7 +469,7 @@ class PubPackageBuilder implements PackageBuilder {
     logInfo('Discovering libraries...');
     var foundLibraries = <LibraryElement>{};
     await _discoverLibraries(
-      uninitializedPackageGraph.addLibraryToGraph,
+      uninitializedPackageGraph,
       foundLibraries,
       files,
     );


### PR DESCRIPTION
The short story of this change is that we're refactoring the "file-finding" code so that `_findFilesToDocumentInPackage` is no longer `async*`, and `_listDir` is no longer `sync*`. Lazy generators like these are nice when the full sequence of elements may not be generated. However, in this code, we definitely iterate over every element returned by these two functions, and `sync*` is known to be slow, and a package set may be thousands of files.

The longer story has more details:

* `findFilesToDocumentInPackage` was async because of the code that finds a package config, and that code is only needed when the `includeDependencies` parameter is `true`. The function only has two callers, one of which always passed `includeDependencies: false`.
  * So we can extract out the code that looks for a package config, and iterates over the listed packages, into a new function, `_findPackagesToDocument`, only called by `_getFilesToDocument`. Now `_findFilesToDocumentInPackage` doesn't need to be async, or a generator.
* Further efficiencies are found in `getFilesToDocument`: This function can actually be split into two cases: are we documenting the SDK, or not?
  * If documenting the SDK, we don't need to consider the `auto-include-dependencies` flag, as it is never used when documenting the SDK. We also don't need to consider the deprecated `include-externals` flag, as it is also never used when documenting the SDK. So we return a very simple calculation in this case. When documenting the SDK, the code is now simpler and does less work.
  * We can then isolate all of the complexity in the "not documenting the SDK" case, taking into account these two flags, and the embedder SDK files.
* Now that `_discoverLibraries` is only called once, we don't need to pass in the `addLibrary` callback. Instead, `_discoverLibraries` can directly call `uninitializedPackageGraph.addLibraryToGraph`.

I benchmarked this both documenting the SDK and googleapis package. There was no visible difference in time-to-document or memory usage when documenting the SDK. For the googleapis package, there was a -1% time-to-document, and -0.5% memory usage, which might well be within the error margins. 🤷 

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
