### PR TITLE
Simplify InheritingContainer wrt inherited elements

### DIFF
--- a/lib/src/generator/templates.runtime_renderers.dart
+++ b/lib/src/generator/templates.runtime_renderers.dart
@@ -7213,14 +7213,6 @@ class _Renderer_Enum extends RendererBase<Enum> {
                       );
                     },
               ),
-              'hasPublicEnumValues': Property(
-                getValue: (CT_ c) => c.hasPublicEnumValues,
-                renderVariable:
-                    (CT_ c, Property<CT_> self, List<String> remainingNames) =>
-                        self.renderSimpleVariable(c, remainingNames, 'bool'),
-
-                getBool: (CT_ c) => c.hasPublicEnumValues,
-              ),
               'inheritanceChain': Property(
                 getValue: (CT_ c) => c.inheritanceChain,
                 renderVariable:
@@ -11498,29 +11490,6 @@ class _Renderer_InheritingContainer extends RendererBase<InheritingContainer> {
             CT_,
             () => {
               ..._Renderer_Container.propertyMap<CT_>(),
-              'allFields': Property(
-                getValue: (CT_ c) => c.allFields,
-                renderVariable:
-                    (CT_ c, Property<CT_> self, List<String> remainingNames) =>
-                        self.renderSimpleVariable(
-                          c,
-                          remainingNames,
-                          'List<Field>',
-                        ),
-
-                renderIterable:
-                    (
-                      CT_ c,
-                      RendererBase<CT_> r,
-                      List<MustachioNode> ast,
-                      StringSink sink,
-                    ) {
-                      return c.allFields.map(
-                        (e) =>
-                            _render_Field(e, ast, r.template, sink, parent: r),
-                      );
-                    },
-              ),
               'allModelElements': Property(
                 getValue: (CT_ c) => c.allModelElements,
                 renderVariable:
@@ -11944,57 +11913,6 @@ class _Renderer_InheritingContainer extends RendererBase<InheritingContainer> {
                     ) {
                       return c.inheritanceChain.map(
                         (e) => _render_InheritingContainer(
-                          e,
-                          ast,
-                          r.template,
-                          sink,
-                          parent: r,
-                        ),
-                      );
-                    },
-              ),
-              'inheritedMethods': Property(
-                getValue: (CT_ c) => c.inheritedMethods,
-                renderVariable:
-                    (CT_ c, Property<CT_> self, List<String> remainingNames) =>
-                        self.renderSimpleVariable(
-                          c,
-                          remainingNames,
-                          'Iterable<Method>',
-                        ),
-
-                renderIterable:
-                    (
-                      CT_ c,
-                      RendererBase<CT_> r,
-                      List<MustachioNode> ast,
-                      StringSink sink,
-                    ) {
-                      return c.inheritedMethods.map(
-                        (e) =>
-                            _render_Method(e, ast, r.template, sink, parent: r),
-                      );
-                    },
-              ),
-              'inheritedOperators': Property(
-                getValue: (CT_ c) => c.inheritedOperators,
-                renderVariable:
-                    (CT_ c, Property<CT_> self, List<String> remainingNames) =>
-                        self.renderSimpleVariable(
-                          c,
-                          remainingNames,
-                          'List<Operator>',
-                        ),
-
-                renderIterable:
-                    (
-                      CT_ c,
-                      RendererBase<CT_> r,
-                      List<MustachioNode> ast,
-                      StringSink sink,
-                    ) {
-                      return c.inheritedOperators.map(
-                        (e) => _render_Operator(
                           e,
                           ast,
                           r.template,
@@ -14263,7 +14181,7 @@ class _Renderer_LibraryContainer extends RendererBase<LibraryContainer> {
   }
 }
 
-String renderLibraryRedirect(LibraryTemplateData context, Template template) {
+String renderLibrary(LibraryTemplateData context, Template template) {
   var buffer = StringBuffer();
   _render_LibraryTemplateData(context, template.ast, template, buffer);
   return buffer.toString();
@@ -14501,7 +14419,7 @@ class _Renderer_LibraryTemplateData extends RendererBase<LibraryTemplateData> {
   }
 }
 
-String renderLibrary(LibraryTemplateData context, Template template) {
+String renderLibraryRedirect(LibraryTemplateData context, Template template) {
   var buffer = StringBuffer();
   _render_LibraryTemplateData(context, template.ast, template, buffer);
   return buffer.toString();
@@ -20021,7 +19939,7 @@ class _Renderer_Package extends RendererBase<Package> {
   }
 }
 
-String renderSearchPage(PackageTemplateData context, Template template) {
+String renderIndex(PackageTemplateData context, Template template) {
   var buffer = StringBuffer();
   _render_PackageTemplateData(context, template.ast, template, buffer);
   return buffer.toString();
@@ -20379,7 +20297,7 @@ class _Renderer_PackageTemplateData extends RendererBase<PackageTemplateData> {
   }
 }
 
-String renderIndex(PackageTemplateData context, Template template) {
+String renderSearchPage(PackageTemplateData context, Template template) {
   var buffer = StringBuffer();
   _render_PackageTemplateData(context, template.ast, template, buffer);
   return buffer.toString();

--- a/lib/src/model/enum.dart
+++ b/lib/src/model/enum.dart
@@ -6,11 +6,9 @@ import 'package:analyzer/dart/analysis/features.dart';
 import 'package:analyzer/dart/element/element2.dart';
 import 'package:dartdoc/src/model/kind.dart';
 import 'package:dartdoc/src/model/model.dart';
-import 'package:dartdoc/src/model_utils.dart' as model_utils;
 import 'package:meta/meta.dart';
 
 class Enum extends InheritingContainer with Constructable, MixedInTypes {
- 
   @override
   final EnumElement2 element;
 
@@ -51,12 +49,12 @@ class Enum extends InheritingContainer with Constructable, MixedInTypes {
       declaredFields.where((f) => f is! EnumField && f.isConst);
 
   @override
-  late final List<Field> publicEnumValues =
-      allFields.whereType<EnumField>().wherePublic.toList(growable: false);
-
-  @override
-  bool get hasPublicEnumValues =>
-      allFields.whereType<EnumField>().any((e) => e.isPublic);
+  late final List<Field> publicEnumValues = [
+    for (var value in element.constants2)
+      getModelForPropertyInducingElement(value, library,
+          getter: getModelFor(value.getter2!, library) as ContainerAccessor,
+          setter: null) as Field
+  ];
 
   @override
   bool get isAbstract => false;

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -243,7 +243,7 @@ void main() async {
     test('typedef references display aliases', () {
       var g = C.instanceMethods.named('g');
 
-      var c = C2.allFields.named('c');
+      var c = C2.declaredFields.named('c');
       var d = C2.instanceMethods.named('d');
 
       expectAliasedTypeName(c.modelType as Aliased, equals('T1'));
@@ -263,8 +263,8 @@ void main() async {
     test('typedef references to special types work',
         skip: 'dart-lang/sdk#45291', () {
       var a = generalizedTypedefs.properties.named('a');
-      var b = C2.allFields.named('b');
-      var f = C.allFields.named('f');
+      var b = C2.declaredFields.named('b');
+      var f = C.declaredFields.named('f');
       expectAliasedTypeName(a.modelType as Aliased, equals('T0'));
       expectAliasedTypeName(b.modelType as Aliased, equals('T0'));
       expectAliasedTypeName(f.modelType as Aliased, equals('T0'));
@@ -1699,7 +1699,7 @@ void main() async {
       var MixedInImplementation =
           fakeLibrary.classes.wherePublic.named('MixedInImplementation');
       var MixInImplementation = fakeLibrary.mixins.named('MixInImplementation');
-      var mixinGetter = MixInImplementation.allFields.named('mixinGetter');
+      var mixinGetter = MixInImplementation.instanceFields.named('mixinGetter');
 
       expect(ThingToImplementInMixin.hasModifiers, isTrue);
       expect(MixInImplementation.hasModifiers, isTrue);
@@ -1713,7 +1713,7 @@ void main() async {
         orderedEquals([MixedInImplementation]),
       );
       expect(
-        MixedInImplementation.allFields
+        MixedInImplementation.inheritedFields
             .named('mixinGetter')
             .canonicalModelElement,
         equals(mixinGetter),
@@ -2118,7 +2118,7 @@ void main() async {
         T8 = generalizedTypedefs.typedefs.named('T8');
         C1 = generalizedTypedefs.classes.named('C1');
         C2 = generalizedTypedefs.classes.named('C2');
-        C1a = C1.allFields.named('a');
+        C1a = C1.declaredFields.named('a');
       });
 
       test('Verify basic ability to link anything', () {
@@ -2178,8 +2178,8 @@ void main() async {
         // This group tests lookups from the perspective of the reexported
         // elements, to verify that various fallbacks work correctly.
         ExtendingAgain = two_exports.classes.named('ExtendingAgain');
-        aField = ExtendingAgain.allFields.named('aField');
-        anotherField = ExtendingAgain.allFields.named('anotherField');
+        aField = ExtendingAgain.inheritedFields.named('aField');
+        anotherField = ExtendingAgain.declaredFields.named('anotherField');
 
         aNotReexportedVariable =
             local_scope.properties.named('aNotReexportedVariable');
@@ -2397,9 +2397,9 @@ void main() async {
             baseForDocComments.constructors.named('BaseForDocComments.new');
         somethingShadowyParameter =
             defaultConstructor.parameters.named('somethingShadowy');
-        initializeMe = baseForDocComments.allFields.named('initializeMe');
+        initializeMe = baseForDocComments.declaredFields.named('initializeMe');
         somethingShadowy =
-            baseForDocComments.allFields.named('somethingShadowy');
+            baseForDocComments.declaredFields.named('somethingShadowy');
         doAwesomeStuff =
             baseForDocComments.instanceMethods.named('doAwesomeStuff');
         anotherMethod =
@@ -2433,18 +2433,18 @@ void main() async {
         ExtraSpecialList = fakeLibrary.classes.named('ExtraSpecialList');
         forInheriting = fakeLibrary.classes
             .named('ImplicitProperties')
-            .allFields
+            .declaredFields
             .named('forInheriting');
         action = packageGraph.libraries
             .named('reexport.somelib')
             .classes
             .named('BaseReexported')
-            .allFields
+            .declaredFields
             .named('action');
         aConstructorShadowed = baseForDocComments.constructors
             .named('BaseForDocComments.aConstructorShadowed');
         aConstructorShadowedField =
-            baseForDocComments.allFields.named('aConstructorShadowed');
+            baseForDocComments.declaredFields.named('aConstructorShadowed');
 
         FactoryConstructorThings =
             fakeLibrary.classes.named('FactoryConstructorThings');
@@ -2462,11 +2462,11 @@ void main() async {
         differentName = anotherName.parameters.named('differentName');
         redHerring = anotherConstructor.parameters.named('redHerring');
 
-        aNameField = FactoryConstructorThings.allFields.named('aName');
+        aNameField = FactoryConstructorThings.declaredFields.named('aName');
         yetAnotherNameField =
-            FactoryConstructorThings.allFields.named('yetAnotherName');
+            FactoryConstructorThings.declaredFields.named('yetAnotherName');
         initViaFieldFormal =
-            FactoryConstructorThings.allFields.named('initViaFieldFormal');
+            FactoryConstructorThings.declaredFields.named('initViaFieldFormal');
 
         aMethod = FactoryConstructorThings.instanceMethods.named('aMethod');
         yetAnotherName = aMethod.parameters.named('yetAnotherName');
@@ -2499,7 +2499,7 @@ void main() async {
           expect(referenceLookup(FactoryConstructorThings, 'aName'),
               equals(MatchingLinkResult(aNameField)));
           var anotherNameField =
-              FactoryConstructorThings.allFields.named('anotherName');
+              FactoryConstructorThings.declaredFields.named('anotherName');
           expect(referenceLookup(FactoryConstructorThings, 'anotherName'),
               equals(MatchingLinkResult(anotherNameField)));
           expect(referenceLookup(FactoryConstructorThings, 'yetAnotherName'),
@@ -3645,13 +3645,14 @@ String? topLevelFunction(int param1, bool param2, Cool coolBeans,
 
       // classB has a variety of inherited and partially overridden fields.
       // All should have valid locations on their accessors.
-      for (var a in classB.allFields.expand(expandAccessors)) {
+      for (var a in classB.inheritedFields.expand(expandAccessors)) {
         expectValidLocation(a.characterLocation!);
       }
 
       // Enums also have fields and have historically had problems.
       var macrosFromAccessors = fakeLibrary.enums.named('MacrosFromAccessors');
-      for (var a in macrosFromAccessors.allFields.expand(expandAccessors)) {
+      for (var a
+          in macrosFromAccessors.inheritedFields.expand(expandAccessors)) {
         if (a.name == 'values') {
           continue;
         }
@@ -3791,7 +3792,7 @@ String? topLevelFunction(int param1, bool param2, Cool coolBeans,
       expect(
           exLibrary.classes
               .named('Apple')
-              .allFields
+              .instanceFields
               .named('internalField')
               .isPublic,
           isFalse);

--- a/test/enums_test.dart
+++ b/test/enums_test.dart
@@ -657,12 +657,9 @@ export 'src/library.dart';
 
   void test_values_haveIndices() async {
     var library = await bootPackageWithLibrary('enum E { one, two, three }');
-    var oneValue =
-        library.enums.named('E').publicEnumValues.named('one') as EnumField;
-    var twoValue =
-        library.enums.named('E').publicEnumValues.named('two') as EnumField;
-    var threeValue =
-        library.enums.named('E').publicEnumValues.named('three') as EnumField;
+    var oneValue = library.enums.named('E').publicEnumValues.named('one');
+    var twoValue = library.enums.named('E').publicEnumValues.named('two');
+    var threeValue = library.enums.named('E').publicEnumValues.named('three');
 
     // TODO(srawlins): These should link back to the E enum. Something like
     // `'const <a href="$linkPrefix/E/E.html">E</a>(0)'`.

--- a/test/options_test.dart
+++ b/test/options_test.dart
@@ -225,7 +225,7 @@ class Foo {
     final foo =
         packageGraph.localPackages.first.libraries.first.classes.named('Foo');
     // The name is not linked, but also does not error.
-    expect(foo.allFields.first.modelType.linkedName, 'Client?');
+    expect(foo.declaredFields.first.modelType.linkedName, 'Client?');
   }
 
   void test_includeCommandLineOption_overridesOptionsFileOption() async {


### PR DESCRIPTION
While working with analyzer's InheritanceManager3, I noticed there was a fair bit of code in dartdoc's InheritingContainer that could be simplified. The `_inheritedElements` field is relied on by `inheritedMethods`, `inheritedOperators`, and `allFields`. It performs some calculations to come up with the collection of inherited elements using its own homegrown dartdoc logic, but this logic exists in the analyzer APIs on `InterfaceElement`. We can basically replace this field with access to `element.inheritedElements`.

While investigating, I found that I could make a few members `@visibleForTesting`: `inheritedMethods`, `inheritedOperators`. Also `allFields` can be made private. And `Enum.hasPublicEnumValues` can be removed, as it is the same as the super implementation. This leads to all of the deleted code in `templates.runtime_renderers.dart`.