### PR TITLE
Fix #4207: Preserve display text for reference-style documentation links

### DIFF
--- a/lib/src/markdown_processor.dart
+++ b/lib/src/markdown_processor.dart
@@ -261,8 +261,8 @@ class MarkdownDocument extends md.Document {
   /// Creates a document which resolves comment references as stemming from
   /// [element].
   factory MarkdownDocument.withElementLinkResolver(Warnable element) {
-    final linkResolver =
-        (String name, [String? _]) => _makeLinkNode(name, element);
+    md.Node? linkResolver(String name, [String? _]) =>
+        _makeLinkNode(name, element);
     return MarkdownDocument._(
       inlineSyntaxes: _markdownSyntaxes(linkResolver),
       blockSyntaxes: _markdownBlockSyntaxes,
@@ -356,8 +356,8 @@ class _LinkSyntaxWithPreservedReferenceText extends md.LinkSyntax {
     md.InlineParser parser,
     covariant md.SimpleDelimiter opener,
     md.Delimiter? closer, {
-    String? tag,
     required List<md.Node> Function() getChildren,
+    String? tag,
   }) {
     final referenceText = parser.source.substring(opener.endPos, parser.pos);
     final referenceLabelData =

--- a/lib/src/markdown_processor.dart
+++ b/lib/src/markdown_processor.dart
@@ -122,13 +122,14 @@ final RegExp _nonHtml =
 
 final HtmlEscape _htmlEscape = const HtmlEscape(HtmlEscapeMode.element);
 
-final List<md.InlineSyntax> _markdownSyntaxes = [
-  _InlineCodeSyntax(),
-  _AutolinkWithoutScheme(),
-  md.InlineHtmlSyntax(),
-  md.StrikethroughSyntax(),
-  md.AutolinkExtensionSyntax(),
-];
+List<md.InlineSyntax> _markdownSyntaxes(md.Resolver linkResolver) => [
+      _InlineCodeSyntax(),
+      _LinkSyntaxWithPreservedReferenceText(linkResolver: linkResolver),
+      _AutolinkWithoutScheme(),
+      md.InlineHtmlSyntax(),
+      md.StrikethroughSyntax(),
+      md.AutolinkExtensionSyntax(),
+    ];
 
 final List<md.BlockSyntax> _markdownBlockSyntaxes = [
   const md.AlertBlockSyntax(),
@@ -260,10 +261,12 @@ class MarkdownDocument extends md.Document {
   /// Creates a document which resolves comment references as stemming from
   /// [element].
   factory MarkdownDocument.withElementLinkResolver(Warnable element) {
+    final linkResolver =
+        (String name, [String? _]) => _makeLinkNode(name, element);
     return MarkdownDocument._(
-      inlineSyntaxes: _markdownSyntaxes,
+      inlineSyntaxes: _markdownSyntaxes(linkResolver),
       blockSyntaxes: _markdownBlockSyntaxes,
-      linkResolver: (String name, [String? _]) => _makeLinkNode(name, element),
+      linkResolver: linkResolver,
     );
   }
 
@@ -340,6 +343,116 @@ class MarkdownDocument extends md.Document {
           message: referenceText, referredFrom: referredFrom);
       return md.Element.text('code', textContent);
     }
+  }
+}
+
+/// A custom markdown link syntax that preserves first-label text for fallback
+/// doc links of the form `[text][target]`.
+class _LinkSyntaxWithPreservedReferenceText extends md.LinkSyntax {
+  _LinkSyntaxWithPreservedReferenceText({required super.linkResolver});
+
+  @override
+  Iterable<md.Node>? close(
+    md.InlineParser parser,
+    covariant md.SimpleDelimiter opener,
+    md.Delimiter? closer, {
+    String? tag,
+    required List<md.Node> Function() getChildren,
+  }) {
+    final referenceText = parser.source.substring(opener.endPos, parser.pos);
+    final referenceLabelData =
+        _parseFullReferenceLabel(parser.source, parser.pos);
+
+    final nodes = super.close(
+      parser,
+      opener,
+      closer,
+      tag: tag,
+      getChildren: getChildren,
+    );
+
+    if (nodes == null || referenceLabelData == null) {
+      return nodes;
+    }
+
+    final referenceLabel = referenceLabelData.label;
+    if (referenceText == referenceLabel) {
+      return nodes;
+    }
+
+    final rewrittenNodes = nodes.toList(growable: false);
+    if (rewrittenNodes.length != 1) {
+      return rewrittenNodes;
+    }
+
+    final rewrittenNode = rewrittenNodes.single;
+    if (rewrittenNode is! md.Element ||
+        (rewrittenNode.tag != 'a' && rewrittenNode.tag != 'code')) {
+      return rewrittenNodes;
+    }
+
+    final children = rewrittenNode.children;
+    if (children == null || children.length != 1) {
+      return rewrittenNodes;
+    }
+
+    final child = children.single;
+    if (child is! md.Text) {
+      return rewrittenNodes;
+    }
+
+    final escapedReferenceLabel = _htmlEscape.convert(referenceLabel);
+    if (child.text != escapedReferenceLabel) {
+      return rewrittenNodes;
+    }
+
+    children[0] = md.Text(_htmlEscape.convert(referenceText));
+    return rewrittenNodes;
+  }
+
+  ({String label})? _parseFullReferenceLabel(
+      String source, int closingTextBracketPosition) {
+    final openingLabelBracketPosition = closingTextBracketPosition + 1;
+    if (openingLabelBracketPosition >= source.length ||
+        source[openingLabelBracketPosition] != '[') {
+      return null;
+    }
+
+    // `[text][]` (collapsed reference link) is not the full reference form.
+    if (openingLabelBracketPosition + 1 < source.length &&
+        source[openingLabelBracketPosition + 1] == ']') {
+      return null;
+    }
+
+    final buffer = StringBuffer();
+    for (var index = openingLabelBracketPosition + 1;
+        index < source.length;
+        index++) {
+      final char = source[index];
+      if (char == r'\') {
+        index++;
+        if (index >= source.length) {
+          return null;
+        }
+        final escapedChar = source[index];
+        if (escapedChar != r'\' && escapedChar != ']') {
+          buffer.write(r'\');
+        }
+        buffer.write(escapedChar);
+      } else if (char == '[') {
+        return null;
+      } else if (char == ']') {
+        final label = buffer.toString();
+        if (label.trim().isEmpty) {
+          return null;
+        }
+        return (label: label);
+      } else {
+        buffer.write(char);
+      }
+    }
+
+    return null;
   }
 }
 

--- a/test/reference_style_links_test.dart
+++ b/test/reference_style_links_test.dart
@@ -78,6 +78,7 @@ class C {
       m.documentationAsHtml,
       contains(RegExp('<a href="[^"]+">Platform\\.current</a>')),
     );
-    expect(m.documentationAsHtml, isNot(contains('>Platform.nativePlatform</a>')));
+    expect(
+        m.documentationAsHtml, isNot(contains('>Platform.nativePlatform</a>')));
   }
 }

--- a/test/reference_style_links_test.dart
+++ b/test/reference_style_links_test.dart
@@ -1,0 +1,83 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+import 'package:test_reflective_loader/test_reflective_loader.dart';
+
+import 'dartdoc_test_base.dart';
+import 'src/utils.dart';
+
+void main() {
+  defineReflectiveSuite(() {
+    defineReflectiveTests(ReferenceStyleLinksTest);
+  });
+}
+
+@reflectiveTest
+class ReferenceStyleLinksTest extends DartdocTestBase {
+  @override
+  String get libraryName => 'reference_style_links';
+
+  void test_referenceStyleLink_withDefinedReference_usesMarkdownLink() async {
+    var library = await bootPackageWithLibrary('''
+class C {
+  /// The [banana][Bananas] is fine.
+  ///
+  /// [Bananas]: http://example.com/bananas "example of bananas"
+  void m() {}
+}
+''');
+
+    var m = library.classes.named('C').instanceMethods.named('m');
+
+    expect(
+      m.documentationAsHtml,
+      '<p>The <a href="http://example.com/bananas" '
+      'title="example of bananas">banana</a> is fine.</p>',
+    );
+  }
+
+  void test_referenceStyleLink_withoutDefinition_fallsBackToDocLink() async {
+    var library = await bootPackageWithLibrary('''
+class Foo {
+  static int get bar => 0;
+}
+
+class C {
+  /// Link [Foo.current.bar][Foo.bar].
+  void m() {}
+}
+''');
+
+    var m = library.classes.named('C').instanceMethods.named('m');
+
+    expect(
+      m.documentationAsHtml,
+      contains(RegExp('<a href="[^"]+">Foo\\.current\\.bar</a>')),
+    );
+    expect(m.documentationAsHtml, isNot(contains('>Foo.bar</a>')));
+  }
+
+  void test_referenceStyleLink_withoutDefinition_preservesFirstLabel() async {
+    var library = await bootPackageWithLibrary('''
+class Platform {
+  static Platform get current => Platform();
+  String get nativePlatform => 'linux';
+}
+
+class C {
+  /// [Platform.current][Platform.nativePlatform]
+  void m() {}
+}
+''');
+
+    var m = library.classes.named('C').instanceMethods.named('m');
+
+    expect(
+      m.documentationAsHtml,
+      contains(RegExp('<a href="[^"]+">Platform\\.current</a>')),
+    );
+    expect(m.documentationAsHtml, isNot(contains('>Platform.nativePlatform</a>')));
+  }
+}

--- a/testing/test_package/lib/fake.dart
+++ b/testing/test_package/lib/fake.dart
@@ -1162,3 +1162,12 @@ class TypeParameterThingsExtendedQ
 /// and [fParam.fParamC].
 void set aSetterWithFunctionParameter(
     bool fParam(int fParamA, String fParamB, String fParamC)) {}
+
+
+class VisualFallbackTarget {
+  static int get bar => 0;
+}
+
+/// Visual fallback link check:
+/// [VisualFallbackTarget.current.bar][VisualFallbackTarget.bar]
+void visualFallbackLinkCheck() {}

--- a/testing/test_package/lib/fake.dart
+++ b/testing/test_package/lib/fake.dart
@@ -1163,7 +1163,6 @@ class TypeParameterThingsExtendedQ
 void set aSetterWithFunctionParameter(
     bool fParam(int fParamA, String fParamB, String fParamC)) {}
 
-
 class VisualFallbackTarget {
   static int get bar => 0;
 }


### PR DESCRIPTION
Fixes #4207

## Description
This PR fixes an issue where Dartdoc ignores the custom text provided in a Markdown reference-style link (`[text][target]`) and instead aggressively overwrites it with the target's element name. 

With this fix, writing `[Platform.current][Platform.nativePlatform]` will correctly link to `Platform.nativePlatform` while displaying `Platform.current` as the link text.

## Implementation Details
Instead of heavily refactoring Dartdoc's core link resolver (`_makeLinkNode` / `getMatchingLinkElement`), which handles complex edge cases like callable hints, shadowing, and inherited documentation, this fix introduces a localized, safe AST interception via `package:markdown`.

* Added `_LinkSyntaxWithPreservedReferenceText` which extends `md.LinkSyntax`.
* It intercepts the node creation in the `close()` method. 
* If the `linkResolver` has overwritten the text to match the target label, it safely swaps the `md.Text` child back to the user's intended `referenceText`.
* Implemented `_parseFullReferenceLabel` to safely extract the target label while accounting for escaped characters and ignoring collapsed links (`[text][]`).

This approach guarantees that standard Markdown links remain unaffected while accurately restoring the text for Dartdoc-resolved elements.

## Testing
Added comprehensive tests in `test/reference_style_links_test.dart`:
* Verified that standard defined Markdown reference links are untouched.
* Verified that `[text][target]` correctly falls back to Dartdoc link resolution.
* Verified that the first label (`text`) is successfully preserved in the generated HTML and the fallback target label is not displayed.

## Checklist
- [x] I have read the [Contributor Guide](https://github.com/dart-lang/dartdoc/blob/main/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All tests pass (`dart test`).