### PR TITLE
Remove analyzer_use_new_elements from analysis_options.yaml

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -18,7 +18,6 @@ linter:
   rules:
     - always_declare_return_types
     - always_put_required_named_parameters_first
-    - analyzer_use_new_elements
     - avoid_bool_literals_in_conditional_expressions
     - avoid_catching_errors
     - avoid_dynamic_calls


### PR DESCRIPTION
It was removed from the sdk in https://dart-review.googlesource.com/c/sdk/+/426980, so broke our CI.
