### PR TITLE
Simplify characterLocation; remove unitElement

### DIFF
--- a/lib/src/model/accessor.dart
+++ b/lib/src/model/accessor.dart
@@ -5,7 +5,6 @@
 import 'dart:convert';
 
 import 'package:analyzer/dart/element/element.dart';
-import 'package:analyzer/source/line_info.dart';
 import 'package:collection/collection.dart' show IterableExtension;
 import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
@@ -28,11 +27,6 @@ class Accessor extends ModelElement with HasLibrary {
 
   Accessor(this.element, Library super.library, super.packageGraph,
       {ExecutableElement? super.originalElement});
-
-  @override
-  CharacterLocation? get characterLocation => element.isOriginDeclaration
-      ? super.characterLocation
-      : enclosingCombo.characterLocation;
 
   @override
   ExecutableElement? get originalMember =>
@@ -178,19 +172,6 @@ class ContainerAccessor extends Accessor with ContainerMember, Inheritable {
       super.element, super.library, super.packageGraph, this._enclosingElement,
       {super.originalElement})
       : isInherited = true;
-
-  /// The index and values fields are never declared, and must be special cased.
-  bool get _isEnumSynthetic =>
-      enclosingCombo is EnumField && (name == 'index' || name == 'values');
-
-  @override
-  CharacterLocation? get characterLocation {
-    if (_isEnumSynthetic) return enclosingElement.characterLocation;
-    // TODO(jcollins-g): Remove the enclosingCombo case below once
-    // https://github.com/dart-lang/sdk/issues/46154 is fixed.
-    if (enclosingCombo is EnumField) return enclosingCombo.characterLocation;
-    return super.characterLocation;
-  }
 
   @override
   bool get isCovariant => isSetter && parameters.first.isCovariant;

--- a/lib/src/model/constructor.dart
+++ b/lib/src/model/constructor.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:analyzer/dart/element/element.dart';
-import 'package:analyzer/source/line_info.dart';
 import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
 import 'package:dartdoc/src/model/kind.dart';
@@ -16,23 +15,6 @@ class Constructor extends ModelElement
   final ConstructorElement element;
 
   Constructor(this.element, Library super.library, super.packageGraph);
-
-  @override
-  CharacterLocation? get characterLocation {
-    if (!element.isOriginDeclaration) {
-      // Make warnings for a synthetic constructor refer to somewhere reasonable
-      // since a synthetic constructor has no definition independent of the
-      // parent class.
-      return enclosingElement.characterLocation;
-    }
-    final lineInfo = unitElement.lineInfo;
-    var offset = element.firstFragment.nameOffset ??
-        element.firstFragment.typeNameOffset;
-    if (offset != null && offset >= 0) {
-      return lineInfo.getLocation(offset);
-    }
-    return null;
-  }
 
   @override
   bool get isPublic {

--- a/lib/src/model/getter_setter_combo.dart
+++ b/lib/src/model/getter_setter_combo.dart
@@ -6,8 +6,6 @@ import 'dart:convert';
 
 import 'package:analyzer/dart/ast/ast.dart'
     show Expression, InstanceCreationExpression;
-import 'package:analyzer/dart/element/element.dart';
-import 'package:analyzer/source/line_info.dart';
 // ignore: implementation_imports
 import 'package:analyzer/src/dart/element/element.dart'
     show VariableFragmentImpl;
@@ -104,32 +102,6 @@ mixin GetterSetterCombo on ModelElement {
     }
     return original.replaceAll('${enclosingElement.name}.${target.name}',
         '${enclosingElement.linkedName}.${target.linkedName}');
-  }
-
-  @override
-  CharacterLocation? get characterLocation {
-    if (enclosingElement is Enum) {
-      if (name == 'values') {
-        return null;
-      } else if (name == 'index') {
-        return null;
-      }
-    }
-    if (element
-        case FieldElement(isOriginGetterSetter: false) ||
-            TopLevelVariableElement(isOriginGetterSetter: false)) {
-      return super.characterLocation;
-    }
-
-    // Handle all synthetic possibilities.  Ordinarily, warnings for
-    // explicit setters/getters will be handled by those objects, but
-    // if a warning comes up for an enclosing synthetic field we have to
-    // put it somewhere.  So pick an accessor.
-    if (hasExplicitGetter) {
-      return getter!.characterLocation;
-    }
-    assert(hasExplicitSetter);
-    return setter!.characterLocation;
   }
 
   String get constantValue => linkifyConstantValue(constantValueBase);

--- a/lib/src/model/library.dart
+++ b/lib/src/model/library.dart
@@ -5,7 +5,6 @@
 import 'package:analyzer/dart/analysis/features.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/scope.dart';
-import 'package:analyzer/source/line_info.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
 import 'package:dartdoc/src/model/kind.dart';
 import 'package:dartdoc/src/model/model.dart';
@@ -74,25 +73,13 @@ class Library extends ModelElement with TopLevelContainer {
 
   bool get isInSdk => element.isInSdk;
 
-  @override
-  CharacterLocation? get characterLocation {
-    if (element.firstFragment.nameOffset == null) {
-      return CharacterLocation(1, 1);
-    }
-    return super.characterLocation;
-  }
-
-  @override
-  LibraryFragment get unitElement => element.library.firstFragment;
-
-  @override
-
   /// Whether this library is considered "public."
   ///
   /// A library is considered public if it:
   /// * is an SDK library and it is documented and it is not internal, or
   /// * is found in a package's top-level 'lib' directory, and
   ///   not found in it's 'lib/src' directory, and it is not excluded.
+  @override
   bool get isPublic {
     // Package-private libraries are not public.
     var elementUri = element.firstFragment.source.uri;

--- a/lib/src/model/method.dart
+++ b/lib/src/model/method.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:analyzer/dart/element/element.dart';
-import 'package:analyzer/source/line_info.dart';
 import 'package:dartdoc/src/element_type.dart';
 import 'package:dartdoc/src/model/attribute.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
@@ -48,19 +47,6 @@ class Method extends ModelElement
     typeParameters = element.typeParameters.map((f) {
       return getModelFor(f, library) as TypeParameter;
     }).toList(growable: false);
-  }
-
-  @override
-  CharacterLocation? get characterLocation {
-    if (enclosingElement is Enum && name == 'toString') {
-      // The toString() method on Enums is special, treated as not having
-      // a definition location by the analyzer yet not being inherited, either.
-      // Just directly override our location with the Enum definition --
-      // this is OK because Enums can not inherit from each other nor
-      // have their definitions split between files.
-      return enclosingElement.characterLocation;
-    }
-    return super.characterLocation;
   }
 
   @override


### PR DESCRIPTION
I'm looking at simplifying the `SourceCode` mixin (merging it into DocumentationComment), and found that our implementations of `characterLocation` were unnecessarily complex.

For one thing, the analyzer APIs have recently added some nice `isOriginX` getters, which tell us where an element came from, similar to the previous `isSynthetic` getters, but more informative.

Since the `characterLocation` question is all about the analyzer Element, and requires no knowledge of the dartdoc ModelElement, it was easy enough to round up all of the edge cases, and answer the question in one place in `ModelElement.characterLocation`. This helps us to delete a ton of cruft. The implementation is now a single switch statement, switching on the Element and the enclosing Element. I kept the helpful comments but was able to largely merge them since the code is now in one place.