### PR TITLE
Require analyzer 12.0.0, with breaking changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 9.0.5-dev
+## 9.0.5-wip
 
 * Require analyzer 12.0.0 APIs.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 9.0.5-dev
+
+* Require analyzer 12.0.0 APIs.
+
+
 ## 9.0.4
 * Fix a bug where experiment flags passed via command-line were ignored.
 * Support specifying experimental features in `dartdoc_options.yaml`.

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -233,11 +233,13 @@ class PackageGraph with Referable {
             }
           case EnumDeclaration():
             if (declaration.declaredFragment?.element.isPublic ?? false) {
-              for (var constant in declaration.body.constants) {
-                _populateModelNodeFor(constant);
-              }
-              for (var member in declaration.body.members) {
-                _populateModelNodeFor(member);
+              if (declaration.body case BlockEnumBody body) {
+                for (var constant in body.constants) {
+                  _populateModelNodeFor(constant);
+                }
+                for (var member in body.members) {
+                  _populateModelNodeFor(member);
+                }
               }
             }
           case MixinDeclaration(body: BlockClassBody(:var members)):
@@ -246,8 +248,10 @@ class PackageGraph with Referable {
             }
           case ExtensionDeclaration():
             if (declaration.declaredFragment?.element.isPublic ?? false) {
-              for (var member in declaration.body.members) {
-                _populateModelNodeFor(member);
+              if (declaration.body case BlockClassBody body) {
+                for (var member in body.members) {
+                  _populateModelNodeFor(member);
+                }
               }
             }
           case ExtensionTypeDeclaration():

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dartdoc
-version: 9.0.4
+version: 9.0.5-dev
 description: A non-interactive HTML documentation generator for Dart source code.
 repository: https://github.com/dart-lang/dartdoc
 
@@ -7,7 +7,7 @@ environment:
   sdk: ^3.6.0
 
 dependencies:
-  analyzer: ^10.2.0
+  analyzer: ^12.0.0
   args: ^2.4.1
   collection: ^1.17.0
   crypto: ^3.0.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dartdoc
-version: 9.0.5-dev
+version: 9.0.5-wip
 description: A non-interactive HTML documentation generator for Dart source code.
 repository: https://github.com/dart-lang/dartdoc
 


### PR DESCRIPTION
This change refers to not yet published `analyzer 12.0.0`, because I cannot land corresponding [analyzer CL](https://dart-review.googlesource.com/c/sdk/+/486080) (and then publish) without pulling into the Dart SDK a version of `dartdoc` (and `dart_style`, see https://github.com/dart-lang/dart_style/pull/1815) that is compatible with this breaking change version of the analyzer. So, I want to land this PR with a version of `dartdoc` that is compatible with `analyzer 12.0.0` (to be), and the pull this git commit into [the CL](https://dart-review.googlesource.com/c/sdk/+/486080).

I tested it locally with
```yaml
dependency_overrides:
  _fe_analyzer_shared:
    path: /Users/scheglov/Source/Dart/sdk.git/sdk/pkg/_fe_analyzer_shared
  analyzer:
    path: /Users/scheglov/Source/Dart/sdk.git/sdk/pkg/analyzer
  dart_style:
    path: /Users/scheglov/dart/dart_style
```
Obviously, GitHub bots will be red until `analyzer 12.0.0` is published.