### PR TITLE
Display constructor names in annotations

### DIFF
--- a/lib/src/model/annotation.dart
+++ b/lib/src/model/annotation.dart
@@ -5,6 +5,7 @@
 import 'dart:convert';
 
 import 'package:analyzer/dart/element/element.dart';
+// ignore: implementation_imports
 import 'package:analyzer/src/dart/element/member.dart';
 import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/model/attribute.dart';

--- a/lib/src/model/annotation.dart
+++ b/lib/src/model/annotation.dart
@@ -5,8 +5,7 @@
 import 'dart:convert';
 
 import 'package:analyzer/dart/element/element.dart';
-// ignore: implementation_imports
-import 'package:analyzer/src/dart/element/member.dart';
+import 'package:analyzer/dart/element/type.dart';
 import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/model/attribute.dart';
 import 'package:dartdoc/src/model/class.dart';
@@ -54,24 +53,25 @@ final class Annotation extends Attribute {
   /// The linked type argument text, with `<` and `>`, if there are any type
   /// arguments.
   String get _linkedTypeArguments {
-    var element = _annotation.element;
-    if (element is! SubstitutedConstructorElementImpl) {
+    if (_annotation.element is PropertyAccessorElement) {
+      return '';
+    }
+
+    var type = _modelType.type;
+    if (type is! InterfaceType) {
+      return '';
+    }
+
+    var typeArguments = type.typeArguments;
+    if (typeArguments.isEmpty) {
       return '';
     }
 
     var buffer = StringBuffer();
     buffer.write('&lt;');
-    var container = element.baseElement.enclosingElement;
-    for (var p in container.typeParameters) {
-      var type = element.substitution.map[p];
-      assert(type != null);
-      if (type == null) {
-        // Abandon this type arguments string, as something is wrong with the
-        // user's code.
-        return '';
-      }
-      buffer.write(_packageGraph.getTypeFor(type, _library).linkedName);
-      if (p != container.typeParameters.last) {
+    for (var t in typeArguments) {
+      buffer.write(_packageGraph.getTypeFor(t, _library).linkedName);
+      if (t != typeArguments.last) {
         buffer.write(', ');
       }
     }

--- a/lib/src/model/annotation.dart
+++ b/lib/src/model/annotation.dart
@@ -5,6 +5,7 @@
 import 'dart:convert';
 
 import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/src/dart/element/member.dart';
 import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/model/attribute.dart';
 import 'package:dartdoc/src/model/class.dart';
@@ -36,14 +37,46 @@ final class Annotation extends Attribute {
     var parameterText =
         source.substring(startIndex == -1 ? source.length : startIndex);
 
-    return '@$linkedName${const HtmlEscape().convert(parameterText)}';
+    var escapedParameterText = const HtmlEscape().convert(parameterText);
+    return '@$linkedName$_linkedTypeArguments$escapedParameterText';
   }
 
   @override
-  String get linkedName => _annotation.element is PropertyAccessorElement
-      ? _packageGraph.getModelForElement(_annotation.element!).linkedName
-      // TODO(jcollins-g): consider linking to constructor instead of type?
-      : _modelType.linkedName;
+  String get linkedName => switch (_annotation.element) {
+        PropertyAccessorElement element =>
+          _packageGraph.getModelForElement(element).linkedName,
+        ConstructorElement element =>
+          _packageGraph.getModelForElement(element).linkedName,
+        _ => _modelType.linkedName
+      };
+
+  /// The linked type argument text, with `<` and `>`, if there are any type
+  /// arguments.
+  String get _linkedTypeArguments {
+    var element = _annotation.element;
+    if (element is! SubstitutedConstructorElementImpl) {
+      return '';
+    }
+
+    var buffer = StringBuffer();
+    buffer.write('&lt;');
+    var container = element.baseElement.enclosingElement;
+    for (var p in container.typeParameters) {
+      var type = element.substitution.map[p];
+      assert(type != null);
+      if (type == null) {
+        // Abandon this type arguments string, as something is wrong with the
+        // user's code.
+        return '';
+      }
+      buffer.write(_packageGraph.getTypeFor(type, _library).linkedName);
+      if (p != container.typeParameters.last) {
+        buffer.write(', ');
+      }
+    }
+    buffer.write('&gt;');
+    return buffer.toString();
+  }
 
   late final ElementType _modelType = switch (_annotation.element) {
     ConstructorElement(:var returnType) =>

--- a/lib/src/model/constructor.dart
+++ b/lib/src/model/constructor.dart
@@ -92,8 +92,7 @@ class Constructor extends ModelElement with ContainerMember, TypeParameters {
   @override
   Kind get kind => Kind.constructor;
 
-  late final Callable modelType =
-      getTypeFor(element.type, library) as Callable;
+  late final Callable modelType = getTypeFor(element.type, library) as Callable;
 
   @override
   String get name =>
@@ -101,6 +100,11 @@ class Constructor extends ModelElement with ContainerMember, TypeParameters {
       // [name] around the conventions used in referenceChildren and replace
       // code there and elsewhere with simple references to the name.
       '${enclosingElement.name}.${element.name}';
+
+  @override
+  String get displayName => isUnnamedConstructor
+      ? enclosingElement.name
+      : '${enclosingElement.name}.${element.name}';
 
   @override
   String get nameWithGenerics {

--- a/test/annotations_test.dart
+++ b/test/annotations_test.dart
@@ -48,11 +48,11 @@ int value = 0;
     var annotation = valueVariable.annotations.single;
     expect(
       annotation.linkedName,
-      '<a href="$dartCoreUrlPrefix/Deprecated-class.html">Deprecated</a>',
+      '<a href="$dartCoreUrlPrefix/Deprecated/Deprecated.html">Deprecated</a>',
     );
     expect(
       annotation.linkedNameWithParameters,
-      '@<a href="$dartCoreUrlPrefix/Deprecated-class.html">Deprecated</a>'
+      '@<a href="$dartCoreUrlPrefix/Deprecated/Deprecated.html">Deprecated</a>'
       '(&#39;text&#39;)',
     );
   }
@@ -97,13 +97,37 @@ int value = 0;
     var annotation = valueVariable.annotations.single;
     expect(
       annotation.linkedName,
-      '<a href="${htmlBasePlaceholder}annotations/MyAnnotation-class.html">'
+      '<a href="${htmlBasePlaceholder}annotations/MyAnnotation/MyAnnotation.html">'
       'MyAnnotation</a>',
     );
     expect(
       annotation.linkedNameWithParameters,
-      '@<a href="${htmlBasePlaceholder}annotations/MyAnnotation-class.html">'
+      '@<a href="${htmlBasePlaceholder}annotations/MyAnnotation/MyAnnotation.html">'
       'MyAnnotation</a>(true)',
+    );
+  }
+
+  void test_locallyDeclaredConstructorCall_named() async {
+    var library = await bootPackageWithLibrary('''
+class MyAnnotation {
+  const MyAnnotation.named(bool b);
+}
+
+@MyAnnotation.named(true)
+int value = 0;
+''');
+    var valueVariable = library.properties.named('value');
+    expect(valueVariable.hasAnnotations, true);
+    var annotation = valueVariable.annotations.single;
+    expect(
+      annotation.linkedName,
+      '<a href="${htmlBasePlaceholder}annotations/MyAnnotation/MyAnnotation.named.html">'
+      'MyAnnotation.named</a>',
+    );
+    expect(
+      annotation.linkedNameWithParameters,
+      '@<a href="${htmlBasePlaceholder}annotations/MyAnnotation/MyAnnotation.named.html">'
+      'MyAnnotation.named</a>(true)',
     );
   }
 
@@ -122,15 +146,13 @@ int value = 0;
     var annotation = valueVariable.annotations.single;
     expect(
       annotation.linkedName,
-      '<a href="${htmlBasePlaceholder}annotations/Ann-class.html">Ann</a>'
-      '<span class="signature">&lt;<wbr><span class="type-parameter">'
-      '<a href="$dartCoreUrlPrefix/bool-class.html">bool</a></span>&gt;</span>',
+      '<a href="${htmlBasePlaceholder}annotations/Ann/Ann.html">Ann</a>',
     );
     expect(
       annotation.linkedNameWithParameters,
-      '@<a href="${htmlBasePlaceholder}annotations/Ann-class.html">Ann</a>'
-      '<span class="signature">&lt;<wbr><span class="type-parameter">'
-      '<a href="$dartCoreUrlPrefix/bool-class.html">bool</a></span>&gt;</span>(true)',
+      '@<a href="${htmlBasePlaceholder}annotations/Ann/Ann.html">Ann</a>'
+      '&lt;<a href="$dartCoreUrlPrefix/bool-class.html">bool</a>&gt;'
+      '(true)',
     );
   }
 }

--- a/test/end2end/model_test.dart
+++ b/test/end2end/model_test.dart
@@ -190,7 +190,9 @@ void main() async {
     test('Verify type arguments on annotations renders, including parameters',
         () {
       var ab0 =
-          '@<a href="%%__HTMLBASE_dartdoc_internal__%%generic_metadata/A-class.html">A</a><span class="signature">&lt;<wbr><span class="type-parameter"><a href="%%__HTMLBASE_dartdoc_internal__%%generic_metadata/B.html">B</a></span>&gt;</span>(0)';
+          '@<a href="%%__HTMLBASE_dartdoc_internal__%%generic_metadata/A/A.html">A</a>'
+          '&lt;<a href="%%__HTMLBASE_dartdoc_internal__%%generic_metadata/B.html">B</a>&gt;'
+          '(0)';
 
       expect(genericMetadata.annotations.first.linkedNameWithParameters,
           equals(ab0));

--- a/test/enums_test.dart
+++ b/test/enums_test.dart
@@ -207,7 +207,7 @@ enum E { one, two, three }
     expect(eEnum.hasAnnotations, true);
     expect(eEnum.annotations, hasLength(1));
     expect(eEnum.annotations.single.linkedName,
-        '<a href="$linkPrefix/C-class.html">C</a>');
+        '<a href="$linkPrefix/C/C.html">C</a>');
   }
 
   void test_hasDocComment() async {

--- a/test/templates/class_test.dart
+++ b/test/templates/class_test.dart
@@ -218,7 +218,7 @@ class C {
 
     htmlLines.expectMainContentContainsAllInOrder([
       matches('<h2>Constructors</h2>'),
-      matches('<a href="../lib/C/C.html">C.new</a>'),
+      matches('<a href="../lib/C/C.html">C</a>'),
       matches('An unnamed constructor.'),
     ]);
   }

--- a/test/templates/enum_test.dart
+++ b/test/templates/enum_test.dart
@@ -180,7 +180,7 @@ extension Ext<T> on E<T> {}
         matches('<dt>Annotations</dt>'),
         matches('<ul class="annotation-list eNum-relationships">'),
         matches(
-            r'<li>@<a href="../lib/C-class.html">C</a>\(&#39;message&#39;\)</li>'),
+            r'<li>@<a href="../lib/C/C.html">C</a>&lt;dynamic&gt;\(&#39;message&#39;\)</li>'),
         matches('</ul>'),
       ]);
     });

--- a/test/templates/extension_type_test.dart
+++ b/test/templates/extension_type_test.dart
@@ -166,7 +166,7 @@ extension type One(int it) {
 
     htmlLines.expectMainContentContainsAllInOrder([
       matches('<h2>Constructors</h2>'),
-      matches('<a href="../lib/One/One.html">One.new</a>'),
+      matches('<a href="../lib/One/One.html">One</a>'),
       matches('<a href="../lib/One/One.named.html">One.named</a>'),
       matches('A named constructor.'),
     ]);

--- a/test/templates/field_test.dart
+++ b/test/templates/field_test.dart
@@ -54,7 +54,7 @@ class A {
         matches('<ol class="annotation-list">'),
         matches('<li>@deprecated</li>'),
         matches(
-            r'<li>@<a href="../../lib/A-class.html">A</a>\(&#39;message&#39;\)</li>'),
+            r'<li>@<a href="../../lib/A/A.html">A</a>\(&#39;message&#39;\)</li>'),
         matches('</ol>'),
       ],
     );

--- a/test/templates/method_test.dart
+++ b/test/templates/method_test.dart
@@ -6,7 +6,6 @@ import 'package:test/test.dart';
 import 'package:test_reflective_loader/test_reflective_loader.dart';
 
 import '../src/utils.dart';
-
 import 'template_test_base.dart';
 
 void main() async {
@@ -53,7 +52,7 @@ class C {
         matches('<ol class="annotation-list">'),
         matches('<li>@deprecated</li>'),
         matches(
-            r'<li>@<a href="../../lib/A-class.html">A</a>\(&#39;message&#39;\)</li>'),
+            r'<li>@<a href="../../lib/A/A.html">A</a>\(&#39;message&#39;\)</li>'),
         matches('</ol>'),
       ],
     );


### PR DESCRIPTION
Two changes in one here:

* I saw in manual testing that a class annotated with `@Deprecated.extend()` was shown in dartdoc's HTML to just be annotated with `@Deprecated`. 🤕 ouch. Dunno how that has been the case for so many years; I guess named constructors are not used too much in annotations 🤷 . So this PR makes dartdoc use the _constructor_ involved (`Deprecated.extend`) instead of the _type_ which is constructed (`Deprecated`).
* _However_, that change makes all regular `@Deprecated("reason")` annotations be printed as `@Deprecated.new("reason")`. That `.new` looks _very non-idiomatic_. Gross. So I coupled another change here where we override `displayName` on `Constructor` to _not_ include `.new` if we're looking at an unnamed constructor.

This should be good to go. We might deprecate extending `RegExp` and `RegExpMatch` in Dart 3.10; it'd be cool if we displayed the deprecated annotations correctly for this release. Note that as per https://github.com/dart-lang/dartdoc/commit/669b15f7da5da04a38e95e8ac0ff6471697a549f, we won't show the element as ~~struck through~~, so the release is safe. But this PR would be a cherry on top.

Fixes https://github.com/dart-lang/dartdoc/issues/4107