### PR TITLE
Refactor and simplify various .isPublic impls

### DIFF
--- a/lib/src/model/constructor.dart
+++ b/lib/src/model/constructor.dart
@@ -37,21 +37,18 @@ class Constructor extends ModelElement with ContainerMember, TypeParameters {
   bool get isPublic {
     if (!super.isPublic) return false;
     if (element.hasPrivateName) return false;
-    var class_ = element.enclosingElement;
-    // Enums cannot be explicitly constructed or extended.
-    if (class_ is EnumElement) return false;
-    if (class_ is ClassElement) {
-      if (element.isFactory) return true;
-      if (class_.isSealed ||
-          (class_.isAbstract && class_.isFinal) ||
-          (class_.isAbstract && class_.isInterface)) {
-        /// Sealed classes, abstract final classes, and abstract interface
-        /// classes, cannot be instantiated nor extended, from outside the
-        /// declaring library. Avoid documenting them.
-        return false;
-      }
-    }
-    return true;
+    return switch (element.enclosingElement) {
+      // Enums cannot be explicitly constructed or extended.
+      EnumElement() => false,
+      ClassElement() when element.isFactory => true,
+      // Sealed classes, abstract final classes, and abstract interface
+      // classes cannot be instantiated nor extended from outside the
+      // declaring library. Avoid documenting them.
+      ClassElement(isSealed: true) => false,
+      ClassElement(isAbstract: true, isFinal: true) => false,
+      ClassElement(isAbstract: true, isInterface: true) => false,
+      _ => true,
+    };
   }
 
   @override

--- a/lib/src/model/package.dart
+++ b/lib/src/model/package.dart
@@ -133,8 +133,8 @@ final class Package extends LibraryContainer
   bool get isDocumented =>
       isFirstPackage || documentedWhere != DocumentLocation.missing;
 
-  /// If we have public libraries, this is the default package, or we are
-  /// auto-including dependencies, this package is public.
+  /// If we have public libraries, this is the default package, or if we are
+  /// auto-including dependencies, then this package is public.
   @override
   bool get isPublic =>
       _isLocalPublicByDefault || libraries.any((l) => l.isPublic);


### PR DESCRIPTION
* `Constructor.isPublic` can be simplified with a switch expression.
* `Library.isPublic` was weird. It called `super.isPublic`, but that code is 90% not concerned with libraries (`if (this is! Library)`, `if (enclosingElement is Class)`, etc.). And then concerned specifically with Libraries in one block (`if (element case LibraryElement(:var uri, :var firstFragment))`. It seemed very confusing. So I made the following changes:
  * Do not call `super.isPublic` in `Library.isPublic`. It's simpler to contain all of the logic in `Library.isPublic`.
  * Move the LibraryElement-concerned code _out_ of `ModelElement.isPublic`, and _into_ `Library.isPublic`.
  * Copy some other basic code into `Library.isPublic`. All of the one-line `false` cases.
  * Remove `if (this is! Library)` and simplify the internal code: `this.canonicalLibrary` is potentially expensive, so instead get the `library == Library.sentinel` and `library.isPublic` cases out of the way first. This simplifies the if-conditions as well to not have so many pieces.