### PR TITLE
Simplify documentationFrom

### DIFF
--- a/lib/src/markdown_processor.dart
+++ b/lib/src/markdown_processor.dart
@@ -329,11 +329,11 @@ class MarkdownDocument extends md.Document {
     } else {
       // Avoid claiming documentation is inherited when it comes from the
       // current element.
+      var referredFrom = {
+        if (element is ModelElement) ...element.documentationFrom
+      }..remove(element);
       element.warn(PackageWarning.unresolvedDocReference,
-          message: referenceText,
-          referredFrom: element.documentationIsLocal
-              ? const []
-              : element.documentationFrom);
+          message: referenceText, referredFrom: referredFrom);
       return md.Element.text('code', textContent);
     }
   }

--- a/lib/src/model/category.dart
+++ b/lib/src/model/category.dart
@@ -91,9 +91,6 @@ final class Category extends LibraryContainer
   PackageGraph get packageGraph => package.packageGraph;
 
   @override
-  List<Warnable> get documentationFrom => [this];
-
-  @override
   DocumentLocation get documentedWhere => package.documentedWhere;
 
   @override

--- a/lib/src/model/container_member.dart
+++ b/lib/src/model/container_member.dart
@@ -64,7 +64,7 @@ mixin ContainerMember on ModelElement {
       // and resolve the pieces with different scopes.  dart-lang/dartdoc#2693.
       // Until then, just pretend we're handling this correctly.
       [
-        (documentationFrom.first as ModelElement).library,
+        documentationFrom.first.library,
         if (this case Field(:var getter, :var setter))
           packageGraph.findCanonicalModelElementFor(getter ?? setter)?.library
         else

--- a/lib/src/model/documentation_comment.dart
+++ b/lib/src/model/documentation_comment.dart
@@ -42,9 +42,6 @@ mixin DocumentationComment implements Warnable, SourceCode {
   Element get element;
 
   @override
-  List<DocumentationComment> get documentationFrom => [this];
-
-  @override
   late final String documentationAsHtml =
       _injectHtmlFragments(elementDocumentation.asHtml);
 

--- a/lib/src/model/enum.dart
+++ b/lib/src/model/enum.dart
@@ -95,7 +95,7 @@ class EnumField extends Field {
           : renderedName;
 
   @override
-  List<DocumentationComment> get documentationFrom {
+  List<ModelElement> get documentationFrom {
     if (name == 'values' || name == 'index') return [this];
     return super.documentationFrom;
   }

--- a/lib/src/model/getter_setter_combo.dart
+++ b/lib/src/model/getter_setter_combo.dart
@@ -16,7 +16,6 @@ import 'package:dartdoc/src/model/attribute.dart';
 import 'package:dartdoc/src/model/class.dart';
 import 'package:dartdoc/src/model/comment_referable.dart';
 import 'package:dartdoc/src/model/constructor.dart';
-import 'package:dartdoc/src/model/documentation_comment.dart';
 import 'package:dartdoc/src/model/enum.dart';
 import 'package:dartdoc/src/model/model_element.dart';
 import 'package:dartdoc/src/model/parameter.dart';
@@ -150,16 +149,16 @@ mixin GetterSetterCombo on ModelElement {
   bool get isPublic => hasPublicGetter || hasPublicSetter;
 
   @override
-  late final List<DocumentationComment> documentationFrom = () {
+  late final List<ModelElement> documentationFrom = () {
     var docFrom = [
       if (getter case Accessor(isPublic: true, :var documentationFrom))
         ...documentationFrom
       else if (setter case Accessor(isPublic: true, :var documentationFrom))
         ...documentationFrom,
     ];
-    return (docFrom.isEmpty || docFrom.every((e) => !e.hasDocumentationComment))
-        ? super.documentationFrom
-        : docFrom;
+    return docFrom.any((e) => e.hasDocumentationComment)
+        ? docFrom
+        : super.documentationFrom;
   }();
 
   bool get hasAccessorsWithDocs =>

--- a/lib/src/model/inheritable.dart
+++ b/lib/src/model/inheritable.dart
@@ -37,7 +37,7 @@ mixin Inheritable on ContainerMember {
       };
 
   @override
-  List<DocumentationComment> get documentationFrom {
+  List<ModelElement> get documentationFrom {
     if (!hasDocumentationComment && overriddenElement != null) {
       return overriddenElement!.documentationFrom;
     } else if (isInherited) {

--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -539,6 +539,15 @@ abstract class ModelElement
   String get documentation => injectMacros(
       documentationFrom.map((e) => e.documentationLocal).join('<p>'));
 
+  /// The [ModelElement]s from which we will get documentation.
+  ///
+  /// Can be more than one if this is a [Field] composing documentation from
+  /// multiple [Accessor]s.
+  ///
+  /// This will walk up the inheritance hierarchy to find docs, if the current
+  /// object doesn't have docs for this element.
+  List<ModelElement> get documentationFrom => [this];
+
   @override
   Element get element;
 

--- a/lib/src/model/package.dart
+++ b/lib/src/model/package.dart
@@ -103,9 +103,6 @@ final class Package extends LibraryContainer
   @override
   String? get belowSidebarPath => null;
 
-  @override
-  List<Warnable> get documentationFrom => [this];
-
   /// Return true if the code has defined non-default categories for libraries
   /// in this package.
   bool get hasCategories => categories.isNotEmpty;

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -169,7 +169,7 @@ class PackageGraph with CommentReferable, Nameable {
           e.enclosingElement!.isCanonical) {
         for (var d
             in e.documentationFrom.where((d) => d.hasDocumentationComment)) {
-          if (precachedElements.add(d as ModelElement)) {
+          if (precachedElements.add(d)) {
             futures.add(d.precacheLocalDocs());
             // [TopLevelVariable]s get their documentation from getters and
             // setters, so should be precached if either has a template.

--- a/lib/src/warnings.dart
+++ b/lib/src/warnings.dart
@@ -110,19 +110,6 @@ mixin Warnable implements CommentReferable, Documentable {
         extendedDebug: extendedDebug);
   }
 
-  /// Whether [documentationFrom] contains only one item, `this`.
-  bool get documentationIsLocal =>
-      documentationFrom.length == 1 && identical(documentationFrom.first, this);
-
-  /// The [Warnable]s from which we will get documentation.
-  ///
-  /// Can be more than one if this is a [Field] composing documentation from
-  /// multiple [Accessor]s.
-  ///
-  /// This will walk up the inheritance hierarchy to find docs, if the current
-  /// class doesn't have docs for this element.
-  List<Warnable> get documentationFrom;
-
   /// The URI of this [Warnable].
   @visibleForOverriding
   String get location;


### PR DESCRIPTION
It seemed weird that `documentationFrom` was declared in Warnable. Well it turns out that was only really for the case in MarkdownDocument where we are computing where a warning might be "referred from." Other than that, we only ever ask about `documentationFrom` on ModelElements!

This is good news because we can move the top declaration to ModelElement, and remove the dummy implementations (on Category, DocumentationComment, and Package).

That MarkdownDocument code was also the only place that accessed `Warnable.documentationIsLocal`, so we can remove that declaration.

We can also change the return type of `documentationFrom` from Warnable to ModelElement, which allows us to remove a few explicit casts.