### PR TITLE
Fix dartdoc canonicalization for explicit getters and prioritize @canonicalFor

### DIFF
--- a/lib/src/model/canonicalization.dart
+++ b/lib/src/model/canonicalization.dart
@@ -39,18 +39,28 @@ Library? canonicalLibraryCandidate(ModelElement modelElement) {
     return null;
   }
 
+  final targetElement = _normalize(topLevelElement);
+
   final candidateLibraries = candidateList.where((l) {
     if (!l.isPublic) return false;
     if (l.package.documentedWhere == DocumentLocation.missing) return false;
     if (modelElement is Library) return true;
     if (l.name == modelElement.library?.name) return true;
     var lookup = l.element.exportNamespace.definedNames2[topLevelElementName];
-    var lookupElement =
-        lookup is PropertyAccessorElement ? lookup.variable : lookup;
-    var targetElement = topLevelElement is PropertyAccessorElement
-        ? topLevelElement.variable
-        : topLevelElement;
-    return targetElement == lookupElement;
+
+    var lookupElement = _normalize(lookup);
+
+    if (targetElement == lookupElement) return true;
+
+    // Fallback: Compare by name and library if == fails
+    // (e.g. for some re-exported elements)
+    if (lookupElement != null &&
+        targetElement?.name == lookupElement.name &&
+        targetElement?.library?.uri == lookupElement.library?.uri) {
+      return true;
+    }
+
+    return false;
   }).toList(growable: true);
 
   if (candidateLibraries.isEmpty) {
@@ -66,6 +76,9 @@ Library? canonicalLibraryCandidate(ModelElement modelElement) {
   return _Canonicalization(topLevelModelElement)
       .canonicalLibraryCandidate(candidateLibraries);
 }
+
+Element? _normalize(Element? e) =>
+    e is PropertyAccessorElement && !e.isOriginDeclaration ? e.variable : e;
 
 /// Canonicalization support in Dartdoc.
 ///

--- a/test/canonical_for_test.dart
+++ b/test/canonical_for_test.dart
@@ -87,4 +87,30 @@ void someFunc() {}
     expect(someFunc.canonicalLibrary, equals(bCanonical));
     expect(someFunc.href, contains('b_canonical/someFunc.html'));
   }
+
+  /// Tests that @canonicalFor works for explicit getters even when they are
+  /// re-exported and standard equality checks might fail.
+  Future<void> test_canonicalFor_getter_reexported() async {
+    var packageGraph = await bootPackageFromFiles([
+      d.file('lib/google_cloud.dart', '''
+library google_cloud;
+export 'http_serving.dart';
+'''),
+      d.file('lib/http_serving.dart', '''
+/// {@canonicalFor http_serving.myGetter}
+library http_serving;
+export 'src/internal.dart';
+'''),
+      d.file('lib/src/internal.dart', '''
+library internal;
+String get myGetter => 'hello';
+'''),
+    ]);
+
+    var httpServing = packageGraph.libraries.named('http_serving');
+    var myGetter = httpServing.properties.named('myGetter');
+
+    expect(myGetter.canonicalLibrary, equals(httpServing));
+    expect(myGetter.href, contains('http_serving/myGetter.html'));
+  }
 }


### PR DESCRIPTION
- Update model_element.dart to check `canonicalLibraryCandidate` (and thus `{@canonicalFor}` tags) before falling back to the local public library shortcut.
- Update canonicalization.dart to provide a name and library-based fallback for comparing elements, fixing issues where explicit top-level getters failed to match.
- Add test_canonicalFor_getter in canonical_for_test.dart to verify explicit getter canonicalization.
