### PR TITLE
Simplify DocumentationComment.documentationFrom

### DIFF
--- a/lib/src/model/documentation_comment.dart
+++ b/lib/src/model/documentation_comment.dart
@@ -10,7 +10,6 @@ import 'package:args/args.dart';
 import 'package:crypto/crypto.dart' as crypto;
 import 'package:dartdoc/src/model/documentable.dart';
 import 'package:dartdoc/src/model/documentation.dart';
-import 'package:dartdoc/src/model/inheritable.dart';
 import 'package:dartdoc/src/model/locatable.dart';
 import 'package:dartdoc/src/model/model_element.dart';
 import 'package:dartdoc/src/model/source_code_mixin.dart';
@@ -43,23 +42,8 @@ mixin DocumentationComment
   @override
   Element get element;
 
-  List<DocumentationComment>? _documentationFrom;
-
   @override
-  List<DocumentationComment> get documentationFrom =>
-      _documentationFrom ??= () {
-        final self = this;
-        if (self is! Inheritable) {
-          return [this];
-        }
-        if (!hasDocumentationComment && self.overriddenElement != null) {
-          return self.overriddenElement!.documentationFrom;
-        } else if (self.isInherited) {
-          return packageGraph.getModelForElement(element).documentationFrom;
-        } else {
-          return [this];
-        }
-      }();
+  List<DocumentationComment> get documentationFrom => [this];
 
   @override
   late final String documentationAsHtml =

--- a/lib/src/model/inheritable.dart
+++ b/lib/src/model/inheritable.dart
@@ -37,6 +37,17 @@ mixin Inheritable on ContainerMember {
       };
 
   @override
+  List<DocumentationComment> get documentationFrom {
+    if (!hasDocumentationComment && overriddenElement != null) {
+      return overriddenElement!.documentationFrom;
+    } else if (isInherited) {
+      return packageGraph.getModelForElement(element).documentationFrom;
+    } else {
+      return super.documentationFrom;
+    }
+  }
+
+  @override
   Library? get canonicalLibrary =>
       canonicalEnclosingContainer?.canonicalLibrary;
 


### PR DESCRIPTION
Sometimes I find these funny impls in a class hierarchy, like this one, where the top impl says, "OK to calculate documentationFrom, first, am I an Inheritable? Oh do it this way. Otherwise do it another way." Ok... so let's just implement it the one way on the Inheritable mixin, and implement it the other way up top.

This also gets rid of the field, which should not be necessary.

This should be a no-op.