### PR TITLE
Simplify oneLineDoc and privatize elementDocumentation

### DIFF
--- a/lib/src/model/documentable.dart
+++ b/lib/src/model/documentable.dart
@@ -24,8 +24,6 @@ abstract interface class Documentable with Nameable {
 
   bool get hasDocumentation;
 
-  String get oneLineDoc;
-
   @override
   PackageGraph get packageGraph;
 
@@ -84,7 +82,6 @@ mixin MarkdownFileDocumentation implements Documentable, Warnable {
   @override
   bool get isDocumented;
 
-  @override
   String get oneLineDoc => _documentation.asOneLiner;
 
   File? get documentationFile;

--- a/lib/src/model/documentation_comment.dart
+++ b/lib/src/model/documentation_comment.dart
@@ -46,9 +46,11 @@ mixin DocumentationComment implements Warnable, SourceCode {
 
   @override
   late final String documentationAsHtml =
-      _injectHtmlFragments(elementDocumentation.asHtml);
+      _injectHtmlFragments(_elementDocumentation.asHtml);
 
-  late final Documentation elementDocumentation =
+  String get oneLineDoc => _elementDocumentation.asOneLiner;
+
+  late final Documentation _elementDocumentation =
       Documentation.forElement(this);
 
   /// The rawest form of the documentation comment, including comment delimiters

--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -759,9 +759,6 @@ abstract class ModelElement
   @override
   String get name => element.lookupName ?? '';
 
-  @override
-  String get oneLineDoc => elementDocumentation.asOneLiner;
-
   Element? get originalMember => _originalMember;
 
   @override

--- a/lib/src/model/package.dart
+++ b/lib/src/model/package.dart
@@ -127,9 +127,6 @@ final class Package extends LibraryContainer
   bool get hasDocumentation => documentation?.isNotEmpty == true;
 
   @override
-  String get oneLineDoc => '';
-
-  @override
   bool get isDocumented =>
       isFirstPackage || documentedWhere != DocumentLocation.missing;
 


### PR DESCRIPTION
This is small, but I noticed nothing depends on `Documentable.oneLineDoc`, and so we can remove it and the dummy impl on Package.

We can also then move the impl on ModelElement to DocumentationComment, which allows us to make `DocumentationComment.elementDocumentation` private.