### PR TITLE
Elements. Migrate lib/src/model/model_element.dart

### DIFF
--- a/lib/src/element_type.dart
+++ b/lib/src/element_type.dart
@@ -214,7 +214,7 @@ mixin Aliased implements ElementType {
   bool get isTypedef => true;
 
   late final ModelElement aliasElement =
-      ModelElement.forElement2(typeAliasElement2, packageGraph);
+      ModelElement.forElement(typeAliasElement2, packageGraph);
 
   late final List<ElementType> aliasArguments = type.alias!.typeArguments
       .map((f) => getTypeFor(f, library))
@@ -322,7 +322,7 @@ abstract class DefinedElementType extends ElementType {
   @internal
   @override
   CommentReferable get definingCommentReferable =>
-      ModelElement.forElement2(modelElement.element2, packageGraph);
+      ModelElement.forElement(modelElement.element2, packageGraph);
 }
 
 /// Any callable [ElementType] will mix-in this class, whether anonymous or not,

--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -3505,6 +3505,34 @@ class _Renderer_Constructor extends RendererBase<Constructor> {
                   );
                 },
               ),
+              'element2': Property(
+                getValue: (CT_ c) => c.element2,
+                renderVariable:
+                    (CT_ c, Property<CT_> self, List<String> remainingNames) =>
+                        self.renderSimpleVariable(
+                          c,
+                          remainingNames,
+                          'ConstructorElement2',
+                        ),
+
+                isNullValue: (CT_ c) => false,
+
+                renderValue: (
+                  CT_ c,
+                  RendererBase<CT_> r,
+                  List<MustachioNode> ast,
+                  StringSink sink,
+                ) {
+                  renderSimple(
+                    c.element2,
+                    ast,
+                    r.template,
+                    sink,
+                    parent: r,
+                    getters: _invisibleGetters['ConstructorElement2']!,
+                  );
+                },
+              ),
               'enclosingElement': Property(
                 getValue: (CT_ c) => c.enclosingElement,
                 renderVariable: (
@@ -13345,34 +13373,6 @@ class _Renderer_Library extends RendererBase<Library> {
                   );
                 },
               ),
-              'compilationUnitElement': Property(
-                getValue: (CT_ c) => c.compilationUnitElement,
-                renderVariable:
-                    (CT_ c, Property<CT_> self, List<String> remainingNames) =>
-                        self.renderSimpleVariable(
-                          c,
-                          remainingNames,
-                          'CompilationUnitElement',
-                        ),
-
-                isNullValue: (CT_ c) => false,
-
-                renderValue: (
-                  CT_ c,
-                  RendererBase<CT_> r,
-                  List<MustachioNode> ast,
-                  StringSink sink,
-                ) {
-                  renderSimple(
-                    c.compilationUnitElement,
-                    ast,
-                    r.template,
-                    sink,
-                    parent: r,
-                    getters: _invisibleGetters['CompilationUnitElement']!,
-                  );
-                },
-              ),
               'constants': Property(
                 getValue: (CT_ c) => c.constants,
                 renderVariable:
@@ -14212,6 +14212,34 @@ class _Renderer_Library extends RendererBase<Library> {
                   );
                 },
               ),
+              'unitElement': Property(
+                getValue: (CT_ c) => c.unitElement,
+                renderVariable:
+                    (CT_ c, Property<CT_> self, List<String> remainingNames) =>
+                        self.renderSimpleVariable(
+                          c,
+                          remainingNames,
+                          'LibraryFragment',
+                        ),
+
+                isNullValue: (CT_ c) => false,
+
+                renderValue: (
+                  CT_ c,
+                  RendererBase<CT_> r,
+                  List<MustachioNode> ast,
+                  StringSink sink,
+                ) {
+                  renderSimple(
+                    c.unitElement,
+                    ast,
+                    r.template,
+                    sink,
+                    parent: r,
+                    getters: _invisibleGetters['LibraryFragment']!,
+                  );
+                },
+              ),
             },
           )
           as Map<String, Property<CT_>>;
@@ -14411,7 +14439,7 @@ class _Renderer_LibraryContainer extends RendererBase<LibraryContainer> {
   }
 }
 
-String renderLibrary(LibraryTemplateData context, Template template) {
+String renderLibraryRedirect(LibraryTemplateData context, Template template) {
   var buffer = StringBuffer();
   _render_LibraryTemplateData(context, template.ast, template, buffer);
   return buffer.toString();
@@ -14657,7 +14685,7 @@ class _Renderer_LibraryTemplateData extends RendererBase<LibraryTemplateData> {
   }
 }
 
-String renderLibraryRedirect(LibraryTemplateData context, Template template) {
+String renderLibrary(LibraryTemplateData context, Template template) {
   var buffer = StringBuffer();
   _render_LibraryTemplateData(context, template.ast, template, buffer);
   return buffer.toString();
@@ -16856,34 +16884,6 @@ class _Renderer_ModelElement extends RendererBase<ModelElement> {
                   );
                 },
               ),
-              'compilationUnitElement': Property(
-                getValue: (CT_ c) => c.compilationUnitElement,
-                renderVariable:
-                    (CT_ c, Property<CT_> self, List<String> remainingNames) =>
-                        self.renderSimpleVariable(
-                          c,
-                          remainingNames,
-                          'CompilationUnitElement',
-                        ),
-
-                isNullValue: (CT_ c) => false,
-
-                renderValue: (
-                  CT_ c,
-                  RendererBase<CT_> r,
-                  List<MustachioNode> ast,
-                  StringSink sink,
-                ) {
-                  renderSimple(
-                    c.compilationUnitElement,
-                    ast,
-                    r.template,
-                    sink,
-                    parent: r,
-                    getters: _invisibleGetters['CompilationUnitElement']!,
-                  );
-                },
-              ),
               'config': Property(
                 getValue: (CT_ c) => c.config,
                 renderVariable:
@@ -18010,6 +18010,34 @@ class _Renderer_ModelElement extends RendererBase<ModelElement> {
                     r.template,
                     sink,
                     parent: r,
+                  );
+                },
+              ),
+              'unitElement': Property(
+                getValue: (CT_ c) => c.unitElement,
+                renderVariable:
+                    (CT_ c, Property<CT_> self, List<String> remainingNames) =>
+                        self.renderSimpleVariable(
+                          c,
+                          remainingNames,
+                          'LibraryFragment',
+                        ),
+
+                isNullValue: (CT_ c) => false,
+
+                renderValue: (
+                  CT_ c,
+                  RendererBase<CT_> r,
+                  List<MustachioNode> ast,
+                  StringSink sink,
+                ) {
+                  renderSimple(
+                    c.unitElement,
+                    ast,
+                    r.template,
+                    sink,
+                    parent: r,
+                    getters: _invisibleGetters['LibraryFragment']!,
                   );
                 },
               ),
@@ -20353,7 +20381,7 @@ class _Renderer_Package extends RendererBase<Package> {
   }
 }
 
-String renderError(PackageTemplateData context, Template template) {
+String renderIndex(PackageTemplateData context, Template template) {
   var buffer = StringBuffer();
   _render_PackageTemplateData(context, template.ast, template, buffer);
   return buffer.toString();
@@ -20710,13 +20738,13 @@ class _Renderer_PackageTemplateData extends RendererBase<PackageTemplateData> {
   }
 }
 
-String renderSearchPage(PackageTemplateData context, Template template) {
+String renderError(PackageTemplateData context, Template template) {
   var buffer = StringBuffer();
   _render_PackageTemplateData(context, template.ast, template, buffer);
   return buffer.toString();
 }
 
-String renderIndex(PackageTemplateData context, Template template) {
+String renderSearchPage(PackageTemplateData context, Template template) {
   var buffer = StringBuffer();
   _render_PackageTemplateData(context, template.ast, template, buffer);
   return buffer.toString();
@@ -26196,28 +26224,6 @@ const _invisibleGetters = {
     'referenceParents',
     'scope',
   },
-  'CompilationUnitElement': {
-    'accessibleExtensions',
-    'accessors',
-    'classes',
-    'enclosingElement3',
-    'enums',
-    'extensionTypes',
-    'extensions',
-    'functions',
-    'hashCode',
-    'libraryExports',
-    'libraryImportPrefixes',
-    'libraryImports',
-    'lineInfo',
-    'mixins',
-    'parts',
-    'runtimeType',
-    'scope',
-    'session',
-    'topLevelVariables',
-    'typeAliases',
-  },
   'Constructable': {
     'constructors',
     'extraReferenceChildren',
@@ -26242,6 +26248,22 @@ const _invisibleGetters = {
     'returnType',
     'runtimeType',
     'superConstructor',
+  },
+  'ConstructorElement2': {
+    'baseElement',
+    'enclosingElement2',
+    'firstFragment',
+    'fragments',
+    'hashCode',
+    'isConst',
+    'isDefaultConstructor',
+    'isFactory',
+    'isGenerative',
+    'name3',
+    'redirectedConstructor2',
+    'returnType',
+    'runtimeType',
+    'superConstructor2',
   },
   'ContainerModifier': {
     'displayName',
@@ -26760,6 +26782,33 @@ const _invisibleGetters = {
     'typeProvider',
     'typeSystem',
     'uri',
+  },
+  'LibraryFragment': {
+    'accessibleExtensions2',
+    'classes2',
+    'element',
+    'enclosingFragment',
+    'enums2',
+    'extensionTypes2',
+    'extensions2',
+    'functions2',
+    'getters',
+    'hashCode',
+    'importedLibraries2',
+    'libraryExports2',
+    'libraryImports2',
+    'lineInfo',
+    'mixins2',
+    'nextFragment',
+    'partIncludes',
+    'prefixes',
+    'previousFragment',
+    'runtimeType',
+    'scope',
+    'setters',
+    'source',
+    'topLevelVariables2',
+    'typeAliases2',
   },
   'List': {'hashCode', 'length', 'reversed', 'runtimeType'},
   'Locatable': {

--- a/lib/src/model/canonicalization.dart
+++ b/lib/src/model/canonicalization.dart
@@ -58,7 +58,7 @@ Library? canonicalLibraryCandidate(ModelElement modelElement) {
   }
 
   var topLevelModelElement =
-      ModelElement.forElement2(topLevelElement, modelElement.packageGraph);
+      ModelElement.forElement(topLevelElement, modelElement.packageGraph);
 
   return _Canonicalization(topLevelModelElement)
       .canonicalLibraryCandidate(candidateLibraries);

--- a/lib/src/model/constructor.dart
+++ b/lib/src/model/constructor.dart
@@ -5,7 +5,10 @@
 // ignore_for_file: analyzer_use_new_elements
 
 import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/source/line_info.dart';
+// ignore: implementation_imports
+import 'package:analyzer/src/utilities/extensions/element.dart';
 import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
 import 'package:dartdoc/src/model/kind.dart';
@@ -14,9 +17,12 @@ import 'package:dartdoc/src/model_utils.dart';
 
 class Constructor extends ModelElement with ContainerMember, TypeParameters {
   @override
-  final ConstructorElement element;
+   ConstructorElement get element => element2.asElement;
 
-  Constructor(this.element, super.library, super.packageGraph);
+  @override
+  final ConstructorElement2 element2;
+
+  Constructor(this.element2, super.library, super.packageGraph);
 
   @override
   CharacterLocation? get characterLocation {

--- a/lib/src/model/extension.dart
+++ b/lib/src/model/extension.dart
@@ -110,12 +110,12 @@ class Extension extends Container {
     ContainerAccessor? getter, setter;
     final fieldGetter = field.getter2;
     if (fieldGetter != null) {
-      getter = ModelElement.for2_(fieldGetter, library, packageGraph,
+      getter = ModelElement.for_(fieldGetter, library, packageGraph,
           enclosingContainer: this) as ContainerAccessor;
     }
     final fieldSetter = field.setter2;
     if (fieldSetter != null) {
-      setter = ModelElement.for2_(fieldSetter, library, packageGraph,
+      setter = ModelElement.for_(fieldSetter, library, packageGraph,
           enclosingContainer: this) as ContainerAccessor;
     }
     return getModelForPropertyInducingElement(field.asElement, library,

--- a/lib/src/model/extension_type.dart
+++ b/lib/src/model/extension_type.dart
@@ -16,16 +16,15 @@ import 'package:meta/meta.dart';
 
 class ExtensionType extends InheritingContainer with Constructable {
   @override
-  final ExtensionTypeElement element;
+  ExtensionTypeElement get element => element2.asElement;
 
   @override
-  ExtensionTypeElement2 get element2 =>
-      element.asElement2 as ExtensionTypeElement2;
+  final ExtensionTypeElement2  element2;
 
   late final ElementType representationType =
       getTypeFor(element.representation.type, library);
 
-  ExtensionType(this.element, super.library, super.packageGraph);
+  ExtensionType(this.element2, super.library, super.packageGraph);
 
   @override
   Library get enclosingElement => library;

--- a/lib/src/model/field.dart
+++ b/lib/src/model/field.dart
@@ -42,7 +42,7 @@ class Field extends ModelElement
     this.setter,
   )   : isInherited = false,
         enclosingElement =
-            ModelElement.for_(element.enclosingElement3, library, packageGraph)
+            ModelElement.for_(element.asElement2.enclosingElement2, library, packageGraph)
                 as Container,
         assert(getter != null || setter != null) {
     getter?.enclosingCombo = this;
@@ -58,7 +58,7 @@ class Field extends ModelElement
   )   : element = element2.asElement as FieldElement,
         isInherited = false,
         enclosingElement =
-            ModelElement.for2_(element2.enclosingElement2!, library, packageGraph)
+            ModelElement.for_(element2.enclosingElement2!, library, packageGraph)
                 as Container,
         assert(getter != null || setter != null) {
     getter?.enclosingCombo = this;
@@ -66,26 +66,28 @@ class Field extends ModelElement
   }
 
   Field.providedByExtension(
-    this.element,
+    Element2 element2,
     this.enclosingElement,
     super.library,
     super.packageGraph,
     this.getter,
     this.setter,
-  )   : isInherited = false,
+  )   : element = element2.asElement as FieldElement,
+        isInherited = false,
         assert(getter != null || setter != null) {
     getter?.enclosingCombo = this;
     setter?.enclosingCombo = this;
   }
 
   Field.inherited(
-    this.element,
+    Element2 element2,
     this.enclosingElement,
     super.library,
     super.packageGraph,
     this.getter,
     this.setter,
-  )   : isInherited = true,
+  )   : element = element2.asElement as FieldElement,
+        isInherited = true,
         assert(getter != null || setter != null) {
     // Can't set `isInherited` to true if this is the defining element, because
     // that would mean it isn't inherited.

--- a/lib/src/model/library.dart
+++ b/lib/src/model/library.dart
@@ -120,8 +120,8 @@ class Library extends ModelElement
   }
 
   @override
-  CompilationUnitElement get compilationUnitElement =>
-      element.definingCompilationUnit;
+  LibraryFragment get unitElement =>
+      element2.library2.firstFragment;
 
   @override
 

--- a/lib/src/model/nameable.dart
+++ b/lib/src/model/nameable.dart
@@ -63,7 +63,7 @@ mixin Nameable {
     Container? enclosingContainer,
   }) =>
       ModelElement.for_(
-        element,
+        element.asElement2!,
         library,
         packageGraph,
         enclosingContainer: enclosingContainer,
@@ -78,7 +78,7 @@ mixin Nameable {
     Container? enclosingContainer,
   }) =>
       ModelElement.for_(
-        element.asElement!,
+        element,
         library,
         packageGraph,
         enclosingContainer: enclosingContainer,
@@ -89,14 +89,14 @@ mixin Nameable {
   /// A convenience method for [ModelElement.forElement], see its
   /// documentation.
   ModelElement getModelForElement(Element element) =>
-      ModelElement.forElement(element, packageGraph);
+      ModelElement.forElement(element.asElement2!, packageGraph);
 
   /// Returns the [ModelElement] for [element], instantiating it if needed.
   ///
   /// A convenience method for [ModelElement.forElement], see its
   /// documentation.
   ModelElement getModelForElement2(Element2 element) =>
-      ModelElement.forElement(element.asElement!, packageGraph);
+      ModelElement.forElement(element, packageGraph);
 
   /// Returns the [ModelElement] for [element], instantiating it if needed.
   ///
@@ -113,7 +113,7 @@ mixin Nameable {
     Container? enclosingContainer,
   }) =>
       ModelElement.forPropertyInducingElement(
-        element,
+        element.asElement2 as PropertyInducingElement2,
         library,
         packageGraph,
         getter: getter,
@@ -136,7 +136,7 @@ mixin Nameable {
     Container? enclosingContainer,
   }) =>
       ModelElement.forPropertyInducingElement(
-        element.asElement as PropertyInducingElement,
+        element,
         library,
         packageGraph,
         getter: getter,


### PR DESCRIPTION
Will do a follow up CL to remove `element` from `ModelElement` and it's hierarchy.
