### PR TITLE
Elements. Migrate package_meta.dart, annotations.dart

### DIFF
--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -13199,6 +13199,34 @@ class _Renderer_Library extends RendererBase<Library> {
                   );
                 },
               ),
+              'element2': Property(
+                getValue: (CT_ c) => c.element2,
+                renderVariable:
+                    (CT_ c, Property<CT_> self, List<String> remainingNames) =>
+                        self.renderSimpleVariable(
+                          c,
+                          remainingNames,
+                          'LibraryElement2',
+                        ),
+
+                isNullValue: (CT_ c) => false,
+
+                renderValue: (
+                  CT_ c,
+                  RendererBase<CT_> r,
+                  List<MustachioNode> ast,
+                  StringSink sink,
+                ) {
+                  renderSimple(
+                    c.element2,
+                    ast,
+                    r.template,
+                    sink,
+                    parent: r,
+                    getters: _invisibleGetters['LibraryElement2']!,
+                  );
+                },
+              ),
               'enclosingElement': Property(
                 getValue: (CT_ c) => c.enclosingElement,
                 renderVariable: (
@@ -14084,7 +14112,7 @@ class _Renderer_LibraryContainer extends RendererBase<LibraryContainer> {
   }
 }
 
-String renderLibrary(LibraryTemplateData context, Template template) {
+String renderLibraryRedirect(LibraryTemplateData context, Template template) {
   var buffer = StringBuffer();
   _render_LibraryTemplateData(context, template.ast, template, buffer);
   return buffer.toString();
@@ -14330,7 +14358,7 @@ class _Renderer_LibraryTemplateData extends RendererBase<LibraryTemplateData> {
   }
 }
 
-String renderLibraryRedirect(LibraryTemplateData context, Template template) {
+String renderLibrary(LibraryTemplateData context, Template template) {
   var buffer = StringBuffer();
   _render_LibraryTemplateData(context, template.ast, template, buffer);
   return buffer.toString();
@@ -26051,6 +26079,36 @@ const _invisibleGetters = {
     'runtimeType',
     'topLevelElements',
     'units',
+  },
+  'LibraryElement2': {
+    'classes',
+    'entryPoint2',
+    'enums',
+    'exportNamespace',
+    'exportedLibraries2',
+    'extensionTypes',
+    'extensions',
+    'featureSet',
+    'firstFragment',
+    'fragments',
+    'functions',
+    'getters',
+    'hashCode',
+    'identifier',
+    'isDartAsync',
+    'isDartCore',
+    'isInSdk',
+    'languageVersion',
+    'library2',
+    'loadLibraryFunction2',
+    'mixins',
+    'publicNamespace',
+    'runtimeType',
+    'setters',
+    'topLevelVariables',
+    'typeAliases',
+    'typeProvider',
+    'typeSystem',
   },
   'List': {'hashCode', 'length', 'reversed', 'runtimeType'},
   'Locatable': {

--- a/lib/src/model/library.dart
+++ b/lib/src/model/library.dart
@@ -6,8 +6,11 @@
 
 import 'package:analyzer/dart/analysis/features.dart';
 import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/dart/element/scope.dart';
 import 'package:analyzer/source/line_info.dart';
+// ignore: implementation_imports
+import 'package:analyzer/src/dart/element/element.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
 import 'package:dartdoc/src/model/kind.dart';
 import 'package:dartdoc/src/model/model.dart';
@@ -24,6 +27,8 @@ class Library extends ModelElement
     with Categorization, TopLevelContainer, CanonicalFor {
   @override
   final LibraryElement element;
+
+   LibraryElement2 get element2 => element as LibraryElementImpl;
 
   /// The set of [Element]s declared directly in this library.
   final Set<Element> _localElements;
@@ -309,7 +314,7 @@ class Library extends ModelElement
 
   /// The real packageMeta, as opposed to the package we are documenting with.
   late final PackageMeta? packageMeta =
-      packageGraph.packageMetaProvider.fromElement(element, config.sdkDir);
+      packageGraph.packageMetaProvider.fromElement(element2, config.sdkDir);
 
   late final List<Class> classesAndExceptions = [
     ..._localElementsOfType<ClassElement, Class>(),

--- a/lib/src/model/package_builder.dart
+++ b/lib/src/model/package_builder.dart
@@ -11,12 +11,15 @@ import 'package:analyzer/dart/analysis/context_root.dart';
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/file_system/file_system.dart';
 // ignore: implementation_imports
 import 'package:analyzer/src/context/builder.dart' show EmbedderYamlLocator;
 // ignore: implementation_imports
 import 'package:analyzer/src/dart/analysis/analysis_context_collection.dart'
     show AnalysisContextCollectionImpl;
+// ignore: implementation_imports
+import 'package:analyzer/src/dart/element/element.dart';
 // ignore: implementation_imports
 import 'package:analyzer/src/dart/sdk/sdk.dart'
     show EmbedderSdk, FolderBasedDartSdk;
@@ -520,6 +523,7 @@ class PubPackageBuilder implements PackageBuilder {
 /// the library.
 class DartDocResolvedLibrary {
   final LibraryElement element;
+  LibraryElement2 get element2 => element as LibraryElementImpl;
   final List<CompilationUnit> units;
 
   DartDocResolvedLibrary(ResolvedLibraryResult result)

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -94,11 +94,11 @@ class PackageGraph with CommentReferable, Nameable {
   /// span packages.
   void addLibraryToGraph(DartDocResolvedLibrary resolvedLibrary) {
     assert(!allLibrariesAdded);
-    var libraryElement = resolvedLibrary.element;
+    var libraryElement2 = resolvedLibrary.element2;
     var packageMeta =
-        packageMetaProvider.fromElement(libraryElement, config.sdkDir);
+        packageMetaProvider.fromElement(libraryElement2, config.sdkDir);
     if (packageMeta == null) {
-      var libraryPath = libraryElement.librarySource.fullName;
+      var libraryPath = libraryElement2.firstFragment.source.fullName;
       var dartOrFlutter = config.flutterRoot == null ? 'dart' : 'flutter';
       throw DartdocFailure(
           "Unknown package for library: '$libraryPath'.  Consider "
@@ -109,10 +109,10 @@ class PackageGraph with CommentReferable, Nameable {
     }
     var package = Package.fromPackageMeta(packageMeta, this);
     var library = Library.fromLibraryResult(resolvedLibrary, this, package);
-    if (_shouldIncludeLibrary(libraryElement)) {
+    if (_shouldIncludeLibrary(resolvedLibrary.element)) {
       package.libraries.add(library);
     }
-    _allLibraries[libraryElement.source.fullName] = library;
+    _allLibraries[libraryElement2.firstFragment.source.fullName] = library;
   }
 
   /// Whether [libraryElement] should be included in the libraries-to-document.

--- a/lib/src/mustachio/annotations.dart
+++ b/lib/src/mustachio/annotations.dart
@@ -2,12 +2,10 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: analyzer_use_new_elements
-
 // See the Mustachio README at tool/mustachio/README.md for high-level
 // documentation.
 
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:meta/meta.dart';
 
@@ -91,5 +89,5 @@ class RendererSpec {
     this.standardHtmlTemplate,
   );
 
-  InterfaceElement get contextElement => contextType.element;
+  InterfaceElement2 get contextElement => contextType.element3;
 }

--- a/lib/src/package_meta.dart
+++ b/lib/src/package_meta.dart
@@ -2,11 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: analyzer_use_new_elements
-
 import 'dart:io' show Platform;
 
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/file_system/file_system.dart';
 import 'package:analyzer/file_system/physical_file_system.dart';
 // ignore: implementation_imports
@@ -51,13 +49,13 @@ final PackageMetaProvider pubPackageMetaProvider = PackageMetaProvider(
 /// Sets the supported way of constructing [PackageMeta] objects.
 ///
 /// These objects can be constructed from a filename, a directory
-/// or a [LibraryElement]. We allow different dartdoc implementations to
+/// or a [LibraryElement2]. We allow different dartdoc implementations to
 /// provide their own [PackageMeta] types.
 ///
 /// By using a different provider, these implementations can control how
 /// [PackageMeta] objects are built.
 class PackageMetaProvider {
-  final PackageMeta? Function(LibraryElement, String, ResourceProvider)
+  final PackageMeta? Function(LibraryElement2, String, ResourceProvider)
       _fromElement;
   final PackageMeta? Function(String, ResourceProvider) _fromFilename;
   final PackageMeta? Function(Folder, ResourceProvider) _fromDir;
@@ -77,7 +75,7 @@ class PackageMetaProvider {
     this.defaultSdk,
   });
 
-  PackageMeta? fromElement(LibraryElement library, String s) =>
+  PackageMeta? fromElement(LibraryElement2 library, String s) =>
       _fromElement(library, s, resourceProvider);
   PackageMeta? fromFilename(String s) => _fromFilename(s, resourceProvider);
   PackageMeta? fromDir(Folder dir) => _fromDir(dir, resourceProvider);
@@ -185,7 +183,7 @@ abstract class PubPackageMeta extends PackageMeta {
   }
 
   /// Use this instead of [fromDir] where possible.
-  static PackageMeta? fromElement(LibraryElement libraryElement, String sdkDir,
+  static PackageMeta? fromElement(LibraryElement2 libraryElement, String sdkDir,
       ResourceProvider resourceProvider) {
     if (libraryElement.isInSdk) {
       return PubPackageMeta.fromDir(
@@ -194,7 +192,7 @@ abstract class PubPackageMeta extends PackageMeta {
     return PubPackageMeta.fromDir(
         resourceProvider
             .getFile(resourceProvider.pathContext
-                .canonicalize(libraryElement.source.fullName))
+                .canonicalize(libraryElement.firstFragment.source.fullName))
             .parent,
         resourceProvider);
   }

--- a/tool/mustachio/codegen_runtime_renderer.dart
+++ b/tool/mustachio/codegen_runtime_renderer.dart
@@ -14,6 +14,8 @@ import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:analyzer/dart/element/type_provider.dart';
 import 'package:analyzer/dart/element/type_system.dart';
+// ignore: implementation_imports
+import 'package:analyzer/src/utilities/extensions/element.dart';
 import 'package:dart_style/dart_style.dart';
 import 'package:dartdoc/src/mustachio/annotations.dart';
 import 'package:dartdoc/src/type_utils.dart';
@@ -129,7 +131,7 @@ import '${path.basename(_sourceUri.path)}';
   /// Adds type specified in [spec] to the [_typesToProcess] queue, as well as
   /// all supertypes, and the types of all valid getters, recursively.
   void _addTypesForRendererSpec(RendererSpec spec) {
-    var element = spec.contextElement;
+    var element = spec.contextElement.asElement as InterfaceElement;
     var rendererInfo = _RendererInfo(element,
         public: _rendererClassesArePublic, publicApiFunctionName: spec.name);
     _typesToProcess.add(rendererInfo);


### PR DESCRIPTION

Element model migration. Migrate

- lib/src/package_meta.dart
- lib/src/mustachio/annotations.dart



