### PR TITLE
Remove use of deprecated parameter

### DIFF
--- a/lib/src/model/package_builder.dart
+++ b/lib/src/model/package_builder.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 
 import 'package:analyzer/dart/analysis/analysis_context.dart';
-import 'package:analyzer/dart/analysis/context_root.dart';
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/element/element2.dart';
@@ -64,9 +63,8 @@ class PubPackageBuilder implements PackageBuilder {
       // of handling it ourselves?
       resourceProvider: packageMetaProvider.resourceProvider,
       sdkPath: config.sdkDir,
-      updateAnalysisOptions2: ({
+      updateAnalysisOptions3: ({
         required AnalysisOptionsImpl analysisOptions,
-        required ContextRoot contextRoot,
         required DartSdk sdk,
       }) =>
           analysisOptions


### PR DESCRIPTION
This replaces the use of `updateAnalysisOptions2` with a use of `updateAnalysisOptions3`. The latter callback has one fewer parameter, but since we weren't using that parameter no other changes (other than import cleanup) are required.