### PR TITLE
Remove use of deprecated parameter

### DIFF
--- a/lib/src/model/package_builder.dart
+++ b/lib/src/model/package_builder.dart
@@ -64,9 +64,8 @@ class PubPackageBuilder implements PackageBuilder {
       // of handling it ourselves?
       resourceProvider: packageMetaProvider.resourceProvider,
       sdkPath: config.sdkDir,
-      updateAnalysisOptions2: ({
+      updateAnalysisOptions3: ({
         required AnalysisOptionsImpl analysisOptions,
-        required ContextRoot contextRoot,
         required DartSdk sdk,
       }) =>
           analysisOptions


### PR DESCRIPTION
This removes the use of the deprecated parameter `updateAnalysisOptions2`, replacing it with `updateAnalysisOptions3`.

The new parameter takes a function with one fewer parameters, but we weren't using the old parameter anyway so there are no other changes required.