### PR TITLE
Handle private named parameters.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 9.1.0-dev
+* Show the corresponding public name for private named parameters.
+
 ## 9.0.0
 * Remove the deprecated `missingCodeBlockLanguage` warning.
 * Remove the deprecated `templates-dir` option.

--- a/lib/src/model/parameter.dart
+++ b/lib/src/model/parameter.dart
@@ -2,7 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/element/element.dart';
+import 'package:dartdoc/src/charcode.dart' show $z, $a, $dollar, $A;
 import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
 import 'package:dartdoc/src/model/kind.dart';
@@ -77,6 +79,27 @@ class Parameter extends ModelElement with HasNoPage {
 
   @override
   Kind get kind => Kind.parameter;
+
+  @override
+  String get name {
+    var name = element.lookupName;
+    // For private named parameters, use the corresponding public name
+    // for documentation.
+    // (TODO: Also do that even if the parameter isn't named, if the name isn't
+    // conflicted.)
+    if (element.isNamed &&
+        name != null &&
+        Identifier.isPrivateName(name) &&
+        name.length > 1) {
+      // Check if the remainder is a valid non-private identifier.
+      var nextChar = name.codeUnitAt(1);
+      var nextCharLower = nextChar | ($a ^ $A);
+      if (nextCharLower >= $a && nextCharLower <= $z || nextChar == $dollar) {
+        name = name.substring(1);
+      }
+    }
+    return name ?? '';
+  }
 
   @override
   late final Map<String, CommentReferable> referenceChildren = {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dartdoc
-version: 9.0.0
+version: 9.1.0-dev
 description: A non-interactive HTML documentation generator for Dart source code.
 repository: https://github.com/dart-lang/dartdoc
 

--- a/test/parameters_test.dart
+++ b/test/parameters_test.dart
@@ -157,6 +157,27 @@ class A {
       '''));
   }
 
+  void test_formalParameter_named_private() async {
+    var library = await bootPackageWithLibrary('''
+class A {
+  int? _f;
+  A.privateNamed({this._f});
+}
+''');
+    var privateNamed = library.constructor('A.privateNamed');
+
+    expect(privateNamed.linkedParams, matchesCompressed(r'''
+        \{
+        <span class="parameter" id="privateNamed-param-f">
+          <span class="type-annotation">
+            <a href=".*/dart-core/int-class\.html">int</a>\?
+          </span>
+          <span class="parameter-name">f</span>
+        </span>
+        \}
+      '''));
+  }
+
   void test_formalParameter_named_required() async {
     var library = await bootPackageWithLibrary('''
 class A {


### PR DESCRIPTION
Uses the corresponding public name for private named parameters. (If the program is valid, there won't be any conflicts.)

@munificent 
I had a look at the code, and it looked "easy" to make it work with private-named-parameters.

(But feel free to ignore, may want to wait if a later analyzer version will expose the correct name for you directly.)
