### PR TITLE
Remove "parsedConstructorHint" from "PrefixResultType"

### DIFF
--- a/lib/src/comment_references/parser.dart
+++ b/lib/src/comment_references/parser.dart
@@ -110,9 +110,6 @@ class CommentReferenceParser {
     if (prefixResult.type == _PrefixResultType.endOfFile) {
       return [];
     }
-    if (prefixResult.type == _PrefixResultType.parsedConstructorHint) {
-      children.add(prefixResult.node!);
-    }
     // [_PrefixResultType.junk] and [_PrefixResultType.missing] we can skip.
 
     // <commentReference>
@@ -370,7 +367,6 @@ enum _PrefixResultType {
   endOfFile, // Found end of file instead of a prefix.
   junk, // Found some recognized junk that can be ignored.
   missing, // There is no prefix here.
-  parsedConstructorHint, // Parsed a [ConstructorHintStartNode].
 }
 
 /// The result of attempting to parse a prefix to a comment reference.

--- a/test/comment_referable/parser_test.dart
+++ b/test/comment_referable/parser_test.dart
@@ -7,7 +7,7 @@ import 'package:test/test.dart';
 
 void main() {
   void expectParseEquivalent(String codeRef, List<String> parts,
-      {bool constructorHint = false, bool callableHint = false}) {
+      {bool callableHint = false}) {
     var result = CommentReferenceParser(codeRef).parse();
     var hasCallableHint =
         result.isNotEmpty && result.last is CallableHintEndNode;


### PR DESCRIPTION
I stumbled across this which, I believe, is from when we supported leading "new" in comment references. 