### PR TITLE
Fix link generation for remote and re-exported symbols

### DIFF
--- a/lib/src/model/canonicalization.dart
+++ b/lib/src/model/canonicalization.dart
@@ -14,14 +14,14 @@ Library? canonicalLibraryCandidate(ModelElement modelElement) {
   var libraryElement = modelElement.element.library;
   if (libraryElement == null) return null;
   var libraryExports = modelElement.packageGraph.libraryExports[libraryElement];
+  var definingLibrary =
+      modelElement.packageGraph.findButDoNotCreateLibraryFor(libraryElement);
   var candidateList = {
     ...?libraryExports,
-    // When the element is defined in a library that is not documented, the
-    // `libraryExports` map will not contain that library. However, we still want
-    // to consider the defining library as a candidate if it happens to be
-    // documented.
     if (modelElement.library case var library?) library,
+    if (definingLibrary != null) definingLibrary,
   };
+
   if (candidateList.isEmpty) {
     return null;
   }

--- a/lib/src/model/enum.dart
+++ b/lib/src/model/enum.dart
@@ -107,7 +107,7 @@ class EnumField extends Field {
     }
     assert(canonicalEnclosingContainer == enclosingElement);
     assert(canonicalLibrary != null);
-    return '${package.baseHref}${canonicalLibrary!.dirName}/'
+    return '${canonicalLibrary!.package.baseHref}${canonicalLibrary!.dirName}/'
         '${enclosingElement.fileName}';
   }
 

--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -500,16 +500,7 @@ abstract class ModelElement
     // This is not accurate if we are still constructing the Package.
     assert(packageGraph.allLibrariesAdded);
 
-    var definingLibraryElement = element.library;
-    var definingLibrary = definingLibraryElement == null
-        ? null
-        : packageGraph.findButDoNotCreateLibraryFor(definingLibraryElement);
-    var definingLibraryIsLocalPublic = definingLibrary != null &&
-        packageGraph.localPublicLibraries.contains(definingLibrary);
-    var possibleCanonicalLibrary = definingLibraryIsLocalPublic
-        ? library
-        : canonicalLibraryCandidate(this);
-
+    var possibleCanonicalLibrary = canonicalLibraryCandidate(this);
     if (possibleCanonicalLibrary != null) return possibleCanonicalLibrary;
 
     if (this case Inheritable(isInherited: true)) {

--- a/lib/src/model/model_element.dart
+++ b/lib/src/model/model_element.dart
@@ -500,8 +500,12 @@ abstract class ModelElement
     // This is not accurate if we are still constructing the Package.
     assert(packageGraph.allLibrariesAdded);
 
-    var definingLibraryIsLocalPublic =
-        packageGraph.localPublicLibraries.contains(library);
+    var definingLibraryElement = element.library;
+    var definingLibrary = definingLibraryElement == null
+        ? null
+        : packageGraph.findButDoNotCreateLibraryFor(definingLibraryElement);
+    var definingLibraryIsLocalPublic = definingLibrary != null &&
+        packageGraph.localPublicLibraries.contains(definingLibrary);
     var possibleCanonicalLibrary = definingLibraryIsLocalPublic
         ? library
         : canonicalLibraryCandidate(this);

--- a/lib/src/model/model_function.dart
+++ b/lib/src/model/model_function.dart
@@ -59,14 +59,6 @@ class ModelFunctionTyped extends ModelElement with HasLibrary, TypeParameters {
   String? get belowSidebarPath => null;
 
   @override
-  String? get href {
-    if (!identical(canonicalModelElement, this)) {
-      return canonicalModelElement?.href;
-    }
-    return '${package.baseHref}$filePath';
-  }
-
-  @override
   Kind get kind => Kind.function;
 
   // Food for mustache. TODO(jcollins-g): what about enclosing elements?

--- a/lib/src/model/top_level_variable.dart
+++ b/lib/src/model/top_level_variable.dart
@@ -36,14 +36,6 @@ class TopLevelVariable extends ModelElement with GetterSetterCombo, HasLibrary {
   String? get belowSidebarPath => null;
 
   @override
-  String? get href {
-    if (!identical(canonicalModelElement, this)) {
-      return canonicalModelElement?.href;
-    }
-    return '${package.baseHref}$filePath';
-  }
-
-  @override
   bool get isConst => element.isConst;
 
   @override

--- a/lib/src/model/typedef.dart
+++ b/lib/src/model/typedef.dart
@@ -44,14 +44,6 @@ abstract class Typedef extends ModelElement with TypeParameters, HasLibrary {
   /// without this.
   FunctionTypedef get asCallable => this as FunctionTypedef;
 
-  @override
-  String? get href {
-    if (!identical(canonicalModelElement, this)) {
-      return canonicalModelElement?.href;
-    }
-    return '${package.baseHref}$filePath';
-  }
-
   // Food for mustache.
   bool get isInherited => false;
 

--- a/test/packages_test.dart
+++ b/test/packages_test.dart
@@ -256,6 +256,8 @@ library bar;
 library one;
 
 class One {}
+int topLevelVariable = 0;
+typedef MyTypedef = void Function();
 ''');
         packageOneRoot.getChildAssumingFolder('bin').create();
         packageOneRoot
@@ -305,6 +307,41 @@ dartdoc:
         expect(packageOne.documentedWhere, equals(DocumentLocation.remote));
         expect(classOne.href,
             equals('https://mypub.topdomain/one/0.0.1/one/One-class.html'));
+      });
+
+      test('includes remote elements for re-exported symbols', () async {
+        packageOneRoot
+            .getChildAssumingFile('dartdoc_options.yaml')
+            .writeAsStringSync('''
+dartdoc:
+  linkTo:
+    url: 'https://mypub.topdomain/%n%/%v%'
+''');
+        packageTwoRoot
+            .getChildAssumingFolder('lib')
+            .getChildAssumingFile('two.dart')
+            .writeAsStringSync('''
+/// Documentation comment.
+library two;
+export 'package:one/one.dart';
+
+class Two extends One {}
+''');
+        var packageGraph = await utils.bootBasicPackage(
+            packageTwoRoot.path, packageMetaProvider,
+            additionalArguments: ['--link-to-remote']);
+
+        var packageTwo = packageGraph.defaultPackage;
+        var libraryTwo =
+            packageTwo.allLibraries.lastWhere((l) => l.name == 'two');
+
+        var topLevelVar = libraryTwo.properties.named('topLevelVariable');
+        expect(topLevelVar.href,
+            equals('https://mypub.topdomain/one/0.0.1/one/topLevelVariable.html'));
+
+        var myTypedef = libraryTwo.typedefs.named('MyTypedef');
+        expect(myTypedef.href,
+            equals('https://mypub.topdomain/one/0.0.1/one/MyTypedef.html'));
       });
 
       test(

--- a/test/packages_test.dart
+++ b/test/packages_test.dart
@@ -342,6 +342,10 @@ class Two extends One {}
         var myTypedef = libraryTwo.typedefs.named('MyTypedef');
         expect(myTypedef.href,
             equals('https://mypub.topdomain/one/0.0.1/one/MyTypedef.html'));
+
+        var oneClass = libraryTwo.classes.named('One');
+        expect(oneClass.href,
+            equals('https://mypub.topdomain/one/0.0.1/one/One-class.html'));
       });
 
       test(


### PR DESCRIPTION
* Remove incorrect href overrides in TopLevelVariable, ModelFunctionTyped, and Typedef that were hardcoding local paths.
* Correct EnumField.href to use canonicalLibrary!.package.baseHref.
* Fix canonicalLibraryCandidate to consider the defining library as a candidate.
* Fix ModelElement.canonicalLibrary to use defining library for locality check.

Fixes #4075 
Fixes #4239
