### PR TITLE
Properly adjust comment offsets in light of interleaved non-doc comments

### DIFF
--- a/lib/src/model/documentation_comment.dart
+++ b/lib/src/model/documentation_comment.dart
@@ -882,7 +882,9 @@ mixin DocumentationComment implements Warnable, SourceCode {
         offset = docImport.end;
         docImportIndex++;
       }
-      buffer.write(content.substring(offset, rangeEnd));
+      if (offset < rangeEnd) {
+        buffer.write(content.substring(offset, rangeEnd));
+      }
     }
     return buffer.toString();
   }

--- a/lib/src/model/documentation_comment.dart
+++ b/lib/src/model/documentation_comment.dart
@@ -871,31 +871,18 @@ mixin DocumentationComment implements Warnable, SourceCode {
 
     var buffer = StringBuffer();
     // Track which `@docImport` we are stripping.
-    int? docImportIndex = 0;
+    var docImportIndex = 0;
     for (var sourceRange in sourceRanges) {
       var SourceRange(offset: rangeStart, end: rangeEnd) = sourceRange;
-      var docImportStart = docImportIndex == null
-          ? null
-          : docImportSourceRanges[docImportIndex].offset;
-      if (docImportStart == null || docImportStart > rangeEnd) {
-        buffer.write(content.substring(rangeStart, rangeEnd));
-      } else {
-        // [sourceRange] is a line with a `@docImport`.
-        var offset = rangeStart;
-        while (docImportStart != null && docImportStart < rangeEnd) {
-          buffer.write(content.substring(offset, docImportStart));
-          buffer.write(content.substring(
-              docImportSourceRanges[docImportIndex!].end, rangeEnd));
-          offset = docImportSourceRanges[docImportIndex].end;
-          docImportIndex = docImportIndex + 1;
-          if (docImportIndex >= docImportSourceRanges.length) {
-            docImportIndex = null;
-          }
-          docImportStart = docImportIndex == null
-              ? null
-              : docImportSourceRanges[docImportIndex].offset;
-        }
+      var offset = rangeStart;
+      while (docImportIndex < docImportSourceRanges.length &&
+          docImportSourceRanges[docImportIndex].offset < rangeEnd) {
+        var docImport = docImportSourceRanges[docImportIndex];
+        buffer.write(content.substring(offset, docImport.offset));
+        offset = docImport.end;
+        docImportIndex++;
       }
+      buffer.write(content.substring(offset, rangeEnd));
     }
     return buffer.toString();
   }

--- a/lib/src/model/documentation_comment.dart
+++ b/lib/src/model/documentation_comment.dart
@@ -6,7 +6,9 @@
 library;
 
 import 'dart:convert';
+
 import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/source/source_range.dart';
 import 'package:args/args.dart';
 import 'package:crypto/crypto.dart' as crypto;
 import 'package:dartdoc/src/model/category.dart';
@@ -861,26 +863,41 @@ mixin DocumentationComment implements Warnable, SourceCode {
   }
 
   String _stripDocImports(String content) {
-    if (modelNode?.commentData case var commentData?) {
-      var commentOffset = commentData.offset;
-      var buffer = StringBuffer();
-      if (commentData.docImports.isEmpty) return content;
-      var firstDocImport = commentData.docImports.first;
-      buffer.write(content.substring(0, firstDocImport.offset - commentOffset));
-      var offset = firstDocImport.end - commentOffset;
-      for (var docImport in commentData.docImports.skip(1)) {
-        buffer
-            .write(content.substring(offset, docImport.offset - commentOffset));
-        offset = docImport.end - commentOffset;
+    var commentData = modelNode?.commentData;
+    if (commentData == null) return content;
+    if (commentData.docImportSourceRanges.isEmpty) return content;
+    var sourceRanges = commentData.sourceRanges;
+    var docImportSourceRanges = commentData.docImportSourceRanges;
+
+    var buffer = StringBuffer();
+    // Track which `@docImport` we are stripping.
+    int? docImportIndex = 0;
+    for (var sourceRange in sourceRanges) {
+      var SourceRange(offset: rangeStart, end: rangeEnd) = sourceRange;
+      var docImportStart = docImportIndex == null
+          ? null
+          : docImportSourceRanges[docImportIndex].offset;
+      if (docImportStart == null || docImportStart > rangeEnd) {
+        buffer.write(content.substring(rangeStart, rangeEnd));
+      } else {
+        // [sourceRange] is a line with a `@docImport`.
+        var offset = rangeStart;
+        while (docImportStart != null && docImportStart < rangeEnd) {
+          buffer.write(content.substring(offset, docImportStart));
+          buffer.write(content.substring(
+              docImportSourceRanges[docImportIndex!].end, rangeEnd));
+          offset = docImportSourceRanges[docImportIndex].end;
+          docImportIndex = docImportIndex + 1;
+          if (docImportIndex >= docImportSourceRanges.length) {
+            docImportIndex = null;
+          }
+          docImportStart = docImportIndex == null
+              ? null
+              : docImportSourceRanges[docImportIndex].offset;
+        }
       }
-      if (offset < content.length) {
-        // Write from the end of the last doc-import to the end of the comment.
-        buffer.write(content.substring(offset));
-      }
-      return buffer.toString();
-    } else {
-      return content;
     }
+    return buffer.toString();
   }
 
   /// Parse and remove &#123;@inject-html ...&#125; in API comments and store

--- a/lib/src/model/model_node.dart
+++ b/lib/src/model/model_node.dart
@@ -8,6 +8,7 @@ import 'package:analyzer/dart/analysis/analysis_context.dart';
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/source/source_range.dart';
 import 'package:meta/meta.dart';
 
 /// Stripped down information derived from [AstNode] containing only information
@@ -22,31 +23,27 @@ class ModelNode {
   final CommentData? commentData;
 
   factory ModelNode(
-    AstNode? sourceNode,
+    AstNode sourceNode,
     Element element,
     AnalysisContext analysisContext, {
-    CommentData? commentData,
+    Comment? comment,
   }) {
-    if (sourceNode == null) {
-      return ModelNode._(element, analysisContext,
-          sourceEnd: -1, sourceOffset: -1);
-    } else {
-      // Get a node higher up the syntax tree that includes the semicolon.
-      // In this case, it is either a [FieldDeclaration] or
-      // [TopLevelVariableDeclaration]. (#2401)
-      if (sourceNode is VariableDeclaration) {
-        sourceNode = sourceNode.parent!.parent!;
-        assert(sourceNode is FieldDeclaration ||
-            sourceNode is TopLevelVariableDeclaration);
-      }
-      return ModelNode._(
-        element,
-        analysisContext,
-        sourceEnd: sourceNode.end,
-        sourceOffset: sourceNode.offset,
-        commentData: commentData,
-      );
+    var commentData = comment?.data;
+    // Get a node higher up the syntax tree that includes the semicolon.
+    // In this case, it is either a [FieldDeclaration] or
+    // [TopLevelVariableDeclaration]. (#2401)
+    if (sourceNode is VariableDeclaration) {
+      sourceNode = sourceNode.parent!.parent!;
+      assert(sourceNode is FieldDeclaration ||
+          sourceNode is TopLevelVariableDeclaration);
     }
+    return ModelNode._(
+      element,
+      analysisContext,
+      sourceEnd: sourceNode.end,
+      sourceOffset: sourceNode.offset,
+      commentData: commentData,
+    );
   }
 
   ModelNode._(
@@ -84,14 +81,17 @@ class ModelNode {
 /// Various comment data is not available on the analyzer's Element model, so we
 /// store it in instances of this class after resolving libraries.
 class CommentData {
-  /// The offset of this comment in the source text.
-  final int offset;
-  final List<CommentDocImportData> docImports;
+  /// The source ranges of this comment's tokens.
+  final List<SourceRange> sourceRanges;
+
+  /// The source ranges of this comment's doc-imports.
+  final List<SourceRange> docImportSourceRanges;
+
   final Map<String, CommentReferenceData> references;
 
   CommentData({
-    required this.offset,
-    required this.docImports,
+    required this.sourceRanges,
+    required this.docImportSourceRanges,
     required this.references,
   });
 }
@@ -201,3 +201,118 @@ final String _escapedSlashStarStar = _escape.convert(_slashStarStar);
 const String _starSlash = '*/';
 
 final String _escapedStarSlash = _escape.convert(_starSlash);
+
+extension on Comment {
+  /// A mapping of all comment references to their various data.
+  CommentData get data {
+    var sourceRanges0 = <SourceRange>[
+      for (var token in tokens)
+        SourceRange(
+            token.offset,
+            switch (token.next) {
+                  var next? => next.offset,
+                  null => token.end,
+                } -
+                token.offset),
+    ];
+    var docImportsData = <CommentDocImportData>[];
+    for (var docImport in docImports) {
+      docImportsData.add(
+        CommentDocImportData(
+            offset: docImport.offset, end: docImport.import.end),
+      );
+    }
+
+    var (:sourceRanges, :docImportSourceRanges) =
+        _normalizeSourceRanges(sourceRanges0, docImportsData);
+
+    var referencesData = <String, CommentReferenceData>{};
+    for (var reference in references) {
+      var referable = reference.expression;
+      String name;
+      Element? staticElement;
+      if (referable case PropertyAccess(:var propertyName)) {
+        var target = referable.target;
+        if (target is! PrefixedIdentifier) continue;
+        name = '${target.name}.${propertyName.name}';
+        staticElement = propertyName.element;
+      } else if (referable case PrefixedIdentifier(:var identifier)) {
+        name = referable.name;
+        staticElement = identifier.element;
+      } else if (referable case SimpleIdentifier()) {
+        name = referable.name;
+        staticElement = referable.element;
+      } else {
+        continue;
+      }
+
+      if (staticElement != null && !referencesData.containsKey(name)) {
+        referencesData[name] = CommentReferenceData(
+          staticElement,
+          name,
+          referable.offset,
+          referable.length,
+        );
+      }
+    }
+    return CommentData(
+      sourceRanges: sourceRanges,
+      docImportSourceRanges: docImportSourceRanges,
+      references: referencesData,
+    );
+  }
+
+  /// Normalizes the comment's source ranges and the doc-import source ranges,
+  /// to be relative to the start of the comment text, and to skip over gaps
+  /// produced by interleaved comments.
+  ({List<SourceRange> sourceRanges, List<SourceRange> docImportSourceRanges})
+      _normalizeSourceRanges(
+    List<SourceRange> sourceRanges,
+    List<CommentDocImportData> docImportsData,
+  ) {
+    // All of the `offset` and `end` properties are offsets from the start of
+    // the file (rather than from `content`). For the purposes of stripping
+    // `@docImport` directives, we need to shift all offsets by this value,
+    // the starting offset of the doc comment.
+    var commentOffset = sourceRanges.first.offset;
+
+    // Adjust the source ranges in two ways:
+    // 1. Change the offsets to be offsets from the start of the comment text,
+    //    instead of the file.
+    // 2. Collapse the offsets between one token's end and the next one's start,
+    //    which accounts for non-comment text between comment tokens.
+    var normalizedSourceRanges = <SourceRange>[];
+    var docImportSourceRanges = <SourceRange>[];
+    var accumulatedGapSize = 0;
+    var docImportIndex = 0;
+    for (var i = 0; i < sourceRanges.length; i++) {
+      var sourceRange = sourceRanges[i];
+      var rangeStart = sourceRange.offset - commentOffset;
+      var rangeEnd = sourceRange.end - commentOffset;
+      var gapSize =
+          i == 0 ? 0 : rangeStart - (sourceRanges[i - 1].end - commentOffset);
+      accumulatedGapSize += gapSize;
+      var rangeStartWithGap = rangeStart - accumulatedGapSize;
+      var rangeEndWithGap = rangeEnd - accumulatedGapSize;
+      normalizedSourceRanges.add(
+          SourceRange(rangeStartWithGap, rangeEndWithGap - rangeStartWithGap));
+
+      while (docImportIndex < docImportsData.length &&
+          docImportsData[docImportIndex].end - commentOffset <= rangeEnd) {
+        var docImportOffset =
+            docImportsData[docImportIndex].offset - commentOffset;
+        var docImportEnd = docImportsData[docImportIndex].end - commentOffset;
+        docImportSourceRanges.add(SourceRange(
+          docImportOffset - accumulatedGapSize,
+          docImportEnd - docImportOffset,
+        ));
+        docImportIndex++;
+      }
+    }
+
+    return (
+      sourceRanges: normalizedSourceRanges,
+      docImportSourceRanges: docImportSourceRanges
+    );
+  }
+}

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -215,14 +215,13 @@ class PackageGraph with Referable {
       for (var directive in unit.directives.whereType<LibraryDirective>()) {
         // There should be only one library directive. If there are more, there
         // is no harm in grabbing ModelNode for each.
-        var commentData = directive.documentationComment?.data;
         _modelNodes.putIfAbsent(
             resolvedLibrary.element,
             () => ModelNode(
                   directive,
                   resolvedLibrary.element,
                   _analysisContext,
-                  commentData: commentData,
+                  comment: directive.documentationComment,
                 ));
       }
 
@@ -270,7 +269,7 @@ class PackageGraph with Referable {
   }
 
   void _populateModelNodeFor(Declaration declaration) {
-    var commentData = declaration.documentationComment?.data;
+    var comment = declaration.documentationComment;
 
     void addModelNode(Declaration declaration) {
       var e = declaration.declaredFragment?.element;
@@ -283,7 +282,7 @@ class PackageGraph with Referable {
           declaration,
           e,
           _analysisContext,
-          commentData: commentData,
+          comment: comment,
         ),
       );
     }
@@ -988,49 +987,4 @@ class InheritableElementsKey {
   final Library library;
 
   InheritableElementsKey(this.element, this.library);
-}
-
-extension on Comment {
-  /// A mapping of all comment references to their various data.
-  CommentData get data {
-    var docImportsData = <CommentDocImportData>[];
-    for (var docImport in docImports) {
-      docImportsData.add(
-        CommentDocImportData(
-            offset: docImport.offset, end: docImport.import.end),
-      );
-    }
-
-    var referencesData = <String, CommentReferenceData>{};
-    for (var reference in references) {
-      var referable = reference.expression;
-      String name;
-      Element? staticElement;
-      if (referable case PropertyAccess(:var propertyName)) {
-        var target = referable.target;
-        if (target is! PrefixedIdentifier) continue;
-        name = '${target.name}.${propertyName.name}';
-        staticElement = propertyName.element;
-      } else if (referable case PrefixedIdentifier(:var identifier)) {
-        name = referable.name;
-        staticElement = identifier.element;
-      } else if (referable case SimpleIdentifier()) {
-        name = referable.name;
-        staticElement = referable.element;
-      } else {
-        continue;
-      }
-
-      if (staticElement != null && !referencesData.containsKey(name)) {
-        referencesData[name] = CommentReferenceData(
-          staticElement,
-          name,
-          referable.offset,
-          referable.length,
-        );
-      }
-    }
-    return CommentData(
-        offset: offset, docImports: docImportsData, references: referencesData);
-  }
 }

--- a/test/documentation_comment_test.dart
+++ b/test/documentation_comment_test.dart
@@ -277,6 +277,95 @@ Three.'''));
     expect(doc, equals(''));
   }
 
+  void skip_test_docImport_overshoot() async {
+    // Force \r\n line endings to simulate index drift if the analyzer normalizes it to \n.
+    // We use many lines to ensure the shift overshoots the string length and throws RangeError.
+    var lines = List.generate(50, (i) => '/// Line $i').join('\n');
+    await writePackageWithCommentedLibrary('''
+$lines
+/// @docImport 'dart:async' as async;
+'''
+        .replaceAll('\n', '\r\n'));
+    var doc = libraryModel.documentation;
+
+    expect(doc, '''
+Line 1
+Line 2''');
+  }
+
+  void test_docImport_ignoreLine() async {
+    await writePackageWithCommentedLibrary('''
+var x = 1;
+/// Line 1
+// ignore: something
+/// Line 2
+/// @docImport 'dart:async' as async;
+''');
+    var doc = libraryModel.documentation;
+
+    expect(doc, '''
+Line 1
+Line 2''');
+  }
+
+  void test_docImport_ignoreLine_justBeforeDocImport() async {
+    await writePackageWithCommentedLibrary('''
+/// Line 1
+/// Line 2
+// ignore: something
+/// @docImport 'dart:async' as async;
+''');
+    var doc = libraryModel.documentation;
+
+    expect(doc, '''
+Line 1
+Line 2''');
+  }
+
+  void test_docImport_ignoreBlock() async {
+    await writePackageWithCommentedLibrary('''
+/// Line 1
+/// Line 2
+/* ignore: something */
+/// @docImport 'dart:async' as async;
+''');
+    var doc = libraryModel.documentation;
+
+    expect(doc, '''
+Line 1
+Line 2''');
+  }
+
+  void test_docImport_blockForm() async {
+    await writePackageWithCommentedLibrary('''
+/** Line 1
+ * Line 2
+ @docImport 'dart:async' as async;
+ */
+''');
+    var doc = libraryModel.documentation;
+
+    expect(doc, '''
+Line 1
+Line 2''');
+  }
+
+  void test_docImport_blockForm_interleavedComment() async {
+    await writePackageWithCommentedLibrary('''
+/** Line 1
+ * Line 2
+ /* ignore: something */
+ @docImport 'dart:async' as async;
+ */
+''');
+    var doc = libraryModel.documentation;
+
+    expect(doc, '''
+Line 1
+Line 2
+/* ignore: something */''');
+  }
+
   void test_animationDirectiveHasFewerThanThreeArguments() async {
     await writePackageWithCommentedLibrary('''
 /// Text.

--- a/test/documentation_comment_test.dart
+++ b/test/documentation_comment_test.dart
@@ -350,6 +350,21 @@ Line 1
 Line 2''');
   }
 
+  void test_docImport_blockForm2() async {
+    await writePackageWithCommentedLibrary('''
+/** Line 1
+ * Line 2
+ @docImport 'dart:async' as async;
+ @docImport 'dart:math' as math;
+ */
+''');
+    var doc = libraryModel.documentation;
+
+    expect(doc, '''
+Line 1
+Line 2''');
+  }
+
   void test_docImport_blockForm_interleavedComment() async {
     await writePackageWithCommentedLibrary('''
 /** Line 1


### PR DESCRIPTION
This is a partial replacement for https://github.com/dart-lang/dartdoc/pull/4231. I haven't tested the `\r\n` issue, so it's not a full replacement yet.