### PR TITLE
Heavily refactor how a Flutter Embedder SDK is discovered

### DIFF
--- a/lib/src/package_config_provider.dart
+++ b/lib/src/package_config_provider.dart
@@ -6,19 +6,62 @@ import 'dart:io' as io;
 
 import 'package:analyzer/file_system/file_system.dart';
 import 'package:package_config/package_config.dart' as package_config;
+import 'package:path/path.dart' as path;
 
 /// A provider of PackageConfig-finding methods.
 ///
 /// This provides an abstraction around package_config, which can only work
 /// with the physical file system.
 abstract class PackageConfigProvider {
-  Future<package_config.PackageConfig?> findPackageConfig(Folder dir);
+  package_config.PackageConfig? findPackageConfig(Folder dir);
 }
 
 class PhysicalPackageConfigProvider implements PackageConfigProvider {
   @override
-  Future<package_config.PackageConfig?> findPackageConfig(Folder dir) =>
-      package_config.findPackageConfig(io.Directory(dir.path));
+
+  /// Discovers the package configuration for a Dart script.
+  ///
+  /// This is a synchronous version of
+  /// [`findPackageConfig`](https://github.com/dart-lang/tools/blob/52cc9b5bb10e2293a094678815c2b4d13b1a3acf/pkgs/package_config/lib/src/discovery.dart#L34).
+  ///
+  /// See https://github.com/dart-lang/tools/issues/1536 for any progress on
+  /// synchronous APIs in the package_config package.
+  package_config.PackageConfig? findPackageConfig(Folder baseDirectory) {
+    var directory = io.Directory(baseDirectory.path);
+    if (!directory.isAbsolute) directory = directory.absolute;
+    if (!directory.existsSync()) return null;
+
+    do {
+      var packageConfig = findPackageConfigInDirectory(directory);
+      if (packageConfig != null) return packageConfig;
+      // Check in parent directories.
+      var parentDirectory = directory.parent;
+      if (parentDirectory.path == directory.path) break;
+      directory = parentDirectory;
+    } while (true);
+    return null;
+  }
+
+  /// Finds a `.dart_tool/package_config.json` file in [directory].
+  ///
+  /// This is a synchronous version of
+  /// [`findPackageConfigInDirectory`](https://github.com/dart-lang/tools/blob/52cc9b5bb10e2293a094678815c2b4d13b1a3acf/pkgs/package_config/lib/src/discovery.dart#L119C24-L119C52).
+  /// with `checkForPackageConfigJsonFile` inlined.
+  package_config.PackageConfig? findPackageConfigInDirectory(
+      io.Directory directory) {
+    var packageConfigFile =
+        io.File(path.join(directory.path, '.dart_tool', 'package_config.json'));
+    if (!packageConfigFile.existsSync()) return null;
+
+    var bytes = packageConfigFile.readAsBytesSync();
+    var config =
+        package_config.PackageConfig.parseBytes(bytes, packageConfigFile.uri);
+    if (config.version < _minVersion) return null;
+    return config;
+  }
+
+  /// The minimum "Package Config" version which we can parse.
+  static const _minVersion = 1;
 }
 
 class FakePackageConfigProvider implements PackageConfigProvider {
@@ -34,7 +77,7 @@ class FakePackageConfigProvider implements PackageConfigProvider {
   }
 
   @override
-  Future<package_config.PackageConfig> findPackageConfig(Folder dir) async {
+  package_config.PackageConfig findPackageConfig(Folder dir) {
     var packageConfig = _packageConfigData[dir.path];
     assert(packageConfig != null,
         'Package config data at ${dir.path} should not be null');


### PR DESCRIPTION
I was investigating analyzer's handling of Flutter (sky_engine)'s Embedder SDK, and found we could really simplify how we handle it.

In PackageBuilder we have a couple awkward private APIs: `__embedderSdk` and `_embedderSdk`. The former is of course just the memoized field backing the latter getter. But so awkward.

Ok, and what is `_embedderSdk` used for? Well, if we are documenting Flutter, then we need to find the `sky_engine` `_embedder.yaml` file in order to find the Flutter engine (e.g. `dart:ui`) in order to document it. So the `_embedderSdkFiles` and `_embedderSdkUris` getters support the idea of creating an EmbedderSdk via `sky_engine`. Ultimately it is really only used in `PackageGraph.uninitialized(...)` to say whether we _have_ an EmbedderSdk, and in `_getFilesToDocument`, to list out libraries specified in the EmbedderSdk that we need to document.

How is the `_embedderSdk` calculated? Since it's a memoization thing it is only calculated once, via the private field, `_packageMap`. That field is named very generally, but it is a field which only exists to be consumed once by this `_embedderSdk` getter. That `_packageMap` field is hydrated by `_calculatePackageMap`, which is called once (and has the comment, "Do not call more than once for a given PackageBuilder," yikes) during `buildPackageGraph`. So we've identified a number of instance members (`__embedderSdk`, `_packageMap`, and `_calculatePackageMap`, who only exist to support `_embedderSdk` returning something useful. Maybe we can calculate this field differently.

Well the complication comes from how `_calculatePackageMap` needs to be asynchronous, because the package_config package _only provides asynchronous APIs._ (See https://github.com/dart-lang/tools/issues/1536.) And that more-or-less prevents us from doing all of these calculations in the `PackageGraphBuilder` factory constructor. (Or makes it yuckier.) So in this PR I also include ~40 lines of code that lets us synchronously find a `package_config.json` file and parse it into a PackageConfig object. This code is all cribbed from package_config's `discovery.dart` file, stripping Future return types and unused optional parameters, and switching to synchronous APIs like `File.existsSync` and `File.readAsBytesSync`.

With that new functionality, all of the calculations can be done from a static helper, `_findEmbedderSdkFiles`, which calculates the EmbedderSdk object. And then since the `_embedderSdk` field was _itself_ an intermediate value supporting `_embedderSdkFiles`, we go the extra mile and calculate that once statically as well, and only store the list of file paths.



