### PR TITLE
Do not make a copy of PUB_CACHE, just create an empty one instead.

### DIFF
--- a/tool/task.dart
+++ b/tool/task.dart
@@ -9,7 +9,6 @@ import 'package:analyzer/file_system/physical_file_system.dart';
 import 'package:args/args.dart';
 import 'package:collection/collection.dart';
 import 'package:crypto/crypto.dart' as crypto;
-import 'package:dartdoc/src/io_utils.dart';
 import 'package:dartdoc/src/package_meta.dart';
 import 'package:path/path.dart' as path;
 import 'package:sass/sass.dart' as sass;
@@ -497,12 +496,7 @@ Future<void> docSdk({bool withStats = false}) async => _docSdk(
 Map<String, String> createThrowawayPubCache() {
   var pubCache = Directory.systemTemp.createTempSync('pubcache');
   var pubCacheBin = Directory(path.join(pubCache.path, 'bin'));
-  var defaultCache = Directory(_defaultPubCache);
-  if (defaultCache.existsSync()) {
-    io_utils.copy(defaultCache, pubCache);
-  } else {
-    pubCacheBin.createSync();
-  }
+  pubCacheBin.createSync();
   return Map.fromIterables([
     'PUB_CACHE',
     'PATH',
@@ -511,9 +505,6 @@ Map<String, String> createThrowawayPubCache() {
     [pubCacheBin.path, Platform.environment['PATH']].join(':'),
   ]);
 }
-
-final String _defaultPubCache = Platform.environment['PUB_CACHE'] ??
-    path.context.resolveTildePath('~/.pub-cache');
 
 Future<String> docTestingPackage({
   bool withStats = false,


### PR DESCRIPTION
Copying my 11GB `PUB_CACHE` crashed `createThrowawayPubCache`, something about `Link`. But fundamentally, it's probably almost as fast to just download the packages again.

And if we really want to avoid downloading the `PUB_CACHE` we could avoid `global activate`, or create a `PUB_CACHE` we can clone inside `.dart_tool/`.

But creating a copy of the default `PUB_CACHE` is not likely to be faster, and probably harder to do, since you can have entire git checkouts, and legacy packages that were extracted with system `tar` which might have symlinks inside them :see_no_evil: 

(You could also argue I should clean up my 11GB `PUB_CACHE`, :rofl:)