### PR TITLE
Fix internal links in Dart Doc specification

### DIFF
--- a/doc/dart_documentation_comment_specification.md
+++ b/doc/dart_documentation_comment_specification.md
@@ -108,9 +108,9 @@ The content within the delimiters is treated as the documentation. On each line 
 
 ### **2.4. References**
 
-A reference is a special directive within the Markdown content that creates a hyperlink to a Dart element. It is written by enclosing a name in square brackets (e.g., `[foo]`).  See [Section 4](#4.-referenceable-elements) for detailed information about which elements can be referenced.
+A reference is a special directive within the Markdown content that creates a hyperlink to a Dart element. It is written by enclosing a name in square brackets (e.g., `[foo]`).  See [Section 4](#4-referenceable-elements) for detailed information about which elements can be referenced.
 
-Conceptually, these behave like [reference-style links](https://www.markdownguide.org/basic-syntax/#reference-style-links) in Markdown. The documentation generator resolves the name against the available source code to create the link's destination. See [Section 5](#5.-reference-lookup-and-resolution) for detailed resolution rules.
+Conceptually, these behave like [reference-style links](https://www.markdownguide.org/basic-syntax/#reference-style-links) in Markdown. The documentation generator resolves the name against the available source code to create the link's destination. See [Section 5](#5-reference-lookup-and-resolution) for detailed resolution rules.
 
 It is important to distinguish references from other link syntaxes in GFM. Documentation comment references use the shorthand reference link syntax (`[name]`) for their own purpose. Other forms of Markdown links are not treated as references and are parsed as standard Markdown. This includes:
 
@@ -139,7 +139,7 @@ Doc comments are associated with the declaration that immediately follows them. 
 * `typedef`
 * Top-level functions
 * Top-level variables
-* Top-level getters or setters (See [Section 6.2.2](#6.2.2.-getters-and-setters) for details)
+* Top-level getters or setters (See [Section 6.2.2](#622-getters-and-setters) for details)
 
 ### **3.3. Member Declarations**
 
@@ -147,7 +147,7 @@ Doc comments are associated with the declaration that immediately follows them. 
 * Methods (instance, static)
 * Operators
 * Fields (instance, static)
-* Getters or setters (See [Section 6.2.2](#6.2.2.-getters-and-setters) for details)
+* Getters or setters (See [Section 6.2.2](#622-getters-and-setters) for details)
 
 ### **3.4. Enum Constants**
 
@@ -169,7 +169,7 @@ void foo(int s) {}
 
 ## **4\. Referenceable Elements**
 
-A reference in a doc comment (e.g., `[name]`) can link to any Dart element that is visible from the Dart scope of the documented element. See [Section 5](#5.-reference-lookup-and-resolution) for more details about scoping. This includes:
+A reference in a doc comment (e.g., `[name]`) can link to any Dart element that is visible from the Dart scope of the documented element. See [Section 5](#5-reference-lookup-and-resolution) for more details about scoping. This includes:
 
 ### **4.1. Top-Level Declarations:**
 
@@ -181,13 +181,13 @@ A reference in a doc comment (e.g., `[name]`) can link to any Dart element that 
 * Type aliases (Typedefs) (e.g., `[MyTypedef]`)
 * Functions (e.g., `[myTopLevelFunction]`)
 * Variables and constants (e.g., `[myTopLevelVar]`)
-* Getters and Setters  (See [Section 6.2.2](#6.2.2.-getters-and-setters) for full details)
+* Getters and Setters  (See [Section 6.2.2](#622-getters-and-setters) for full details)
 
 ### **4.2. Members:**
 
 * Methods (instance and static) (e.g., `[myMethod]`, `[MyClass.myMethod]`)
 * Fields (instance and static) (e.g., `[myField]`, `[MyClass.myField]`)
-* Getters and Setters  (See [Section 6.2.2](#6.2.2.-getters-and-setters) for full details)
+* Getters and Setters  (See [Section 6.2.2](#622-getters-and-setters) for full details)
 * Constructors (e.g., `[MyClass.new]`, `[MyClass.named]`)
 * Enum constants (e.g., `[MyEnum.value]`)
 
@@ -204,7 +204,7 @@ When a name is enclosed in square brackets (e.g., `[MyClass.myMethod]`), documen
 
 ### **5.1. General Principles**
 
-* **Resolution Follows Scope Hierarchy:** Lookup begins relative to the documented element and proceeds outwards through the well-defined Dart scope precedence hierarchy (see [Section 5.2](#5.2.-scope-precedence-hierarchy)). The first valid match found in this search is used.
+* **Resolution Follows Scope Hierarchy:** Lookup begins relative to the documented element and proceeds outwards through the well-defined Dart scope precedence hierarchy (see [Section 5.2](#52-scope-precedence-hierarchy)). The first valid match found in this search is used.
 
 * **Disambiguation via Qualification:** To prevent ambiguity or to reference an element from a distant scope, a reference should be qualified. This is done by prefixing the name with a class name (e.g., `[ClassName.memberName]`) or an import prefix (e.g., `[prefix.elementName]`).
 
@@ -421,7 +421,7 @@ When a reference contains a qualified name (e.g., `[prefix.ClassName.member]`), 
 
 #### **1\. Resolve the First Identifier**
 
-The tool first resolves the first identifier in the qualified name (e.g., prefix) using the standard lookup process ([Section 5.3](#5.3.-detailed-lookup-process)), starting from the doc comment's current scope.
+The tool first resolves the first identifier in the qualified name (e.g., prefix) using the standard lookup process ([Section 5.3](#53-detailed-lookup-process)), starting from the doc comment's current scope.
 
 #### **2\. Resolve Subsequent Identifiers**
 
@@ -503,13 +503,13 @@ class A {
 }
 ```
 
-* **Getters and Setters:** A reference to a property name (e.g., `[value]`) resolves to the *conceptual property* rather than the individual getter or setter. See full discussion in [Section 6.2.2](#6.2.2.-getters-and-setters).
+* **Getters and Setters:** A reference to a property name (e.g., `[value]`) resolves to the *conceptual property* rather than the individual getter or setter. See full discussion in [Section 6.2.2](#622-getters-and-setters).
 
 * **Shadowing**: A name in an inner scope (like a `[parameterName]`) "shadows" a name in an outer scope (like a class field). The shadowed outer element must be qualified to be referenced, e.g., `[MyClass.fieldName]`.
 
 ## **6\. Associating Documentation with Elements**
 
-While the placement rules in [Section 3](#3.-placement-of-documentation-comments) define where a doc comment must be written, this section defines how documentation tools should associate a specific documentation block with a given code element, especially in cases where the association isn't direct.
+While the placement rules in [Section 3](#3-placement-of-documentation-comments) define where a doc comment must be written, this section defines how documentation tools should associate a specific documentation block with a given code element, especially in cases where the association isn't direct.
 
 ### **6.1. The General Rule**
 


### PR DESCRIPTION
Internal links to headings shouldn't contain `.` ([documentation](https://docs.github.com/ru/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax)).

> Spaces are replaced by hyphens (-). Any other whitespace or punctuation characters are removed.

Therefore currently links to internal headings in the [specification](https://github.com/dart-lang/dartdoc/blob/main/doc/dart_documentation_comment_specification.md) don't work. This PR fixes them.