### PR TITLE
Undo deprecation of api exports

### DIFF
--- a/lib/dartdoc.dart
+++ b/lib/dartdoc.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// A documentation generator for Dart.
-@Deprecated('Will be removed in a later version of DartDoc.')
 library;
 
 export 'package:dartdoc/src/dartdoc.dart';


### PR DESCRIPTION
Preparing for 9.0.0

We will not be removing these exports anytime soon, so we are reversing the deprecation for now. 