### PR TITLE
Fix the check for the expected number of categorized libraries in Dart SDK

### DIFF
--- a/tool/task.dart
+++ b/tool/task.dart
@@ -937,7 +937,7 @@ Not all files are formatted:
 Future<void> validateSdkDocs() async {
   await docSdk();
   const expectedLibCount = 0;
-  const expectedSubLibCount = 13;
+  const expectedSubLibCount = 20;
   const expectedTotalCount = 20;
   var indexHtml = File(path.join(_sdkDocsDir.path, 'index.html'));
   if (!indexHtml.existsSync()) {
@@ -953,8 +953,9 @@ Future<void> validateSdkDocs() async {
   }
   print("Found $foundLibCount 'dart:' entries in 'index.html'");
 
-  var foundSubLibCount =
-      _findCount(indexContents, '<li class="section-subitem"><a href="dart-');
+  var libLinkPattern =
+      RegExp('<li class="section-subitem"><a [^>]*href="dart-');
+  var foundSubLibCount = _findCount(indexContents, libLinkPattern);
   if (expectedSubLibCount != foundSubLibCount) {
     throw StateError("Expected $expectedSubLibCount 'dart:' entries in "
         "'index.html' to be in categories, but found $foundSubLibCount");
@@ -987,12 +988,12 @@ final Directory _sdkDocsDir =
     Directory.systemTemp.createTempSync('sdkdocs').absolute;
 
 /// Returns the number of (perhaps overlapping) occurrences of [str] in [match].
-int _findCount(String str, String match) {
+int _findCount(String str, Pattern match) {
   var count = 0;
   var index = str.indexOf(match);
   while (index != -1) {
     count++;
-    index = str.indexOf(match, index + match.length);
+    index = str.indexOf(match, index + 1);
   }
   return count;
 }

--- a/tool/task.dart
+++ b/tool/task.dart
@@ -937,8 +937,8 @@ Not all files are formatted:
 Future<void> validateSdkDocs() async {
   await docSdk();
   const expectedLibCount = 0;
-  const expectedSubLibCounts = {19, 20, 21};
-  const expectedTotalCounts = {19, 20, 21};
+  const expectedSubLibCount = 13;
+  const expectedTotalCount = 20;
   var indexHtml = File(path.join(_sdkDocsDir.path, 'index.html'));
   if (!indexHtml.existsSync()) {
     throw StateError("No 'index.html' found for the SDK docs");
@@ -955,8 +955,8 @@ Future<void> validateSdkDocs() async {
 
   var foundSubLibCount =
       _findCount(indexContents, '<li class="section-subitem"><a href="dart-');
-  if (!expectedSubLibCounts.contains(foundSubLibCount)) {
-    throw StateError("Expected $expectedSubLibCounts 'dart:' entries in "
+  if (expectedSubLibCount != foundSubLibCount) {
+    throw StateError("Expected $expectedSubLibCount 'dart:' entries in "
         "'index.html' to be in categories, but found $foundSubLibCount");
   }
   print('$foundSubLibCount index.html dart: entries in categories found');
@@ -965,11 +965,11 @@ Future<void> validateSdkDocs() async {
   var libraries =
       _sdkDocsDir.listSync().where((fs) => fs.path.contains('dart-'));
   var libraryCount = libraries.length;
-  if (!expectedTotalCounts.contains(libraryCount)) {
+  if (expectedTotalCount != libraryCount) {
     var libraryNames =
         libraries.map((l) => "'${path.basename(l.path)}'").join(', ');
     throw StateError('Unexpected docs generated for SDK libraries; expected '
-        '$expectedTotalCounts directories, but $libraryCount directories were '
+        '$expectedTotalCount directories, but $libraryCount directories were '
         'generated: $libraryNames');
   }
   print("Found $libraryCount 'dart:' libraries");


### PR DESCRIPTION
Recently many libraries were deprecated, and the HTML changed sufficiently to break our sanity check that we generate _anything_ when we generate the SDK docs.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
