### PR TITLE
Stop using TypeDefiningElement.

### DIFF
--- a/lib/src/element_type.dart
+++ b/lib/src/element_type.dart
@@ -34,7 +34,7 @@ abstract class ElementType with CommentReferable, Nameable {
   factory ElementType.for_(
       DartType type, Library library, PackageGraph packageGraph) {
     runtimeStats.incrementAccumulator('elementTypeInstantiation');
-    var fElement = type.documentableElement2;
+    var fElement = type.documentableElement;
     if (fElement == null ||
         fElement.kind == ElementKind.DYNAMIC ||
         fElement.kind == ElementKind.NEVER) {
@@ -102,9 +102,9 @@ class UndefinedElementType extends ElementType {
     // We can not simply throw here because not all SDK libraries resolve
     // all types.
     if (type is InvalidType) return 'dynamic';
-    assert(const {'Never'}.contains(type.documentableElement2?.name),
+    assert(const {'Never'}.contains(type.documentableElement?.name),
         'Unrecognized type for UndefinedElementType: $type');
-    return type.documentableElement2!.name!;
+    return type.documentableElement!.name!;
   }
 
   @override
@@ -288,7 +288,7 @@ abstract class DefinedElementType extends ElementType {
   }
 
   @override
-  String get name => type.documentableElement2!.name!;
+  String get name => type.documentableElement!.name!;
 
   @override
   String get fullyQualifiedName => modelElement.fullyQualifiedName;

--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -295,7 +295,7 @@ abstract class ModelElement
       TypeAliasElement(aliasedType: FunctionType()) =>
         FunctionTypedef(e, library, packageGraph),
       TypeAliasElement()
-          when e.aliasedType.documentableElement2 is InterfaceElement =>
+          when e.aliasedType.documentableElement is InterfaceElement =>
         ClassTypedef(e, library, packageGraph),
       TypeAliasElement() => GeneralizedTypedef(e, library, packageGraph),
       MethodElement(isOperator: true) when enclosingContainer == null =>

--- a/lib/src/type_utils.dart
+++ b/lib/src/type_utils.dart
@@ -6,16 +6,16 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 
 extension DartTypeExtension on DartType {
-  /// The static element associataed with this type, where documentable, and
+  /// The static element associated with this type, where documentable, and
   /// `null` otherwise.
   ///
   /// For example, the documentable element of [DynamicType] is `null`, as there
   /// is no documentation for `dynamic` which we can link to.
-  TypeDefiningElement? get documentableElement2 {
+  Element? get documentableElement {
     final self = this;
     return switch (self) {
       InterfaceType() => self.element,
-      NeverType() => self.element as TypeDefiningElement,
+      NeverType() => self.element,
       TypeParameterType() => self.element,
       _ => null
     };

--- a/tool/mustachio/codegen_aot_compiler.dart
+++ b/tool/mustachio/codegen_aot_compiler.dart
@@ -935,7 +935,7 @@ extension on StringBuffer {
       if (bound == null) {
         write(typeParameter.name);
       } else {
-        var boundElement = bound.documentableElement2!;
+        var boundElement = bound.documentableElement!;
         referencedElements.add(boundElement);
         write('${typeParameter.name} extends ${boundElement.name!}');
       }


### PR DESCRIPTION
I'd like to remove it from the analyzer's element model.
It does not look that it was used for something specific in DartDoc.

I also renamed `documentableElement2` into `documentableElement`.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
