### PR TITLE
Tidy some interface nits

### DIFF
--- a/lib/src/model/category.dart
+++ b/lib/src/model/category.dart
@@ -17,8 +17,7 @@ final class Category extends LibraryContainer
         Warnable,
         CommentReferable,
         MarkdownFileDocumentation,
-        TopLevelContainer
-    implements Documentable {
+        TopLevelContainer {
   /// The package in which this category is contained.
   ///
   /// All libraries in [libraries] must come from [package].

--- a/lib/src/model/documentable.dart
+++ b/lib/src/model/documentable.dart
@@ -10,9 +10,9 @@ import 'package:dartdoc/src/warnings.dart';
 
 import 'model.dart';
 
-/// Bridges the gap between model elements and packages,
-/// both of which have documentation.
-abstract class Documentable with Nameable {
+/// An interface that bridges the gap between [ModelElement]s, [Category]s, and
+/// [Package]s, all of which have documentation, but in different forms.
+abstract interface class Documentable with Nameable {
   String? get documentation;
 
   String get documentationAsHtml;

--- a/lib/src/model/documentation_comment.dart
+++ b/lib/src/model/documentation_comment.dart
@@ -8,7 +8,6 @@ library;
 import 'package:analyzer/dart/element/element.dart';
 import 'package:args/args.dart';
 import 'package:crypto/crypto.dart' as crypto;
-import 'package:dartdoc/src/model/documentable.dart';
 import 'package:dartdoc/src/model/documentation.dart';
 import 'package:dartdoc/src/model/model_element.dart';
 import 'package:dartdoc/src/model/source_code_mixin.dart';
@@ -36,7 +35,7 @@ final _htmlInjectRegExp = RegExp(r'<dartdoc-html>([a-f0-9]+)</dartdoc-html>');
 ///
 /// [_processCommentWithoutTools] and [processComment] are the primary
 /// entrypoints.
-mixin DocumentationComment implements Documentable, Warnable, SourceCode {
+mixin DocumentationComment implements Warnable, SourceCode {
   @override
   Element get element;
 

--- a/lib/src/model/library_container.dart
+++ b/lib/src/model/library_container.dart
@@ -10,9 +10,8 @@ import 'package:meta/meta.dart';
 /// A set of libraries, initialized after construction by accessing [libraries].
 ///
 /// Do not cache return values of any methods or members excepting [libraries]
-/// and [name] before finishing initialization of a [LibraryContainer].
-abstract base class LibraryContainer
-    implements Nameable, Comparable<LibraryContainer>, Documentable {
+/// before finishing initialization of a [LibraryContainer].
+abstract base class LibraryContainer implements Comparable<LibraryContainer> {
   final List<Library> libraries = [];
 
   late final List<Library> publicLibrariesSorted =
@@ -36,7 +35,8 @@ abstract base class LibraryContainer
   /// Sorting key.
   ///
   /// [containerOrder] should contain these.
-  String get sortKey => name;
+  @visibleForOverriding
+  String get sortKey;
 
   /// Whether this container represents the Dart SDK.
   ///

--- a/lib/src/model/package.dart
+++ b/lib/src/model/package.dart
@@ -377,6 +377,9 @@ final class Package extends LibraryContainer
   List<String> get containerOrder => config.packageOrder;
 
   @override
+  String get sortKey => name;
+
+  @override
   late final Map<String, CommentReferable> referenceChildren = {
     // Do not override any preexisting data, and insert based on the public
     // library sort order.

--- a/lib/src/model/top_level_container.dart
+++ b/lib/src/model/top_level_container.dart
@@ -11,7 +11,7 @@ import 'package:dartdoc/src/model_utils.dart' as model_utils;
 ///
 /// Do not call any methods or members excepting [name] and the private Lists
 /// below before finishing initialization of a [TopLevelContainer].
-mixin TopLevelContainer implements Nameable {
+mixin TopLevelContainer {
   /// All top-level classes except those that subtype [Error] or [Exception].
   Iterable<Class> get classes;
 


### PR DESCRIPTION
All just nits, but simplifying the interfaces (as tangled as they are) makes things easier to understand:

* Category does not need to explicitly implement Documentable, because TopLevelContainer already does.
* Documentable is an interface class.
* DocumentationComment does not need to implement Documentable.
* LibraryContainer does not need to implement Nameable or Documentable.
* LibraryContainer.sortKey can be abstract, because it only needs to be additionally implemented by one subclass (Package); this change makes that more transparent.
* TopLevelContainer does not need to implement Nameable.