### PR TITLE
Elements. element.lookupName can be null, use empty string then.

### DIFF
--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -725,7 +725,7 @@ abstract class ModelElement
       _parameterRenderer.renderLinkedParams(parameters, showMetadata: false);
 
   @override
-  String get name => element.lookupName!;
+  String get name => element.lookupName ?? '';
 
   @override
   String get oneLineDoc => elementDocumentation.asOneLiner;


### PR DESCRIPTION
Found during https://dart-review.googlesource.com/c/sdk/+/432125