### PR TITLE
Pass 'withFineDependencies: true' to AnalysisContextCollectionImpl.

### DIFF
--- a/lib/src/model/package_builder.dart
+++ b/lib/src/model/package_builder.dart
@@ -65,6 +65,7 @@ class PubPackageBuilder implements PackageBuilder {
           analysisOptions
             ..warning = false
             ..lint = false,
+      withFineDependencies: true,
     );
     return PubPackageBuilder._(
       config,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ^3.6.0
 
 dependencies:
-  analyzer: ^8.4.0
+  analyzer: ^9.0.0
   args: ^2.4.1
   collection: ^1.17.0
   crypto: ^3.0.3

--- a/test/mustachio/builder_test_base.dart
+++ b/test/mustachio/builder_test_base.dart
@@ -86,6 +86,7 @@ Future<LibraryElement> resolveGeneratedLibrary2(String libraryPath) async {
     // handling it ourselves?
     resourceProvider: PhysicalResourceProvider.INSTANCE,
     sdkPath: sdkPath,
+    withFineDependencies: true,
   );
   var analysisContext = contextCollection.contextFor(d.sandbox);
   final libraryResult =

--- a/tool/mustachio/builder.dart
+++ b/tool/mustachio/builder.dart
@@ -33,6 +33,7 @@ Future<void> build(
     // handling it ourselves?
     resourceProvider: PhysicalResourceProvider.INSTANCE,
     sdkPath: sdkPath,
+    withFineDependencies: true,
   );
   var analysisContext = contextCollection.contextFor(root);
   final libraryResult = await analysisContext.currentSession


### PR DESCRIPTION
I plan to make this formal parameter required.

Although it is sad that internal `AnalysisContextCollectionImpl` is used.