### PR TITLE
Fix duplicate entries of elements in a category when re-exported.

### DIFF
--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -1541,7 +1541,7 @@ class _Renderer_Category extends RendererBase<Category> {
                         self.renderSimpleVariable(
                           c,
                           remainingNames,
-                          'List<TopLevelVariable>',
+                          'Set<TopLevelVariable>',
                         ),
 
                 renderIterable: (
@@ -1735,7 +1735,7 @@ class _Renderer_Category extends RendererBase<Category> {
                         self.renderSimpleVariable(
                           c,
                           remainingNames,
-                          'List<Enum>',
+                          'Set<Enum>',
                         ),
 
                 renderIterable: (
@@ -1777,7 +1777,7 @@ class _Renderer_Category extends RendererBase<Category> {
                         self.renderSimpleVariable(
                           c,
                           remainingNames,
-                          'List<ExtensionType>',
+                          'Set<ExtensionType>',
                         ),
 
                 renderIterable: (
@@ -1804,7 +1804,7 @@ class _Renderer_Category extends RendererBase<Category> {
                         self.renderSimpleVariable(
                           c,
                           remainingNames,
-                          'List<Extension>',
+                          'Set<Extension>',
                         ),
 
                 renderIterable: (
@@ -1917,7 +1917,7 @@ class _Renderer_Category extends RendererBase<Category> {
                         self.renderSimpleVariable(
                           c,
                           remainingNames,
-                          'List<ModelFunction>',
+                          'Set<ModelFunction>',
                         ),
 
                 renderIterable: (
@@ -2054,7 +2054,7 @@ class _Renderer_Category extends RendererBase<Category> {
                         self.renderSimpleVariable(
                           c,
                           remainingNames,
-                          'List<Mixin>',
+                          'Set<Mixin>',
                         ),
 
                 renderIterable: (
@@ -2167,7 +2167,7 @@ class _Renderer_Category extends RendererBase<Category> {
                         self.renderSimpleVariable(
                           c,
                           remainingNames,
-                          'List<TopLevelVariable>',
+                          'Set<TopLevelVariable>',
                         ),
 
                 renderIterable: (
@@ -2320,7 +2320,7 @@ class _Renderer_Category extends RendererBase<Category> {
                         self.renderSimpleVariable(
                           c,
                           remainingNames,
-                          'List<Typedef>',
+                          'Set<Typedef>',
                         ),
 
                 renderIterable: (

--- a/lib/src/model/category.dart
+++ b/lib/src/model/category.dart
@@ -32,33 +32,33 @@ class Category
   @override
   final DartdocOptionContext config;
 
-  final List<Class> _classes = [];
+  final Set<Class> _classes = {};
 
-  final List<Class> _exceptions = [];
-
-  @override
-  final List<TopLevelVariable> constants = [];
+  final Set<Class> _exceptions = {};
 
   @override
-  final List<Extension> extensions = [];
+  final Set<TopLevelVariable> constants = {};
 
   @override
-  final List<ExtensionType> extensionTypes = [];
+  final Set<Extension> extensions = {};
 
   @override
-  final List<Enum> enums = [];
+  final Set<ExtensionType> extensionTypes = {};
 
   @override
-  final List<ModelFunction> functions = [];
+  final Set<Enum> enums = {};
 
   @override
-  final List<Mixin> mixins = [];
+  final Set<ModelFunction> functions = {};
 
   @override
-  final List<TopLevelVariable> properties = [];
+  final Set<Mixin> mixins = {};
 
   @override
-  final List<Typedef> typedefs = [];
+  final Set<TopLevelVariable> properties = {};
+
+  @override
+  final Set<Typedef> typedefs = {};
 
   final CategoryDefinition _categoryDefinition;
 

--- a/test/end2end/model_special_cases_test.dart
+++ b/test/end2end/model_special_cases_test.dart
@@ -393,6 +393,25 @@ void main() {
       expect(SubForDocComments.categories.first.isDocumented, isFalse);
       expect(SubForDocComments.displayedCategories, isEmpty);
     });
+
+    test('No duplicate entries', () {
+      final categories = ginormousPackageGraph.localPackages
+          .firstWhere((p) => p.name == 'test_package')
+          .categories;
+      for (final c in categories) {
+        expect(c.classes.length, equals(c.classes.toSet().length));
+        expect(c.exceptions.length, equals(c.exceptions.toSet().length));
+        expect(c.extensions.length, equals(c.extensions.toSet().length));
+        expect(
+            c.extensionTypes.length, equals(c.extensionTypes.toSet().length));
+        expect(c.enums.length, equals(c.enums.toSet().length));
+        expect(c.mixins.length, equals(c.mixins.toSet().length));
+        expect(c.constants.length, equals(c.constants.toSet().length));
+        expect(c.properties.length, equals(c.properties.toSet().length));
+        expect(c.functions.length, equals(c.functions.toSet().length));
+        expect(c.typedefs.length, equals(c.typedefs.toSet().length));
+      }
+    });
   });
 
   group('Package', () {

--- a/test/templates/category_test.dart
+++ b/test/templates/category_test.dart
@@ -125,7 +125,9 @@ extension type ExType(int it) {}
 '''),
         d.file('other.dart', '''
 /// {@category Documented}
-library;      
+library;
+
+export 'lib.dart' show C1, E1;
 '''),
       ],
       files: [
@@ -229,6 +231,15 @@ library;
     );
   });
 
+  test('classes are not duplicated', () async {
+    expect(
+      topicOneLines
+          .where((l) => l.contains('<a href="../lib/C1-class.html">C1</a>')),
+      // Once in the sidebar and once in the main body
+      hasLength(2),
+    );
+  });
+
   test('sidebar contains enums', () async {
     expect(
       topicOneLines,
@@ -237,6 +248,14 @@ library;
         matches('<a href="../topics/cat1-topic.html#enums">Enums</a>'),
         matches('<a href="../lib/E1.html">E1</a>'),
       ]),
+    );
+  });
+
+  test('enums are not duplicated', () async {
+    expect(
+      topicOneLines.where((l) => l.contains('<a href="../lib/E1.html">E1</a>')),
+      // Once in the sidebar and once in the main body
+      hasLength(2),
     );
   });
 

--- a/testing/test_package/lib/src/somelib.dart
+++ b/testing/test_package/lib/src/somelib.dart
@@ -1,5 +1,6 @@
 library reexport.somelib;
 
+/// {@category Unreal}
 class SomeClass {}
 
 class SomeOtherClass {}


### PR DESCRIPTION
If a package has two libraries `foo.dart` and `bar.dart` where
 * `foo.dart` contains `Foo` with an `/// {@category ...}` annotation, and,
 * `bar.dart` re-exports `foo.dart`.

Then the category page shall not list `Foo` twice, which is simply a bug.

This change fixes this issue.

--------

There is an example of the issue in production here:
https://pub.dev/documentation/typed_sql/latest/topics/Exceptions-topic.html

![image](https://github.com/user-attachments/assets/04c05459-114b-4f9b-b79c-7c0c480e877f)
