### PR TITLE
Bump to analyzer 10.0.2 and handle deprecation

### DIFF
--- a/lib/src/model/package_builder.dart
+++ b/lib/src/model/package_builder.dart
@@ -11,7 +11,7 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/file_system/file_system.dart';
 // ignore: implementation_imports
-import 'package:analyzer/src/context/builder.dart' show EmbedderYamlLocator;
+import 'package:analyzer/src/context/builder.dart' show locateEmbedderYamlFor;
 // ignore: implementation_imports
 import 'package:analyzer/src/dart/analysis/analysis_context_collection.dart'
     show AnalysisContextCollectionImpl;
@@ -116,8 +116,9 @@ class PubPackageBuilder implements PackageBuilder {
         resourceProvider.pathContext.fromUri(skyEngine.packageUriRoot));
     var skyEngineLibFolder =
         resourceProvider.getResource(packagePath) as Folder;
-    var embedderSdk = EmbedderSdk(resourceProvider,
-        EmbedderYamlLocator.forLibFolder(skyEngineLibFolder).embedderYamls,
+    var embedderYaml = locateEmbedderYamlFor(skyEngineLibFolder);
+    var embedderSdk = EmbedderSdk.new2(
+        resourceProvider, skyEngineLibFolder, embedderYaml,
         languageVersion: languageVersionFromSdkVersion(io.Platform.version));
 
     return [

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ^3.6.0
 
 dependencies:
-  analyzer: ^10.0.0
+  analyzer: ^10.0.2
   args: ^2.4.1
   collection: ^1.17.0
   crypto: ^3.0.3


### PR DESCRIPTION
Analyzer 10.0.2 comes with a deprecation. We can handle it here by moving to the new internal APIs.

Then when this commit is rolled into the Dart SDK, we can delete the old APIs.