### PR TITLE
Simplify ModelElement.documentation overrides

### DIFF
--- a/lib/src/model/field.dart
+++ b/lib/src/model/field.dart
@@ -11,7 +11,6 @@ import 'package:dartdoc/src/model/model.dart';
 
 class Field extends ModelElement
     with GetterSetterCombo, ContainerMember, Inheritable {
- 
   @override
   final FieldElement element;
 
@@ -33,8 +32,7 @@ class Field extends ModelElement
     super.packageGraph,
     this.getter,
     this.setter,
-  )   :
-        isInherited = false,
+  )   : isInherited = false,
         enclosingElement =
             ModelElement.for_(element.enclosingElement, library, packageGraph)
                 as Container,
@@ -50,8 +48,7 @@ class Field extends ModelElement
     super.packageGraph,
     this.getter,
     this.setter,
-  )   :
-        isInherited = false,
+  )   : isInherited = false,
         assert(getter != null || setter != null) {
     getter?.enclosingCombo = this;
     setter?.enclosingCombo = this;
@@ -64,34 +61,13 @@ class Field extends ModelElement
     super.packageGraph,
     this.getter,
     this.setter,
-  )   : 
-        isInherited = true,
+  )   : isInherited = true,
         assert(getter != null || setter != null) {
     // Can't set `isInherited` to true if this is the defining element, because
     // that would mean it isn't inherited.
     assert(enclosingElement != definingEnclosingContainer);
     getter?.enclosingCombo = this;
     setter?.enclosingCombo = this;
-  }
-
-  @override
-  String get documentation {
-    if (enclosingElement is Enum) {
-      if (name == 'values') {
-        return 'A constant List of the values in this enum, in order of their declaration.';
-      } else if (name == 'index') {
-        return 'The integer index of this enum value.';
-      }
-    }
-
-    // Verify that [hasSetter] and [hasGetthasPublicGetterNoSettererNoSetter]
-    // are mutually exclusive, to prevent displaying more or less than one
-    // summary.
-    if (isPublic) {
-      assert((hasPublicSetter && !hasPublicGetterNoSetter) ||
-          (!hasPublicSetter && hasPublicGetterNoSetter));
-    }
-    return super.documentation;
   }
 
   @override
@@ -142,20 +118,21 @@ class Field extends ModelElement
     // Combo attributes can indicate 'inherited' and 'override' if either the
     // getter or setter has one of those properties, but that's not really
     // specific enough for [Field]s that have public getter/setters.
-    if (hasPublicGetter && hasPublicSetter) {
-      if (getter!.isInherited && setter!.isInherited) {
+    if ((getter, setter) case (var getter?, var setter?)
+        when getter.isPublic && setter.isPublic) {
+      if (getter.isInherited && setter.isInherited) {
         allAttributes.add(Attribute.inherited);
       } else {
         allAttributes.remove(Attribute.inherited);
-        if (getter!.isInherited) allAttributes.add(Attribute.inheritedGetter);
-        if (setter!.isInherited) allAttributes.add(Attribute.inheritedSetter);
+        if (getter.isInherited) allAttributes.add(Attribute.inheritedGetter);
+        if (setter.isInherited) allAttributes.add(Attribute.inheritedSetter);
       }
-      if (getter!.isOverride && setter!.isOverride) {
+      if (getter.isOverride && setter.isOverride) {
         allAttributes.add(Attribute.override_);
       } else {
         allAttributes.remove(Attribute.override_);
-        if (getter!.isOverride) allAttributes.add(Attribute.overrideGetter);
-        if (setter!.isOverride) allAttributes.add(Attribute.overrideSetter);
+        if (getter.isOverride) allAttributes.add(Attribute.overrideGetter);
+        if (setter.isOverride) allAttributes.add(Attribute.overrideSetter);
       }
     } else {
       if (isInherited) allAttributes.add(Attribute.inherited);

--- a/lib/src/model/top_level_variable.dart
+++ b/lib/src/model/top_level_variable.dart
@@ -11,7 +11,6 @@ import 'package:dartdoc/src/model/model.dart';
 /// Top-level variables. But also picks up getters and setters?
 class TopLevelVariable extends ModelElement
     with GetterSetterCombo, Categorization {
-
   @override
   final TopLevelVariableElement element;
 
@@ -20,25 +19,14 @@ class TopLevelVariable extends ModelElement
   @override
   final Accessor? setter;
 
-  TopLevelVariable(this.element, super.library, super.packageGraph,
-      this.getter, this.setter) {
+  TopLevelVariable(this.element, super.library, super.packageGraph, this.getter,
+      this.setter) {
     getter?.enclosingCombo = this;
     setter?.enclosingCombo = this;
   }
 
   @override
   bool get isInherited => false;
-
-  @override
-  String get documentation {
-    // Verify that hasSetter and hasGetterNoSetter are mutually exclusive,
-    // to prevent displaying more or less than one summary.
-    if (isPublic) {
-      var assertCheck = {hasPublicSetter, hasPublicGetterNoSetter};
-      assert(assertCheck.containsAll([true, false]));
-    }
-    return super.documentation;
-  }
 
   @override
   Library get enclosingElement => library;


### PR DESCRIPTION
I was looking through Field.documentation and TopLevelVariable.documentation, trying to understand why they'd have different implementations than just `ModelElement.documentation`. The only interesting new bit is `if (enclosingElement is Enum)`, and otherwise they call super. They _do both_ perform this weird check about public getters and setters. But there was a surprise bug! Let's look at the assert:

```dart
assert((hasPublicSetter && !hasPublicGetterNoSetter) ||
    (!hasPublicSetter && hasPublicGetterNoSetter));
```

with:

```dart
bool get hasPublicGetterNoSetter => hasPublicGetter && !hasPublicSetter;
```

What does that boil down to?

```dart
assert((hasPublicSetter && !hasPublicGetterNoSetter) ||
    (!hasPublicSetter && hasPublicGetterNoSetter));
                              |
                              v
assert((hasPublicSetter && !(hasPublicGetter && !hasPublicSetter)) ||
    (!hasPublicSetter && hasPublicGetter && !hasPublicSetter));
                              |
                              v
assert((hasPublicSetter && (!hasPublicGetter || hasPublicSetter)) ||
    (!hasPublicSetter && hasPublicGetter && !hasPublicSetter));
                              |
                              v
assert(true ||
    (!hasPublicSetter && hasPublicGetter));
                              |
                              v
assert(true);
```

So it seems like this assert never guarded against anything. It is safe to remove.

Beyond that, there are some other tidyings, where I hoist `.getter` and `.setter` to local variables so that they can be promoted.

* In `Field.attributes` there are 8 fewer null-asserts.
* `GetterSetterCombo.oneLineDoc` is simplified similarly with patterns, and then the calculations inside are clearly not expensive enough to warrant a `late final` field; instead we make it a getter and potentially save memory.

Also `GetterSetterCombo.hasPublicGetterNoSetter` is removed.