### PR TITLE
Reduce duplicate "visible annotation" code

### DIFF
--- a/lib/src/model/annotation.dart
+++ b/lib/src/model/annotation.dart
@@ -8,7 +8,6 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/model/attribute.dart';
-import 'package:dartdoc/src/model/class.dart';
 import 'package:dartdoc/src/model/getter_setter_combo.dart';
 import 'package:dartdoc/src/model/library.dart';
 import 'package:dartdoc/src/model/package_graph.dart';
@@ -89,19 +88,9 @@ final class Annotation extends Attribute {
         'non-callable element used as annotation?: ${_annotation.element}')
   };
 
-  bool get isPublic {
-    final modelType = _modelType;
-    if (!modelType.isPublic) {
-      return false;
-    }
-    if (modelType is! DefinedElementType) {
-      return false;
-    }
-
-    var modelElement = modelType.modelElement;
-    return modelElement is Class &&
-        _packageGraph.isAnnotationVisible(modelElement);
-  }
+  // We only construct Annotations which are public, as per
+  // [ModelElement.annotations].
+  bool get isPublic => true;
 
   @override
   bool operator ==(Object other) =>

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -672,10 +672,6 @@ class PackageGraph with CommentReferable, Nameable {
           ?.linkedName ??
       'Object';
 
-  bool isAnnotationVisible(Class class_) =>
-      class_.element.name == 'pragma' &&
-      class_.element.library.name == 'dart.core';
-
   @override
   String toString() {
     const divider = '=========================================================';


### PR DESCRIPTION
When I landed the recent code fix (https://github.com/dart-lang/dartdoc/pull/4163) for private annotations, I missed that there was already a spot in PackageGraph where we determine if an annotation is "visible."

This PR deduplicates that code into just one definition of "private annotation."