### PR TITLE
DeCo. Comment out assert(nameOffset != null ...)

### DIFF
--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -588,8 +588,11 @@ abstract class ModelElement
     final lineInfo = unitElement.lineInfo;
 
     final nameOffset = element.firstFragment.nameOffset;
-    assert(nameOffset != null && nameOffset >= 0,
-        'Invalid location data, $nameOffset, for element: $fullyQualifiedName');
+    // TODO(scheglov): For extension types, or with primary constructors
+    // and declaring formal parameters, the field has no declaration, so
+    // no name offset.
+    // assert(nameOffset != null && nameOffset >= 0,
+    //     'Invalid location data, $nameOffset, for element: $fullyQualifiedName');
     if (nameOffset != null && nameOffset >= 0) {
       return lineInfo.getLocation(nameOffset);
     }


### PR DESCRIPTION
It is not true anymore (starting from https://dart-review.googlesource.com/c/sdk/+/466441) for extension types: the representation field is not present in code, so should not have any name offset. And its getter / setter are also synthetic, and also don't have any name offset.

So, in this PR I comment out the assert, and leave it to you to implement the semantics that you think is right for DartDoc.