### PR TITLE
Elements. Remove 'element' from ModelElement

### DIFF
--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -221,34 +221,6 @@ class _Renderer_Accessor extends RendererBase<Accessor> {
                   );
                 },
               ),
-              'element': Property(
-                getValue: (CT_ c) => c.element,
-                renderVariable:
-                    (CT_ c, Property<CT_> self, List<String> remainingNames) =>
-                        self.renderSimpleVariable(
-                          c,
-                          remainingNames,
-                          'PropertyAccessorElement',
-                        ),
-
-                isNullValue: (CT_ c) => false,
-
-                renderValue: (
-                  CT_ c,
-                  RendererBase<CT_> r,
-                  List<MustachioNode> ast,
-                  StringSink sink,
-                ) {
-                  renderSimple(
-                    c.element,
-                    ast,
-                    r.template,
-                    sink,
-                    parent: r,
-                    getters: _invisibleGetters['PropertyAccessorElement']!,
-                  );
-                },
-              ),
               'element2': Property(
                 getValue: (CT_ c) => c.element2,
                 renderVariable:
@@ -1699,30 +1671,6 @@ class _Renderer_Category extends RendererBase<Category> {
                   );
                 },
               ),
-              'element': Property(
-                getValue: (CT_ c) => c.element,
-                renderVariable:
-                    (CT_ c, Property<CT_> self, List<String> remainingNames) =>
-                        self.renderSimpleVariable(c, remainingNames, 'Element'),
-
-                isNullValue: (CT_ c) => c.element == null,
-
-                renderValue: (
-                  CT_ c,
-                  RendererBase<CT_> r,
-                  List<MustachioNode> ast,
-                  StringSink sink,
-                ) {
-                  renderSimple(
-                    c.element,
-                    ast,
-                    r.template,
-                    sink,
-                    parent: r,
-                    getters: _invisibleGetters['Element']!,
-                  );
-                },
-              ),
               'element2': Property(
                 getValue: (CT_ c) => c.element2,
                 renderVariable:
@@ -2651,34 +2599,6 @@ class _Renderer_Class extends RendererBase<Class> {
                   );
                 },
               ),
-              'element': Property(
-                getValue: (CT_ c) => c.element,
-                renderVariable:
-                    (CT_ c, Property<CT_> self, List<String> remainingNames) =>
-                        self.renderSimpleVariable(
-                          c,
-                          remainingNames,
-                          'ClassElement',
-                        ),
-
-                isNullValue: (CT_ c) => false,
-
-                renderValue: (
-                  CT_ c,
-                  RendererBase<CT_> r,
-                  List<MustachioNode> ast,
-                  StringSink sink,
-                ) {
-                  renderSimple(
-                    c.element,
-                    ast,
-                    r.template,
-                    sink,
-                    parent: r,
-                    getters: _invisibleGetters['ClassElement']!,
-                  );
-                },
-              ),
               'element2': Property(
                 getValue: (CT_ c) => c.element2,
                 renderVariable:
@@ -3474,34 +3394,6 @@ class _Renderer_Constructor extends RendererBase<Constructor> {
                     sink,
                     parent: r,
                     getters: _invisibleGetters['CharacterLocation']!,
-                  );
-                },
-              ),
-              'element': Property(
-                getValue: (CT_ c) => c.element,
-                renderVariable:
-                    (CT_ c, Property<CT_> self, List<String> remainingNames) =>
-                        self.renderSimpleVariable(
-                          c,
-                          remainingNames,
-                          'ConstructorElement',
-                        ),
-
-                isNullValue: (CT_ c) => false,
-
-                renderValue: (
-                  CT_ c,
-                  RendererBase<CT_> r,
-                  List<MustachioNode> ast,
-                  StringSink sink,
-                ) {
-                  renderSimple(
-                    c.element,
-                    ast,
-                    r.template,
-                    sink,
-                    parent: r,
-                    getters: _invisibleGetters['ConstructorElement']!,
                   );
                 },
               ),
@@ -4673,30 +4565,6 @@ class _Renderer_Container extends RendererBase<Container> {
                   return c.declaredOperators.map(
                     (e) =>
                         _render_Operator(e, ast, r.template, sink, parent: r),
-                  );
-                },
-              ),
-              'element': Property(
-                getValue: (CT_ c) => c.element,
-                renderVariable:
-                    (CT_ c, Property<CT_> self, List<String> remainingNames) =>
-                        self.renderSimpleVariable(c, remainingNames, 'Element'),
-
-                isNullValue: (CT_ c) => false,
-
-                renderValue: (
-                  CT_ c,
-                  RendererBase<CT_> r,
-                  List<MustachioNode> ast,
-                  StringSink sink,
-                ) {
-                  renderSimple(
-                    c.element,
-                    ast,
-                    r.template,
-                    sink,
-                    parent: r,
-                    getters: _invisibleGetters['Element']!,
                   );
                 },
               ),
@@ -7203,34 +7071,6 @@ class _Renderer_Enum extends RendererBase<Enum> {
                   );
                 },
               ),
-              'element': Property(
-                getValue: (CT_ c) => c.element,
-                renderVariable:
-                    (CT_ c, Property<CT_> self, List<String> remainingNames) =>
-                        self.renderSimpleVariable(
-                          c,
-                          remainingNames,
-                          'EnumElement',
-                        ),
-
-                isNullValue: (CT_ c) => false,
-
-                renderValue: (
-                  CT_ c,
-                  RendererBase<CT_> r,
-                  List<MustachioNode> ast,
-                  StringSink sink,
-                ) {
-                  renderSimple(
-                    c.element,
-                    ast,
-                    r.template,
-                    sink,
-                    parent: r,
-                    getters: _invisibleGetters['EnumElement']!,
-                  );
-                },
-              ),
               'element2': Property(
                 getValue: (CT_ c) => c.element2,
                 renderVariable:
@@ -7777,34 +7617,6 @@ class _Renderer_Extension extends RendererBase<Extension> {
                 ) {
                   return c.declaredMethods.map(
                     (e) => _render_Method(e, ast, r.template, sink, parent: r),
-                  );
-                },
-              ),
-              'element': Property(
-                getValue: (CT_ c) => c.element,
-                renderVariable:
-                    (CT_ c, Property<CT_> self, List<String> remainingNames) =>
-                        self.renderSimpleVariable(
-                          c,
-                          remainingNames,
-                          'ExtensionElement',
-                        ),
-
-                isNullValue: (CT_ c) => false,
-
-                renderValue: (
-                  CT_ c,
-                  RendererBase<CT_> r,
-                  List<MustachioNode> ast,
-                  StringSink sink,
-                ) {
-                  renderSimple(
-                    c.element,
-                    ast,
-                    r.template,
-                    sink,
-                    parent: r,
-                    getters: _invisibleGetters['ExtensionElement']!,
                   );
                 },
               ),
@@ -8536,34 +8348,6 @@ class _Renderer_ExtensionType extends RendererBase<ExtensionType> {
                 ) {
                   return c.declaredFields.map(
                     (e) => _render_Field(e, ast, r.template, sink, parent: r),
-                  );
-                },
-              ),
-              'element': Property(
-                getValue: (CT_ c) => c.element,
-                renderVariable:
-                    (CT_ c, Property<CT_> self, List<String> remainingNames) =>
-                        self.renderSimpleVariable(
-                          c,
-                          remainingNames,
-                          'ExtensionTypeElement',
-                        ),
-
-                isNullValue: (CT_ c) => false,
-
-                renderValue: (
-                  CT_ c,
-                  RendererBase<CT_> r,
-                  List<MustachioNode> ast,
-                  StringSink sink,
-                ) {
-                  renderSimple(
-                    c.element,
-                    ast,
-                    r.template,
-                    sink,
-                    parent: r,
-                    getters: _invisibleGetters['ExtensionTypeElement']!,
                   );
                 },
               ),
@@ -9675,34 +9459,6 @@ class _Renderer_Field extends RendererBase<Field> {
                     r.template,
                     sink,
                     parent: r,
-                  );
-                },
-              ),
-              'element': Property(
-                getValue: (CT_ c) => c.element,
-                renderVariable:
-                    (CT_ c, Property<CT_> self, List<String> remainingNames) =>
-                        self.renderSimpleVariable(
-                          c,
-                          remainingNames,
-                          'FieldElement',
-                        ),
-
-                isNullValue: (CT_ c) => false,
-
-                renderValue: (
-                  CT_ c,
-                  RendererBase<CT_> r,
-                  List<MustachioNode> ast,
-                  StringSink sink,
-                ) {
-                  renderSimple(
-                    c.element,
-                    ast,
-                    r.template,
-                    sink,
-                    parent: r,
-                    getters: _invisibleGetters['FieldElement']!,
                   );
                 },
               ),
@@ -11986,34 +11742,6 @@ class _Renderer_InheritingContainer extends RendererBase<InheritingContainer> {
                   );
                 },
               ),
-              'element': Property(
-                getValue: (CT_ c) => c.element,
-                renderVariable:
-                    (CT_ c, Property<CT_> self, List<String> remainingNames) =>
-                        self.renderSimpleVariable(
-                          c,
-                          remainingNames,
-                          'InterfaceElement',
-                        ),
-
-                isNullValue: (CT_ c) => false,
-
-                renderValue: (
-                  CT_ c,
-                  RendererBase<CT_> r,
-                  List<MustachioNode> ast,
-                  StringSink sink,
-                ) {
-                  renderSimple(
-                    c.element,
-                    ast,
-                    r.template,
-                    sink,
-                    parent: r,
-                    getters: _invisibleGetters['InterfaceElement']!,
-                  );
-                },
-              ),
               'element2': Property(
                 getValue: (CT_ c) => c.element2,
                 renderVariable:
@@ -13499,34 +13227,6 @@ class _Renderer_Library extends RendererBase<Library> {
                     r.template,
                     sink,
                     parent: r,
-                  );
-                },
-              ),
-              'element': Property(
-                getValue: (CT_ c) => c.element,
-                renderVariable:
-                    (CT_ c, Property<CT_> self, List<String> remainingNames) =>
-                        self.renderSimpleVariable(
-                          c,
-                          remainingNames,
-                          'LibraryElement',
-                        ),
-
-                isNullValue: (CT_ c) => false,
-
-                renderValue: (
-                  CT_ c,
-                  RendererBase<CT_> r,
-                  List<MustachioNode> ast,
-                  StringSink sink,
-                ) {
-                  renderSimple(
-                    c.element,
-                    ast,
-                    r.template,
-                    sink,
-                    parent: r,
-                    getters: _invisibleGetters['LibraryElement']!,
                   );
                 },
               ),
@@ -15295,34 +14995,6 @@ class _Renderer_Method extends RendererBase<Method> {
                   );
                 },
               ),
-              'element': Property(
-                getValue: (CT_ c) => c.element,
-                renderVariable:
-                    (CT_ c, Property<CT_> self, List<String> remainingNames) =>
-                        self.renderSimpleVariable(
-                          c,
-                          remainingNames,
-                          'MethodElement',
-                        ),
-
-                isNullValue: (CT_ c) => false,
-
-                renderValue: (
-                  CT_ c,
-                  RendererBase<CT_> r,
-                  List<MustachioNode> ast,
-                  StringSink sink,
-                ) {
-                  renderSimple(
-                    c.element,
-                    ast,
-                    r.template,
-                    sink,
-                    parent: r,
-                    getters: _invisibleGetters['MethodElement']!,
-                  );
-                },
-              ),
               'element2': Property(
                 getValue: (CT_ c) => c.element2,
                 renderVariable:
@@ -16188,34 +15860,6 @@ class _Renderer_Mixin extends RendererBase<Mixin> {
             CT_,
             () => {
               ..._Renderer_InheritingContainer.propertyMap<CT_>(),
-              'element': Property(
-                getValue: (CT_ c) => c.element,
-                renderVariable:
-                    (CT_ c, Property<CT_> self, List<String> remainingNames) =>
-                        self.renderSimpleVariable(
-                          c,
-                          remainingNames,
-                          'MixinElement',
-                        ),
-
-                isNullValue: (CT_ c) => false,
-
-                renderValue: (
-                  CT_ c,
-                  RendererBase<CT_> r,
-                  List<MustachioNode> ast,
-                  StringSink sink,
-                ) {
-                  renderSimple(
-                    c.element,
-                    ast,
-                    r.template,
-                    sink,
-                    parent: r,
-                    getters: _invisibleGetters['MixinElement']!,
-                  );
-                },
-              ),
               'element2': Property(
                 getValue: (CT_ c) => c.element2,
                 renderVariable:
@@ -17001,30 +16645,6 @@ class _Renderer_ModelElement extends RendererBase<ModelElement> {
                     r.template,
                     sink,
                     parent: r,
-                  );
-                },
-              ),
-              'element': Property(
-                getValue: (CT_ c) => c.element,
-                renderVariable:
-                    (CT_ c, Property<CT_> self, List<String> remainingNames) =>
-                        self.renderSimpleVariable(c, remainingNames, 'Element'),
-
-                isNullValue: (CT_ c) => false,
-
-                renderValue: (
-                  CT_ c,
-                  RendererBase<CT_> r,
-                  List<MustachioNode> ast,
-                  StringSink sink,
-                ) {
-                  renderSimple(
-                    c.element,
-                    ast,
-                    r.template,
-                    sink,
-                    parent: r,
-                    getters: _invisibleGetters['Element']!,
                   );
                 },
               ),
@@ -18305,34 +17925,6 @@ class _Renderer_ModelFunctionTyped extends RendererBase<ModelFunctionTyped> {
                     r.template,
                     sink,
                     parent: r,
-                  );
-                },
-              ),
-              'element': Property(
-                getValue: (CT_ c) => c.element,
-                renderVariable:
-                    (CT_ c, Property<CT_> self, List<String> remainingNames) =>
-                        self.renderSimpleVariable(
-                          c,
-                          remainingNames,
-                          'FunctionTypedElement',
-                        ),
-
-                isNullValue: (CT_ c) => false,
-
-                renderValue: (
-                  CT_ c,
-                  RendererBase<CT_> r,
-                  List<MustachioNode> ast,
-                  StringSink sink,
-                ) {
-                  renderSimple(
-                    c.element,
-                    ast,
-                    r.template,
-                    sink,
-                    parent: r,
-                    getters: _invisibleGetters['FunctionTypedElement']!,
                   );
                 },
               ),
@@ -19630,30 +19222,6 @@ class _Renderer_Package extends RendererBase<Package> {
                   );
                 },
               ),
-              'element': Property(
-                getValue: (CT_ c) => c.element,
-                renderVariable:
-                    (CT_ c, Property<CT_> self, List<String> remainingNames) =>
-                        self.renderSimpleVariable(c, remainingNames, 'Element'),
-
-                isNullValue: (CT_ c) => c.element == null,
-
-                renderValue: (
-                  CT_ c,
-                  RendererBase<CT_> r,
-                  List<MustachioNode> ast,
-                  StringSink sink,
-                ) {
-                  renderSimple(
-                    c.element,
-                    ast,
-                    r.template,
-                    sink,
-                    parent: r,
-                    getters: _invisibleGetters['Element']!,
-                  );
-                },
-              ),
               'element2': Property(
                 getValue: (CT_ c) => c.element2,
                 renderVariable:
@@ -20836,34 +20404,6 @@ class _Renderer_Parameter extends RendererBase<Parameter> {
                     r.template,
                     sink,
                     parent: r,
-                  );
-                },
-              ),
-              'element': Property(
-                getValue: (CT_ c) => c.element,
-                renderVariable:
-                    (CT_ c, Property<CT_> self, List<String> remainingNames) =>
-                        self.renderSimpleVariable(
-                          c,
-                          remainingNames,
-                          'ParameterElement',
-                        ),
-
-                isNullValue: (CT_ c) => false,
-
-                renderValue: (
-                  CT_ c,
-                  RendererBase<CT_> r,
-                  List<MustachioNode> ast,
-                  StringSink sink,
-                ) {
-                  renderSimple(
-                    c.element,
-                    ast,
-                    r.template,
-                    sink,
-                    parent: r,
-                    getters: _invisibleGetters['ParameterElement']!,
                   );
                 },
               ),
@@ -24211,34 +23751,6 @@ class _Renderer_TopLevelVariable extends RendererBase<TopLevelVariable> {
                   );
                 },
               ),
-              'element': Property(
-                getValue: (CT_ c) => c.element,
-                renderVariable:
-                    (CT_ c, Property<CT_> self, List<String> remainingNames) =>
-                        self.renderSimpleVariable(
-                          c,
-                          remainingNames,
-                          'TopLevelVariableElement',
-                        ),
-
-                isNullValue: (CT_ c) => false,
-
-                renderValue: (
-                  CT_ c,
-                  RendererBase<CT_> r,
-                  List<MustachioNode> ast,
-                  StringSink sink,
-                ) {
-                  renderSimple(
-                    c.element,
-                    ast,
-                    r.template,
-                    sink,
-                    parent: r,
-                    getters: _invisibleGetters['TopLevelVariableElement']!,
-                  );
-                },
-              ),
               'element2': Property(
                 getValue: (CT_ c) => c.element2,
                 renderVariable:
@@ -24666,34 +24178,6 @@ class _Renderer_TypeParameter extends RendererBase<TypeParameter> {
                     r.template,
                     sink,
                     parent: r,
-                  );
-                },
-              ),
-              'element': Property(
-                getValue: (CT_ c) => c.element,
-                renderVariable:
-                    (CT_ c, Property<CT_> self, List<String> remainingNames) =>
-                        self.renderSimpleVariable(
-                          c,
-                          remainingNames,
-                          'TypeParameterElement',
-                        ),
-
-                isNullValue: (CT_ c) => false,
-
-                renderValue: (
-                  CT_ c,
-                  RendererBase<CT_> r,
-                  List<MustachioNode> ast,
-                  StringSink sink,
-                ) {
-                  renderSimple(
-                    c.element,
-                    ast,
-                    r.template,
-                    sink,
-                    parent: r,
-                    getters: _invisibleGetters['TypeParameterElement']!,
                   );
                 },
               ),
@@ -25385,34 +24869,6 @@ class _Renderer_Typedef extends RendererBase<Typedef> {
                     r.template,
                     sink,
                     parent: r,
-                  );
-                },
-              ),
-              'element': Property(
-                getValue: (CT_ c) => c.element,
-                renderVariable:
-                    (CT_ c, Property<CT_> self, List<String> remainingNames) =>
-                        self.renderSimpleVariable(
-                          c,
-                          remainingNames,
-                          'TypeAliasElement',
-                        ),
-
-                isNullValue: (CT_ c) => false,
-
-                renderValue: (
-                  CT_ c,
-                  RendererBase<CT_> r,
-                  List<MustachioNode> ast,
-                  StringSink sink,
-                ) {
-                  renderSimple(
-                    c.element,
-                    ast,
-                    r.template,
-                    sink,
-                    parent: r,
-                    getters: _invisibleGetters['TypeAliasElement']!,
                   );
                 },
               ),
@@ -26117,30 +25573,6 @@ class _Renderer_Warnable extends RendererBase<Warnable> {
       _propertyMapCache.putIfAbsent(
             CT_,
             () => {
-              'element': Property(
-                getValue: (CT_ c) => c.element,
-                renderVariable:
-                    (CT_ c, Property<CT_> self, List<String> remainingNames) =>
-                        self.renderSimpleVariable(c, remainingNames, 'Element'),
-
-                isNullValue: (CT_ c) => c.element == null,
-
-                renderValue: (
-                  CT_ c,
-                  RendererBase<CT_> r,
-                  List<MustachioNode> ast,
-                  StringSink sink,
-                ) {
-                  renderSimple(
-                    c.element,
-                    ast,
-                    r.template,
-                    sink,
-                    parent: r,
-                    getters: _invisibleGetters['Element']!,
-                  );
-                },
-              ),
               'element2': Property(
                 getValue: (CT_ c) => c.element2,
                 renderVariable:
@@ -26206,26 +25638,6 @@ const _invisibleGetters = {
     'lineNumber',
     'runtimeType',
   },
-  'ClassElement': {
-    'augmentation',
-    'augmentationTarget',
-    'augmented',
-    'hasNonFinalField',
-    'hashCode',
-    'isAbstract',
-    'isBase',
-    'isConstructable',
-    'isDartCoreEnum',
-    'isDartCoreObject',
-    'isExhaustive',
-    'isFinal',
-    'isInterface',
-    'isMixinApplication',
-    'isMixinClass',
-    'isSealed',
-    'isValidMixin',
-    'runtimeType',
-  },
   'ClassElement2': {
     'firstFragment',
     'fragments',
@@ -26261,25 +25673,6 @@ const _invisibleGetters = {
     'extraReferenceChildren',
     'hasPublicConstructors',
     'publicConstructorsSorted',
-  },
-  'ConstructorElement': {
-    'augmentation',
-    'augmentationTarget',
-    'declaration',
-    'displayName',
-    'enclosingElement3',
-    'hashCode',
-    'isConst',
-    'isDefaultConstructor',
-    'isFactory',
-    'isGenerative',
-    'name',
-    'nameEnd',
-    'periodOffset',
-    'redirectedConstructor',
-    'returnType',
-    'runtimeType',
-    'superConstructor',
   },
   'ConstructorElement2': {
     'baseElement',
@@ -26390,58 +25783,6 @@ const _invisibleGetters = {
     'qualifiedName',
     'sourceFileName',
   },
-  'Element': {
-    'children',
-    'context',
-    'declaration',
-    'displayName',
-    'documentationComment',
-    'enclosingElement3',
-    'hasAlwaysThrows',
-    'hasDeprecated',
-    'hasDoNotStore',
-    'hasDoNotSubmit',
-    'hasFactory',
-    'hasImmutable',
-    'hasInternal',
-    'hasIsTest',
-    'hasIsTestGroup',
-    'hasJS',
-    'hasLiteral',
-    'hasMustBeConst',
-    'hasMustBeOverridden',
-    'hasMustCallSuper',
-    'hasNonVirtual',
-    'hasOptionalTypeArgs',
-    'hasOverride',
-    'hasProtected',
-    'hasRedeclare',
-    'hasReopen',
-    'hasRequired',
-    'hasSealed',
-    'hasUseResult',
-    'hasVisibleForOverriding',
-    'hasVisibleForTemplate',
-    'hasVisibleForTesting',
-    'hasVisibleOutsideTemplate',
-    'hashCode',
-    'id',
-    'isPrivate',
-    'isPublic',
-    'isSynthetic',
-    'kind',
-    'library',
-    'location',
-    'metadata',
-    'name',
-    'nameLength',
-    'nameOffset',
-    'nonSynthetic',
-    'runtimeType',
-    'session',
-    'sinceSdkVersion',
-    'source',
-  },
   'Element2': {
     'baseElement',
     'children2',
@@ -26461,13 +25802,6 @@ const _invisibleGetters = {
     'nonSynthetic2',
     'runtimeType',
     'session',
-  },
-  'EnumElement': {
-    'augmentation',
-    'augmentationTarget',
-    'augmented',
-    'hashCode',
-    'runtimeType',
   },
   'EnumElement2': {
     'constants2',
@@ -26553,30 +25887,12 @@ const _invisibleGetters = {
     'typeParameters',
     'typeParameters2',
   },
-  'ExtensionElement': {
-    'augmentation',
-    'augmentationTarget',
-    'augmented',
-    'extendedType',
-    'hashCode',
-    'runtimeType',
-  },
   'ExtensionElement2': {
     'extendedType',
     'firstFragment',
     'fragments',
     'hashCode',
     'runtimeType',
-  },
-  'ExtensionTypeElement': {
-    'augmentation',
-    'augmentationTarget',
-    'augmented',
-    'hashCode',
-    'primaryConstructor',
-    'representation',
-    'runtimeType',
-    'typeErasure',
   },
   'ExtensionTypeElement2': {
     'firstFragment',
@@ -26586,19 +25902,6 @@ const _invisibleGetters = {
     'representation2',
     'runtimeType',
     'typeErasure',
-  },
-  'FieldElement': {
-    'augmentation',
-    'augmentationTarget',
-    'declaration',
-    'hashCode',
-    'isAbstract',
-    'isCovariant',
-    'isEnumConstant',
-    'isExternal',
-    'isPromotable',
-    'isStatic',
-    'runtimeType',
   },
   'FieldElement2': {
     'baseElement',
@@ -26651,13 +25954,6 @@ const _invisibleGetters = {
     'sortedNamedParameters',
     'typeFormals',
     'typeParameters',
-  },
-  'FunctionTypedElement': {
-    'hashCode',
-    'parameters',
-    'returnType',
-    'runtimeType',
-    'type',
   },
   'FunctionTypedElement2': {
     'firstFragment',
@@ -26719,20 +26015,6 @@ const _invisibleGetters = {
     'overriddenDepth',
     'overriddenElement',
   },
-  'InterfaceElement': {
-    'allSupertypes',
-    'augmentationTarget',
-    'augmented',
-    'constructors',
-    'hashCode',
-    'interfaces',
-    'mixins',
-    'name',
-    'runtimeType',
-    'supertype',
-    'thisType',
-    'unnamedConstructor',
-  },
   'InterfaceElement2': {
     'allSupertypes',
     'constructors2',
@@ -26758,31 +26040,6 @@ const _invisibleGetters = {
     'single',
   },
   'Kind': {'hashCode', 'index', 'runtimeType'},
-  'LibraryElement': {
-    'definingCompilationUnit',
-    'enclosingElement3',
-    'entryPoint',
-    'exportNamespace',
-    'exportedLibraries',
-    'featureSet',
-    'hashCode',
-    'identifier',
-    'importedLibraries',
-    'isDartAsync',
-    'isDartCore',
-    'isInSdk',
-    'languageVersion',
-    'library',
-    'loadLibraryFunction',
-    'name',
-    'publicNamespace',
-    'runtimeType',
-    'session',
-    'topLevelElements',
-    'typeProvider',
-    'typeSystem',
-    'units',
-  },
   'LibraryElement2': {
     'classes',
     'entryPoint2',
@@ -26916,13 +26173,6 @@ const _invisibleGetters = {
     'sinceSdkVersion',
     'substitution',
   },
-  'MethodElement': {
-    'augmentation',
-    'augmentationTarget',
-    'declaration',
-    'hashCode',
-    'runtimeType',
-  },
   'MethodElement2': {
     'baseElement',
     'firstFragment',
@@ -26930,15 +26180,6 @@ const _invisibleGetters = {
     'hashCode',
     'isOperator',
     'runtimeType',
-  },
-  'MixinElement': {
-    'augmentation',
-    'augmentationTarget',
-    'augmented',
-    'hashCode',
-    'isBase',
-    'runtimeType',
-    'superclassConstraints',
   },
   'MixinElement2': {
     'firstFragment',
@@ -27003,29 +26244,6 @@ const _invisibleGetters = {
     'resourceProvider',
     'runtimeType',
     'version',
-  },
-  'ParameterElement': {
-    'declaration',
-    'defaultValueCode',
-    'element',
-    'hasDefaultValue',
-    'hashCode',
-    'isCovariant',
-    'isInitializingFormal',
-    'isNamed',
-    'isOptional',
-    'isOptionalNamed',
-    'isOptionalPositional',
-    'isPositional',
-    'isRequired',
-    'isRequiredNamed',
-    'isRequiredPositional',
-    'isSuperFormal',
-    'name',
-    'parameterKind',
-    'parameters',
-    'runtimeType',
-    'typeParameters',
   },
   'ParameterMember': {
     'augmentationSubstitution',
@@ -27113,19 +26331,6 @@ const _invisibleGetters = {
     'typeShared',
   },
   'ParameterizedType': {'hashCode', 'runtimeType', 'typeArguments'},
-  'PropertyAccessorElement': {
-    'augmentation',
-    'augmentationTarget',
-    'correspondingGetter',
-    'correspondingSetter',
-    'declaration',
-    'enclosingElement3',
-    'hashCode',
-    'isGetter',
-    'isSetter',
-    'runtimeType',
-    'variable2',
-  },
   'PropertyAccessorElement2': {
     'baseElement',
     'firstFragment',
@@ -27154,29 +26359,12 @@ const _invisibleGetters = {
     'isEntryPoint',
     'runtimeType',
   },
-  'TopLevelVariableElement': {
-    'augmentation',
-    'augmentationTarget',
-    'declaration',
-    'hashCode',
-    'isExternal',
-    'runtimeType',
-  },
   'TopLevelVariableElement2': {
     'baseElement',
     'firstFragment',
     'fragments',
     'hashCode',
     'isExternal',
-    'runtimeType',
-  },
-  'TypeAliasElement': {
-    'aliasedElement',
-    'aliasedType',
-    'enclosingElement3',
-    'hashCode',
-    'isAugmentation',
-    'name',
     'runtimeType',
   },
   'TypeAliasElement2': {
@@ -27186,14 +26374,6 @@ const _invisibleGetters = {
     'firstFragment',
     'fragments',
     'hashCode',
-    'runtimeType',
-  },
-  'TypeParameterElement': {
-    'bound',
-    'declaration',
-    'displayName',
-    'hashCode',
-    'name',
     'runtimeType',
   },
   'TypeParameterElement2': {

--- a/lib/src/model/accessor.dart
+++ b/lib/src/model/accessor.dart
@@ -4,13 +4,10 @@
 
 import 'dart:convert';
 
-import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/source/line_info.dart';
 // ignore: implementation_imports
 import 'package:analyzer/src/dart/element/member.dart' show ExecutableMember;
-// ignore: implementation_imports
-import 'package:analyzer/src/utilities/extensions/element.dart';
 import 'package:collection/collection.dart' show IterableExtension;
 import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
@@ -21,9 +18,6 @@ import 'package:dartdoc/src/warnings.dart';
 
 /// Getters and setters.
 class Accessor extends ModelElement {
-  @override
-  // ignore: analyzer_use_new_elements
-  PropertyAccessorElement get element => element2.asElement;
 
   @override
   final PropertyAccessorElement2 element2;

--- a/lib/src/model/canonicalization.dart
+++ b/lib/src/model/canonicalization.dart
@@ -70,9 +70,9 @@ Library? canonicalLibraryCandidate(ModelElement modelElement) {
 /// considers this element to be primarily 'from', and therefore, canonical.
 /// Still warn if the heuristic isn't very confident.
 final class _Canonicalization {
-  final ModelElement _element;
+  final ModelElement _modelElement;
 
-  _Canonicalization(this._element);
+  _Canonicalization(this._modelElement);
 
   /// Append an encoded form of the given [component] to the given [buffer].
   void _encode(StringBuffer buffer, String component) {
@@ -122,15 +122,15 @@ final class _Canonicalization {
     return buffer.toString();
   }
 
-  /// Calculates a candidate for the canonical library of [_element], among [libraries].
+  /// Calculates a candidate for the canonical library of [_modelElement], among [libraries].
   Library canonicalLibraryCandidate(Iterable<Library> libraries) {
-    var locationPieces = _getElementLocation(_element.element2)
+    var locationPieces = _getElementLocation(_modelElement.element2)
         .split(_locationSplitter)
         .where((s) => s.isNotEmpty)
         .toSet();
     var scoredCandidates = libraries
         .map((library) => _scoreElementWithLibrary(
-            library, _element.fullyQualifiedName, locationPieces))
+            library, _modelElement.fullyQualifiedName, locationPieces))
         .toList(growable: false)
       ..sort();
 
@@ -141,11 +141,11 @@ final class _Canonicalization {
     var confidence = highestScore - secondHighestScore;
     final canonicalLibrary = librariesByScore.last;
 
-    if (confidence < _element.config.ambiguousReexportScorerMinConfidence) {
+    if (confidence < _modelElement.config.ambiguousReexportScorerMinConfidence) {
       var libraryNames = librariesByScore.map((l) => l.name);
       var message = '$libraryNames -> ${canonicalLibrary.name} '
           '(confidence ${confidence.toStringAsPrecision(4)})';
-      _element.warn(PackageWarning.ambiguousReexport,
+      _modelElement.warn(PackageWarning.ambiguousReexport,
           message: message, extendedDebug: scoredCandidates.map((s) => '$s'));
     }
 

--- a/lib/src/model/category.dart
+++ b/lib/src/model/category.dart
@@ -2,9 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: analyzer_use_new_elements
 
-import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/file_system/file_system.dart';
 import 'package:dartdoc/src/dartdoc_options.dart';
@@ -80,8 +78,6 @@ class Category
     }
   }
 
-  @override
-  Element? get element => null;
 
   @override
   Element2? get element2 => null;

--- a/lib/src/model/class.dart
+++ b/lib/src/model/class.dart
@@ -2,10 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/element2.dart';
-// ignore: implementation_imports
-import 'package:analyzer/src/utilities/extensions/element.dart';
 import 'package:dartdoc/src/model/kind.dart';
 import 'package:dartdoc/src/model/model.dart';
 
@@ -18,8 +15,6 @@ import 'package:dartdoc/src/model/model.dart';
 /// **inherited**: Filtered getters giving only inherited children.
 class Class extends InheritingContainer with Constructable, MixedInTypes {
   @override
-  // ignore: analyzer_use_new_elements
-  ClassElement get element => element2.asElement;
 
   @override
   final ClassElement2 element2;

--- a/lib/src/model/constructor.dart
+++ b/lib/src/model/constructor.dart
@@ -2,13 +2,10 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/source/line_info.dart';
 // ignore: implementation_imports
 import 'package:analyzer/src/dart/element/element.dart';
-// ignore: implementation_imports
-import 'package:analyzer/src/utilities/extensions/element.dart';
 import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
 import 'package:dartdoc/src/model/kind.dart';
@@ -17,8 +14,6 @@ import 'package:dartdoc/src/model_utils.dart';
 
 class Constructor extends ModelElement with ContainerMember, TypeParameters {
   @override
-  // ignore: analyzer_use_new_elements
-  ConstructorElement get element => element2.asElement;
 
   @override
   final ConstructorElement2 element2;
@@ -140,11 +135,11 @@ class Constructor extends ModelElement with ContainerMember, TypeParameters {
         };
 
     var parameterElements = parameters.map((parameter) {
-      var element = dereferenceParameter(parameter.element2);
-      return element == null ? parameter : getModelForElement2(element);
+      var e = dereferenceParameter(parameter.element2);
+      return e == null ? parameter : getModelForElement2(e);
     });
     return {
-      for (var element in parameterElements) element.referenceName: element,
+      for (var e in parameterElements) e.referenceName: e,
       for (var tp in typeParameters) tp.referenceName: tp,
     };
   }();

--- a/lib/src/model/container.dart
+++ b/lib/src/model/container.dart
@@ -2,11 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/dart/element/scope.dart';
-// ignore: implementation_imports
-import 'package:analyzer/src/utilities/extensions/element.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/model_utils.dart' as model_utils;
@@ -33,10 +30,6 @@ import 'package:meta/meta.dart';
 abstract class Container extends ModelElement
     with Categorization, TypeParameters {
   Container(super.library, super.packageGraph);
-
-  @override
-  // ignore: analyzer_use_new_elements
-  Element get element => element2.asElement!;
 
   @override
   Element2 get element2;

--- a/lib/src/model/documentation.dart
+++ b/lib/src/model/documentation.dart
@@ -8,9 +8,9 @@ import 'package:dartdoc/src/warnings.dart';
 import 'package:markdown/markdown.dart' as md;
 
 class Documentation {
-  final Warnable _element;
+  final Warnable _warnable;
 
-  Documentation.forElement(this._element);
+  Documentation.forElement(this._warnable);
 
   /// The documentation text, rendered with the appropriate
   /// [DocumentationRenderer].
@@ -38,10 +38,10 @@ class Documentation {
       // set one. We have this awkward check to make sure we set both fields if
       // we'll need both fields.
       assert(
-        _element.isCanonical,
-        "generating docs for non-canonical element: '$_element' "
-        "('${_element.runtimeType}', ${_element.hashCode}), representing "
-        "'${_element.element2}'",
+        _warnable.isCanonical,
+        "generating docs for non-canonical element: '$_warnable' "
+        "('${_warnable.runtimeType}', ${_warnable.hashCode}), representing "
+        "'${_warnable.element2}'",
       );
       return _asHtml;
     }
@@ -55,7 +55,7 @@ class Documentation {
     if (_hasOneLinerBeenRendered || _hasHtmlBeenRendered) {
       return _asOneLiner;
     }
-    _renderDocumentation(storeFullText: _element.isCanonical);
+    _renderDocumentation(storeFullText: _warnable.isCanonical);
     _hasOneLinerBeenRendered = true;
     return _asOneLiner;
   }
@@ -65,7 +65,7 @@ class Documentation {
 
     var renderResult = _renderer.render(parseResult,
         processFullDocs: storeFullText,
-        sanitizeHtml: _element.config.sanitizeHtml);
+        sanitizeHtml: _warnable.config.sanitizeHtml);
 
     if (storeFullText) {
       _asHtml = renderResult.asHtml;
@@ -74,12 +74,12 @@ class Documentation {
   }
 
   List<md.Node> _parseDocumentation({required bool processFullText}) {
-    final text = _element.documentation;
+    final text = _warnable.documentation;
     if (text == null || text.isEmpty) {
       return const [];
     }
-    showWarningsForGenericsOutsideSquareBracketsBlocks(text, _element);
-    var document = MarkdownDocument.withElementLinkResolver(_element);
+    showWarningsForGenericsOutsideSquareBracketsBlocks(text, _warnable);
+    var document = MarkdownDocument.withElementLinkResolver(_warnable);
     return document.parseMarkdownText(text, processFullText: processFullText);
   }
 

--- a/lib/src/model/documentation_comment.dart
+++ b/lib/src/model/documentation_comment.dart
@@ -720,8 +720,8 @@ mixin DocumentationComment
         firstOfPair.add(results[i]);
       }
     }
-    for (var element in firstOfPair) {
-      final result = element.group(2)!.trim();
+    for (var e in firstOfPair) {
+      final result = e.group(2)!.trim();
       if (result.isEmpty) {
         warn(PackageWarning.missingCodeBlockLanguage,
             message:

--- a/lib/src/model/dynamic.dart
+++ b/lib/src/model/dynamic.dart
@@ -2,20 +2,14 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/element2.dart';
-// ignore: implementation_imports
-import 'package:analyzer/src/utilities/extensions/element.dart';
 import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
 import 'package:dartdoc/src/model/kind.dart';
 import 'package:dartdoc/src/model/model.dart';
 
 class Dynamic extends ModelElement with HasNoPage {
-  @override
-   // ignore: analyzer_use_new_elements
-   Element get element => element2.asElement!;
-
+ 
    @override
    final Element2 element2;
 

--- a/lib/src/model/enum.dart
+++ b/lib/src/model/enum.dart
@@ -3,20 +3,14 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:analyzer/dart/analysis/features.dart';
-import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/element2.dart';
-// ignore: implementation_imports
-import 'package:analyzer/src/utilities/extensions/element.dart';
 import 'package:dartdoc/src/model/kind.dart';
 import 'package:dartdoc/src/model/model.dart';
 import 'package:dartdoc/src/model_utils.dart' as model_utils;
 import 'package:meta/meta.dart';
 
 class Enum extends InheritingContainer with Constructable, MixedInTypes {
-  @override
-  // ignore: analyzer_use_new_elements
-  EnumElement get element => element2.asElement;
-
+ 
   @override
   final EnumElement2 element2;
 
@@ -89,7 +83,7 @@ class EnumField extends Field {
 
   EnumField.forConstant(this.index, FieldElement2 element, Library library,
       PackageGraph packageGraph, Accessor? getter)
-      : super.element2(
+      : super(
             element, library, packageGraph, getter as ContainerAccessor?, null);
 
   @override

--- a/lib/src/model/extension.dart
+++ b/lib/src/model/extension.dart
@@ -4,7 +4,6 @@
 
 // ignore_for_file: analyzer_use_new_elements
 
-import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';
@@ -20,8 +19,6 @@ import 'package:meta/meta.dart';
 /// Static extension on a given type, containing methods (including getters,
 /// setters, operators).
 class Extension extends Container {
-  @override
-  ExtensionElement get element => element2.asElement;
 
   @override
   final ExtensionElement2 element2;

--- a/lib/src/model/extension_type.dart
+++ b/lib/src/model/extension_type.dart
@@ -2,12 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: analyzer_use_new_elements
-
-import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/element2.dart';
-// ignore: implementation_imports
-import 'package:analyzer/src/utilities/extensions/element.dart';
 import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
 import 'package:dartdoc/src/model/kind.dart';
@@ -15,14 +10,12 @@ import 'package:dartdoc/src/model/model.dart';
 import 'package:meta/meta.dart';
 
 class ExtensionType extends InheritingContainer with Constructable {
-  @override
-  ExtensionTypeElement get element => element2.asElement;
 
   @override
   final ExtensionTypeElement2  element2;
 
   late final ElementType representationType =
-      getTypeFor(element.representation.type, library);
+      getTypeFor(element2.representation2.type, library);
 
   ExtensionType(this.element2, super.library, super.packageGraph);
 
@@ -48,19 +41,19 @@ class ExtensionType extends InheritingContainer with Constructable {
   bool get isSealed => false;
 
   @override
-  late final List<Field> declaredFields = element.fields.map((field) {
+  late final List<Field> declaredFields = element2.fields2.map((field) {
     ContainerAccessor? getter, setter;
-    final fieldGetter = field.getter;
+    final fieldGetter = field.getter2;
     if (fieldGetter != null) {
       getter = ContainerAccessor(
-          fieldGetter.asElement2, library, packageGraph, this);
+          fieldGetter, library, packageGraph, this);
     }
-    final fieldSetter = field.setter;
+    final fieldSetter = field.setter2;
     if (fieldSetter != null) {
       setter = ContainerAccessor(
-          fieldSetter.asElement2, library, packageGraph, this);
+          fieldSetter, library, packageGraph, this);
     }
-    return getModelForPropertyInducingElement(field, library,
+    return getModelForPropertyInducingElement2(field, library,
         getter: getter, setter: setter) as Field;
   }).toList(growable: false);
 

--- a/lib/src/model/field.dart
+++ b/lib/src/model/field.dart
@@ -2,25 +2,18 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: analyzer_use_new_elements
-
 import 'dart:convert';
 
-import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/element2.dart';
-// ignore: implementation_imports
-import 'package:analyzer/src/utilities/extensions/element.dart';
 import 'package:dartdoc/src/model/attribute.dart';
 import 'package:dartdoc/src/model/kind.dart';
 import 'package:dartdoc/src/model/model.dart';
 
 class Field extends ModelElement
     with GetterSetterCombo, ContainerMember, Inheritable {
+ 
   @override
-  final FieldElement element;
-
-  @override
-  FieldElement2 get element2 => element.asElement2;
+  final FieldElement2 element2;
 
   @override
   final ContainerAccessor? getter;
@@ -35,30 +28,15 @@ class Field extends ModelElement
   final Container enclosingElement;
 
   Field(
-    this.element,
+    this.element2,
     super.library,
     super.packageGraph,
     this.getter,
     this.setter,
-  )   : isInherited = false,
-        enclosingElement =
-            ModelElement.for_(element.asElement2.enclosingElement2, library, packageGraph)
-                as Container,
-        assert(getter != null || setter != null) {
-    getter?.enclosingCombo = this;
-    setter?.enclosingCombo = this;
-  }
-
-  Field.element2(
-    Element2 element2,
-    super.library,
-    super.packageGraph,
-    this.getter,
-    this.setter,
-  )   : element = element2.asElement as FieldElement,
+  )   :
         isInherited = false,
         enclosingElement =
-            ModelElement.for_(element2.enclosingElement2!, library, packageGraph)
+            ModelElement.for_(element2.enclosingElement2, library, packageGraph)
                 as Container,
         assert(getter != null || setter != null) {
     getter?.enclosingCombo = this;
@@ -66,13 +44,13 @@ class Field extends ModelElement
   }
 
   Field.providedByExtension(
-    Element2 element2,
+    this.element2,
     this.enclosingElement,
     super.library,
     super.packageGraph,
     this.getter,
     this.setter,
-  )   : element = element2.asElement as FieldElement,
+  )   :
         isInherited = false,
         assert(getter != null || setter != null) {
     getter?.enclosingCombo = this;
@@ -80,13 +58,13 @@ class Field extends ModelElement
   }
 
   Field.inherited(
-    Element2 element2,
+    this.element2,
     this.enclosingElement,
     super.library,
     super.packageGraph,
     this.getter,
     this.setter,
-  )   : element = element2.asElement as FieldElement,
+  )   : 
         isInherited = true,
         assert(getter != null || setter != null) {
     // Can't set `isInherited` to true if this is the defining element, because
@@ -124,12 +102,12 @@ class Field extends ModelElement
   }
 
   @override
-  bool get isConst => element.isConst;
+  bool get isConst => element2.isConst;
 
-  /// Whether the [FieldElement] is covariant, or the first parameter for the
+  /// Whether the [FieldElement2] is covariant, or the first parameter for the
   /// setter is covariant.
   @override
-  bool get isCovariant => setter?.isCovariant == true || element.isCovariant;
+  bool get isCovariant => setter?.isCovariant == true || element2.isCovariant;
 
   /// Whether this field is final.
   ///
@@ -138,22 +116,22 @@ class Field extends ModelElement
   @override
   bool get isFinal {
     if (hasExplicitGetter) return false;
-    return element.isFinal;
+    return element2.isFinal;
   }
 
   @override
-  bool get isLate => isFinal && element.isLate;
+  bool get isLate => isFinal && element2.isLate;
 
-  bool get isStatic => element.isStatic;
+  bool get isStatic => element2.isStatic;
 
   @override
   Kind get kind => isConst ? Kind.constant : Kind.property;
 
   String get fullkind =>
-      element.isAbstract ? 'abstract $kind' : kind.toString();
+      element2.isAbstract ? 'abstract $kind' : kind.toString();
 
   bool get isProvidedByExtension =>
-      element.enclosingElement3 is ExtensionElement;
+      element2.enclosingElement2 is ExtensionElement2;
 
   /// The [enclosingElement], which is expected to be an [Extension].
   Extension get enclosingExtension => enclosingElement as Extension;

--- a/lib/src/model/inheriting_container.dart
+++ b/lib/src/model/inheriting_container.dart
@@ -2,11 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/dart/element/type.dart';
-// ignore: implementation_imports
-import 'package:analyzer/src/utilities/extensions/element.dart';
 import 'package:collection/collection.dart' show IterableExtension;
 import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
@@ -298,9 +295,6 @@ abstract class InheritingContainer extends Container {
       getModelFor2(element2, library) as InheritingContainer;
 
   @override
-
-  // ignore: analyzer_use_new_elements
-  InterfaceElement get element => element2.asElement;
 
   @override
   InterfaceElement2 get element2;

--- a/lib/src/model/library.dart
+++ b/lib/src/model/library.dart
@@ -3,12 +3,9 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:analyzer/dart/analysis/features.dart';
-import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/dart/element/scope.dart';
 import 'package:analyzer/source/line_info.dart';
-// ignore: implementation_imports
-import 'package:analyzer/src/utilities/extensions/element.dart';
 // ignore: implementation_imports
 import 'package:dartdoc/src/model/comment_referable.dart';
 import 'package:dartdoc/src/model/kind.dart';
@@ -26,10 +23,6 @@ class Library extends ModelElement
     with Categorization, TopLevelContainer, CanonicalFor {
   @override
   final LibraryElement2 element2;
-
-  @override
-  // ignore: analyzer_use_new_elements
-  LibraryElement get element => element2.asElement;
 
   /// The set of [Element2]s declared directly in this library.
   final Set<Element2> _localElements;
@@ -63,24 +56,24 @@ class Library extends ModelElement
       PackageGraph packageGraph, Package package) {
     packageGraph.gatherModelNodes(resolvedLibrary);
 
-    var element = resolvedLibrary.element2;
+    var libraryElement = resolvedLibrary.element2;
 
     var localElements = <Element2>{
-      ...element.firstFragment.getters.map((g) => g.element),
-      ...element.firstFragment.setters.map((s) => s.element),
-      ...element.firstFragment.classes2.map((c) => c.element),
-      ...element.firstFragment.enums2.map((e) => e.element),
-      ...element.firstFragment.extensions2.map((e) => e.element),
-      ...element.firstFragment.extensionTypes2.map((e) => e.element),
-      ...element.firstFragment.functions2.map((f) => f.element),
-      ...element.firstFragment.mixins2.map((m) => m.element),
-      ...element.firstFragment.topLevelVariables2.map((v) => v.element),
-      ...element.firstFragment.typeAliases2.map((a) => a.element),
+      ...libraryElement.firstFragment.getters.map((g) => g.element),
+      ...libraryElement.firstFragment.setters.map((s) => s.element),
+      ...libraryElement.firstFragment.classes2.map((c) => c.element),
+      ...libraryElement.firstFragment.enums2.map((e) => e.element),
+      ...libraryElement.firstFragment.extensions2.map((e) => e.element),
+      ...libraryElement.firstFragment.extensionTypes2.map((e) => e.element),
+      ...libraryElement.firstFragment.functions2.map((f) => f.element),
+      ...libraryElement.firstFragment.mixins2.map((m) => m.element),
+      ...libraryElement.firstFragment.topLevelVariables2.map((v) => v.element),
+      ...libraryElement.firstFragment.typeAliases2.map((a) => a.element),
     };
-    var exportedElements = {...element.exportNamespace.definedNames2.values}
+    var exportedElements = {...libraryElement.exportNamespace.definedNames2.values}
         .difference(localElements);
     var library = Library._(
-      element,
+      libraryElement,
       packageGraph,
       package,
       resolvedLibrary.element2.firstFragment.source.uri.toString(),
@@ -402,18 +395,18 @@ class Library extends ModelElement
     }.map(_topLevelVariableFor);
   }
 
-  TopLevelVariable _topLevelVariableFor(TopLevelVariableElement2 element) {
+  TopLevelVariable _topLevelVariableFor(TopLevelVariableElement2 topLevelVariableElement) {
     Accessor? getter;
-    var elementGetter = element.getter2;
+    var elementGetter = topLevelVariableElement.getter2;
     if (elementGetter != null) {
       getter = packageGraph.getModelFor2(elementGetter, this) as Accessor;
     }
     Accessor? setter;
-    var elementSetter = element.setter2;
+    var elementSetter = topLevelVariableElement.setter2;
     if (elementSetter != null) {
       setter = packageGraph.getModelFor2(elementSetter, this) as Accessor;
     }
-    return getModelForPropertyInducingElement2(element, this,
+    return getModelForPropertyInducingElement2(topLevelVariableElement, this,
         getter: getter, setter: setter) as TopLevelVariable;
   }
 

--- a/lib/src/model/method.dart
+++ b/lib/src/model/method.dart
@@ -2,13 +2,10 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/source/line_info.dart';
 // ignore: implementation_imports
 import 'package:analyzer/src/dart/element/member.dart' show ExecutableMember;
-// ignore: implementation_imports
-import 'package:analyzer/src/utilities/extensions/element.dart';
 import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/model/attribute.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
@@ -17,9 +14,6 @@ import 'package:dartdoc/src/model/model.dart';
 
 class Method extends ModelElement
     with ContainerMember, Inheritable, TypeParameters {
-  @override
-  // ignore: analyzer_use_new_elements
-  MethodElement get element => element2.asElement;
 
   @override
   final MethodElement2 element2;

--- a/lib/src/model/mixin.dart
+++ b/lib/src/model/mixin.dart
@@ -2,11 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/dart/element/type.dart';
-// ignore: implementation_imports
-import 'package:analyzer/src/utilities/extensions/element.dart';
 import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
 import 'package:dartdoc/src/model/kind.dart';
@@ -15,9 +12,6 @@ import 'package:dartdoc/src/model_utils.dart' as model_utils;
 import 'package:meta/meta.dart';
 
 class Mixin extends InheritingContainer {
-  @override
-  // ignore: analyzer_use_new_elements
-  MixinElement get element => element2.asElement;
 
   @override
   final MixinElement2 element2;

--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -8,7 +8,6 @@ library;
 import 'dart:collection';
 import 'dart:convert';
 
-import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/dart/element/type.dart' show FunctionType;
 import 'package:analyzer/source/line_info.dart';
@@ -143,7 +142,7 @@ abstract class ModelElement
           TopLevelVariable(e, library, packageGraph, getter, setter);
     } else if (e is FieldElement2) {
       if (enclosingContainer is Extension) {
-        newModelElement = Field.element2(e, library, packageGraph,
+        newModelElement = Field(e, library, packageGraph,
             getter as ContainerAccessor?, setter as ContainerAccessor?);
       } else if (enclosingContainer == null) {
         if (e.isEnumConstant) {
@@ -161,10 +160,10 @@ abstract class ModelElement
           newModelElement =
               EnumField.forConstant(index, e, library, packageGraph, getter);
         } else if (e.enclosingElement2 is ExtensionElement2) {
-          newModelElement = Field.element2(e, library, packageGraph,
+          newModelElement = Field(e, library, packageGraph,
               getter as ContainerAccessor?, setter as ContainerAccessor?);
         } else {
-          newModelElement = Field.element2(e, library, packageGraph,
+          newModelElement = Field(e, library, packageGraph,
               getter as ContainerAccessor?, setter as ContainerAccessor?);
         }
       } else {
@@ -548,10 +547,6 @@ abstract class ModelElement
       documentationFrom.map((e) => e.documentationLocal).join('<p>'));
 
   @override
-  // ignore: analyzer_use_new_elements
-  Element get element => element2.asElement!;
-
-  @override
   Element2 get element2;
 
   @override
@@ -751,32 +746,32 @@ abstract class ModelElement
   // TODO(srawlins): This really smells like it should just be implemented in
   // the subclasses.
   late final List<Parameter> parameters = () {
-    final element = element2;
+    final e = element2;
     if (!isCallable) {
       throw StateError(
-          '$element (${element.runtimeType}) cannot have parameters');
+          '$e (${e.runtimeType}) cannot have parameters');
     }
 
     final List<FormalParameterElement> params;
-    if (element is TypeAliasElement2) {
-      final aliasedType = element.aliasedType;
+    if (e is TypeAliasElement2) {
+      final aliasedType = e.aliasedType;
       if (aliasedType is FunctionType) {
         params = aliasedType.formalParameters;
       } else {
         return const <Parameter>[];
       }
-    } else if (element is ExecutableElement2) {
+    } else if (e is ExecutableElement2) {
       if (_originalMember != null) {
         assert(_originalMember is ExecutableMember);
         params = (_originalMember as ExecutableMember).formalParameters;
       } else {
-        params = element.formalParameters;
+        params = e.formalParameters;
       }
-    } else if (element is FunctionTypedElement2) {
+    } else if (e is FunctionTypedElement2) {
       if (_originalMember != null) {
         params = (_originalMember as FunctionTypedElement2).formalParameters;
       } else {
-        params = element.formalParameters;
+        params = e.formalParameters;
       }
     } else {
       return const <Parameter>[];

--- a/lib/src/model/model_function.dart
+++ b/lib/src/model/model_function.dart
@@ -2,10 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/element2.dart';
-// ignore: implementation_imports
-import 'package:analyzer/src/utilities/extensions/element.dart';
 import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
 import 'package:dartdoc/src/model/kind.dart';
@@ -37,9 +34,6 @@ class ModelFunctionTypedef extends ModelFunctionTyped {
 }
 
 class ModelFunctionTyped extends ModelElement with TypeParameters {
-  @override
-   // ignore: analyzer_use_new_elements
-   FunctionTypedElement get element => element2.asElement as FunctionTypedElement;
 
   @override
   final FunctionTypedElement2 element2;

--- a/lib/src/model/never.dart
+++ b/lib/src/model/never.dart
@@ -2,18 +2,12 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/element2.dart';
-// ignore: implementation_imports
-import 'package:analyzer/src/utilities/extensions/element.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
 import 'package:dartdoc/src/model/kind.dart';
 import 'package:dartdoc/src/model/model.dart';
 
 class NeverType extends ModelElement with HasNoPage {
-  @override
-  // ignore: analyzer_use_new_elements
-  Element get element => element2.asElement!;
 
   @override
   final Element2 element2;

--- a/lib/src/model/package.dart
+++ b/lib/src/model/package.dart
@@ -4,7 +4,6 @@
 
 // ignore_for_file: analyzer_use_new_elements
 
-import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/element2.dart';
 import 'package:dartdoc/src/dartdoc_options.dart';
 import 'package:dartdoc/src/io_utils.dart';
@@ -158,8 +157,8 @@ class Package extends LibraryContainer
     if (!packageGraph.hasEmbedderSdk) return false;
     if (!packageMeta.isSdk) return false;
     final packagePath = packageGraph.packageMeta.dir.path;
-    return libraries.any(
-        (l) => _pathContext.isWithin(packagePath, l.element.source.fullName));
+    return libraries.any((l) => _pathContext.isWithin(
+        packagePath, l.element2.firstFragment.source.fullName));
   }
 
   /// True if the global config excludes this package by name.
@@ -375,9 +374,6 @@ class Package extends LibraryContainer
   String get version => packageMeta.version;
 
   final PackageMeta packageMeta;
-
-  @override
-  Element? get element => null;
 
   @override
   Element2? get element2 => null;

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -160,27 +160,27 @@ class PackageGraph with CommentReferable, Nameable {
     var allModelElements = _gatherModelElements();
     logInfo('Precaching local docs for ${allModelElements.length} elements...');
     progressBarStart(allModelElements.length);
-    for (var element in allModelElements) {
+    for (var e in allModelElements) {
       progressBarTick();
       // Only precache elements which are canonical, have a canonical element
       // somewhere, or have a canonical enclosing element. Not the same as
       // `allCanonicalModelElements` since we need to run for any [ModelElement]
       // that might not _have_ a canonical [ModelElement], too.
-      if (element.isCanonical ||
-          element.canonicalModelElement == null ||
-          element is Library ||
-          element.enclosingElement!.isCanonical) {
-        for (var d in element.documentationFrom
+      if (e.isCanonical ||
+          e.canonicalModelElement == null ||
+          e is Library ||
+          e.enclosingElement!.isCanonical) {
+        for (var d in e.documentationFrom
             .where((d) => d.hasDocumentationComment)) {
           if (d.needsPrecache && !precachedElements.contains(d)) {
             precachedElements.add(d as ModelElement);
             futures.add(d.precacheLocalDocs());
             // [TopLevelVariable]s get their documentation from getters and
             // setters, so should be precached if either has a template.
-            if (element is TopLevelVariable &&
-                !precachedElements.contains(element)) {
-              precachedElements.add(element);
-              futures.add(element.precacheLocalDocs());
+            if (e is TopLevelVariable &&
+                !precachedElements.contains(e)) {
+              precachedElements.add(e);
+              futures.add(e.precacheLocalDocs());
             }
           }
         }
@@ -733,7 +733,7 @@ class PackageGraph with CommentReferable, Nameable {
       {Container? preferredClass}) {
     assert(allLibrariesAdded);
     if (modelElement == null) return null;
-    var element = modelElement.element2;
+    var e = modelElement.element2;
     if (preferredClass != null) {
       var canonicalClass =
           findCanonicalModelElementFor(preferredClass) as Container?;
@@ -746,32 +746,32 @@ class PackageGraph with CommentReferable, Nameable {
       library = preferredClass.canonicalLibrary;
     }
     // For elements defined in extensions, they are canonical.
-    var enclosingElement = element.enclosingElement2;
+    var enclosingElement = e.enclosingElement2;
     if (enclosingElement is ExtensionElement2) {
       library ??= getModelForElement2(enclosingElement.library2) as Library?;
       // TODO(keertip): Find a better way to exclude members of extensions
       // when libraries are specified using the "--include" flag.
       if (library != null && library.isDocumented) {
-        return getModelFor2(element, library,
+        return getModelFor2(e, library,
             enclosingContainer: preferredClass);
       }
     }
     // TODO(jcollins-g): The data structures should be changed to eliminate
     // guesswork with member elements.
-    var declaration = element.baseElement;
+    var declaration = e.baseElement;
     ModelElement? canonicalModelElement;
-    if (element is ConstructorElement2 ||
-        element is MethodElement2 ||
-        element is FieldElement2 ||
-        element is PropertyAccessorElement2) {
+    if (e is ConstructorElement2 ||
+        e is MethodElement2 ||
+        e is FieldElement2 ||
+        e is PropertyAccessorElement2) {
       var declarationModelElement = getModelForElement2(declaration);
-      element = declarationModelElement.element2;
+      e = declarationModelElement.element2;
       canonicalModelElement = _findCanonicalModelElementForAmbiguous(
           declarationModelElement, library,
           preferredClass: preferredClass as InheritingContainer?);
     } else {
       if (library != null) {
-        if (element case PropertyInducingElement2(:var getter2, :var setter2)) {
+        if (e case PropertyInducingElement2(:var getter2, :var setter2)) {
           var getterElement = getter2 == null
               ? null
               : getModelFor2(getter2, library) as Accessor;
@@ -779,10 +779,10 @@ class PackageGraph with CommentReferable, Nameable {
               ? null
               : getModelFor2(setter2, library) as Accessor;
           canonicalModelElement = getModelForPropertyInducingElement2(
-              element, library,
+              e, library,
               getter: getterElement, setter: setterElement);
         } else {
-          canonicalModelElement = getModelFor2(element, library);
+          canonicalModelElement = getModelFor2(e, library);
         }
       }
       assert(canonicalModelElement is! Inheritable);
@@ -791,7 +791,7 @@ class PackageGraph with CommentReferable, Nameable {
       }
     }
     // Prefer fields and top-level variables.
-    if (element is PropertyAccessorElement2 &&
+    if (e is PropertyAccessorElement2 &&
         canonicalModelElement is Accessor) {
       canonicalModelElement = canonicalModelElement.enclosingCombo;
     }

--- a/lib/src/model/parameter.dart
+++ b/lib/src/model/parameter.dart
@@ -2,21 +2,15 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/element2.dart';
 // ignore: implementation_imports
 import 'package:analyzer/src/dart/element/member.dart' show ParameterMember;
-// ignore: implementation_imports
-import 'package:analyzer/src/utilities/extensions/element.dart';
 import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
 import 'package:dartdoc/src/model/kind.dart';
 import 'package:dartdoc/src/model/model.dart';
 
 class Parameter extends ModelElement with HasNoPage {
-  @override
-  // ignore: analyzer_use_new_elements
-  ParameterElement get element => element2.asElement;
 
   @override
   final FormalParameterElement element2;

--- a/lib/src/model/prefix.dart
+++ b/lib/src/model/prefix.dart
@@ -2,11 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/dart/element/scope.dart';
-// ignore: implementation_imports
-import 'package:analyzer/src/utilities/extensions/element.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
 import 'package:dartdoc/src/model/kind.dart';
 import 'package:dartdoc/src/model/model.dart';
@@ -16,9 +13,6 @@ import 'package:dartdoc/src/model/model.dart';
 /// Like [Parameter], it doesn't have doc pages, but participates in lookups.
 /// Forwards to its referenced library if referred to directly.
 class Prefix extends ModelElement with HasNoPage {
-  @override
-  // ignore: analyzer_use_new_elements
-  PrefixElement get element => element2.asElement;
 
   @override
   final PrefixElement2 element2;

--- a/lib/src/model/top_level_variable.dart
+++ b/lib/src/model/top_level_variable.dart
@@ -2,10 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/element2.dart';
-// ignore: implementation_imports
-import 'package:analyzer/src/dart/element/element.dart';
 import 'package:dartdoc/src/model/attribute.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
 import 'package:dartdoc/src/model/kind.dart';
@@ -14,11 +11,6 @@ import 'package:dartdoc/src/model/model.dart';
 /// Top-level variables. But also picks up getters and setters?
 class TopLevelVariable extends ModelElement
     with GetterSetterCombo, Categorization {
-  @override
-  // ignore: analyzer_use_new_elements
-  TopLevelVariableElement get element =>
-      // ignore: analyzer_use_new_elements
-      (element2.firstFragment as TopLevelVariableElementImpl).declaration;
 
   @override
   final TopLevelVariableElement2 element2;

--- a/lib/src/model/type_parameter.dart
+++ b/lib/src/model/type_parameter.dart
@@ -2,20 +2,13 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/element2.dart';
-// ignore: implementation_imports
-import 'package:analyzer/src/dart/element/element.dart';
 import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
 import 'package:dartdoc/src/model/kind.dart';
 import 'package:dartdoc/src/model/model.dart';
 
 class TypeParameter extends ModelElement with HasNoPage {
-  @override
-  // ignore: analyzer_use_new_elements
-  TypeParameterElement get element =>
-      (element2 as TypeParameterElementImpl2).firstFragment;
 
   @override
   final TypeParameterElement2 element2;

--- a/lib/src/model/typedef.dart
+++ b/lib/src/model/typedef.dart
@@ -2,11 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/dart/element/type.dart';
-// ignore: implementation_imports
-import 'package:analyzer/src/utilities/extensions/element.dart';
 import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
 import 'package:dartdoc/src/model/kind.dart';
@@ -14,9 +11,6 @@ import 'package:dartdoc/src/model/model.dart';
 
 abstract class Typedef extends ModelElement
     with TypeParameters, Categorization {
-  @override
-   // ignore: analyzer_use_new_elements
-   TypeAliasElement get element => element2.asElement;
 
   @override
   final TypeAliasElement2 element2;

--- a/lib/src/warnings.dart
+++ b/lib/src/warnings.dart
@@ -5,7 +5,6 @@
 import 'dart:io';
 import 'dart:math' as math;
 
-import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/file_system/file_system.dart';
 import 'package:collection/collection.dart';
@@ -96,8 +95,6 @@ List<DartdocOption<Object?>> createPackageWarningOptions(
 /// Something that package warnings can be reported on. Optionally associated
 /// with an analyzer [element].
 mixin Warnable implements CommentReferable, Documentable, Locatable {
-  // ignore: analyzer_use_new_elements
-  Element? get element;
 
   Element2? get element2;
 
@@ -543,14 +540,14 @@ class PackageWarningCounter {
   /// If this package has had any warnings counted.
   bool get hasWarnings => _countedWarnings.isNotEmpty;
 
-  /// Whether we've already warned for this combination of [element], [kind],
+  /// Whether we've already warned for this combination of [e], [kind],
   /// and [messageFragment].
   bool hasWarning(
-      Warnable? element, PackageWarning kind, String messageFragment) {
-    if (element == null) {
+      Warnable? e, PackageWarning kind, String messageFragment) {
+    if (e == null) {
       return false;
     }
-    final warning = _countedWarnings[element.element2];
+    final warning = _countedWarnings[e.element2];
     if (warning != null) {
       final messages = warning[kind];
       return messages != null &&
@@ -561,13 +558,14 @@ class PackageWarningCounter {
 
   /// Adds the warning to the counter, and writes out the fullMessage string
   /// if configured to do so.
-  void addWarning(Warnable? element, PackageWarning kind, String message,
+  void addWarning(Warnable? e
+  , PackageWarning kind, String message,
       String fullMessage) {
-    assert(!hasWarning(element, kind, message));
+    assert(!hasWarning(e, kind, message));
     // TODO(jcollins-g): Make addWarning not accept nulls for element.
     PackageWarningOptionContext config =
-        element?.config ?? packageGraph.defaultPackage.config;
-    var isLocal = element?.package.isLocal ?? true;
+        e?.config ?? packageGraph.defaultPackage.config;
+    var isLocal = e?.package.isLocal ?? true;
     var warningMode = !isLocal && !config.allowNonLocalWarnings
         ? PackageWarningMode.ignore
         : config.packageWarningOptions.getMode(kind);
@@ -577,9 +575,9 @@ class PackageWarningCounter {
     } else if (warningMode == PackageWarningMode.error) {
       _errorCount += 1;
     }
-    var elementName = element == null ? '<global>' : element.fullyQualifiedName;
+    var elementName = e == null ? '<global>' : e.fullyQualifiedName;
     _countedWarnings
-        .putIfAbsent(element?.element2, () => {})
+        .putIfAbsent(e?.element2, () => {})
         .putIfAbsent(kind, () => {})
         .add(message);
     _writeWarning(

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -4,6 +4,8 @@
 
 // ignore_for_file: non_constant_identifier_names
 
+ // ignore_for_file: analyzer_use_new_elements
+
 import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:analyzer/source/line_info.dart';

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -4,9 +4,7 @@
 
 // ignore_for_file: non_constant_identifier_names
 
-// ignore_for_file: analyzer_use_new_elements
-
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:analyzer/source/line_info.dart';
 import 'package:async/async.dart';
@@ -181,9 +179,9 @@ void main() async {
         'Verify annotations and their type arguments render on type parameters '
         'for typedefs',
         skip: 'dart-lang/sdk#46064', () {
-      expect((F.aliasedType as FunctionType).typeFormals.first.metadata,
+      expect((F.aliasedType as FunctionType).typeParameters.first.metadata2,
           isNotEmpty);
-      expect((F.aliasedType as FunctionType).parameters.first.metadata,
+      expect((F.aliasedType as FunctionType).typeParameters.first.metadata2,
           isNotEmpty);
       // TODO(jcollins-g): add rendering verification once we have data from
       // analyzer.
@@ -234,7 +232,7 @@ void main() async {
     void expectTypedefs(Typedef t, String modelTypeToString,
         Iterable<String> genericParameters) {
       expect(t.modelType.toString(), equals(modelTypeToString));
-      expect(t.element.typeParameters.map((p) => p.toString()),
+      expect(t.element2.typeParameters2.map((p) => p.toString()),
           orderedEquals(genericParameters));
     }
 
@@ -909,18 +907,24 @@ void main() async {
     });
 
     test('can import other libraries with unusual URIs', () {
+        final importLists = fakeLibrary.element2.fragments
+          .map((fragment) => fragment.libraryImports2);
+      final exportLists = fakeLibrary.element2.fragments
+          .map((fragment) => fragment.libraryExports2);
       final fakeLibraryImportedExported = <Library>{
-        for (final l in <LibraryElement>{
-          ...fakeLibrary.element.definingCompilationUnit.libraryImports
+        for (final l in <LibraryElement2>{
+          ...importLists
+              .expand((imports) => imports)
               .map((import) => import.uri)
               .whereType<DirectiveUriWithLibrary>()
-              .map((uri) => uri.library),
-          ...fakeLibrary.element.definingCompilationUnit.libraryExports
-              .map((import) => import.uri)
+              .map((uri) => uri.library2),
+          ...exportLists
+              .expand((exports) => exports)
+              .map((export) => export.uri)
               .whereType<DirectiveUriWithLibrary>()
-              .map((uri) => uri.library)
+              .map((uri) => uri.library2)
         })
-          packageGraph.getModelForElement(l) as Library
+          packageGraph.getModelForElement2(l) as Library
       };
       expect(fakeLibraryImportedExported.any((l) => l.name == 'import_unusual'),
           isTrue);
@@ -1682,7 +1686,7 @@ void main() async {
           fakeLibrary.classes.wherePublic.named('MIEEMixinWithOverride');
       var problematicOperator =
           MIEEMixinWithOverride.inheritedOperators.named('operator []=');
-      expect(problematicOperator.element.enclosingElement3.name,
+      expect(problematicOperator.element2.enclosingElement2?.name3,
           equals('_MIEEPrivateOverride'));
       expect(problematicOperator.canonicalModelElement!.enclosingElement!.name,
           equals('MIEEMixinWithOverride'));
@@ -3572,7 +3576,7 @@ String? topLevelFunction(int param1, bool param2, Cool coolBeans,
     test('inheritance of docs from SDK works for getter/setter combos', () {
       expect(
           ExtraSpecialListLength
-              .getter!.documentationFrom.first.element!.library!.name,
+              .getter!.documentationFrom.first.element2.library2!.name3,
           equals('dart.core'));
       expect(ExtraSpecialListLength.oneLineDoc == '', isFalse);
     });


### PR DESCRIPTION
Migrate to Element2

- remove 'element' from ModelElement/Warnable
- lib/src/model/accessor.dart
- lib/src/model/field.dart
- lib/src/model/extension_type.dart
- test/end2end/model_test.dart


Was looking to also rename `element2` to `element`, but this was not possible as it there are some local variables also named `element`. Hence the renames in the PR, but this is still not the whole set. Will do the rename in a later PR.
