### PR TITLE
Add baseline tests for Primary Constructors field induction and metadata propagation.

### DIFF
--- a/test/dartdoc_test_base.dart
+++ b/test/dartdoc_test_base.dart
@@ -49,7 +49,6 @@ abstract class DartdocTestBase {
 
   List<String> get experiments => [
         'enhanced-parts',
-        'wildcard-variables',
         'primary-constructors',
       ];
 

--- a/test/dartdoc_test_base.dart
+++ b/test/dartdoc_test_base.dart
@@ -47,7 +47,11 @@ abstract class DartdocTestBase {
   /// These are written out to a pubspec file using `path` keys.
   Map<String, String> get pubDependencyPaths => const {};
 
-  List<String> get experiments => ['enhanced-parts', 'wildcard-variables'];
+  List<String> get experiments => [
+        'enhanced-parts',
+        'wildcard-variables',
+        'primary-constructors',
+      ];
 
   bool get skipUnreachableSdkLibraries => true;
 

--- a/test/primary_constructor_test.dart
+++ b/test/primary_constructor_test.dart
@@ -26,7 +26,7 @@ class PrimaryConstructorsTest extends DartdocTestBase {
   void test_fieldInduction_class() async {
     var library = await bootPackageWithLibrary('''
 class C(var int x, final int y, int z);
-class Derived(super.x) extends C;
+class Derived(super.x, super.y, super.z) extends C;
 ''');
 
     var c = library.classes.named('C');
@@ -39,6 +39,50 @@ class Derived(super.x) extends C;
     expect(derived.declaredFields.any((f) => f.name == 'x'), isFalse);
     var constructor = derived.constructors.first;
     expect(constructor.parameters.any((p) => p.name == 'x'), isTrue);
+  }
+
+  void test_fieldInduction_optionalPositional() async {
+    var library = await bootPackageWithLibrary('''
+class C([var int x = 1]);
+''');
+
+    var c = library.classes.named('C');
+    var constructor = c.constructors.first;
+
+    expect(c.instanceFields.any((f) => f.name == 'x'), isTrue);
+
+    var paramX = constructor.parameters.firstWhere((p) => p.name == 'x');
+
+    expect(paramX.isOptionalPositional, isTrue);
+    expect(paramX.defaultValue, equals('1'));
+  }
+
+  void test_fieldInduction_named() async {
+    var library = await bootPackageWithLibrary('''
+class C({final int y = 2});
+''');
+
+    var c = library.classes.named('C');
+    var constructor = c.constructors.first;
+
+    expect(c.instanceFields.any((f) => f.name == 'y'), isTrue);
+
+    var paramY = constructor.parameters.firstWhere((p) => p.name == 'y');
+
+    expect(paramY.isNamed, isTrue);
+    expect(paramY.defaultValue, equals('2'));
+  }
+
+  void test_fieldInduction_typeParameters() async {
+    var library = await bootPackageWithLibrary('''
+class Box<T>(var T value);
+''');
+
+    var box = library.classes.named('Box');
+    var field = box.instanceFields.named('value');
+
+    expect(field, isNotNull);
+    expect(field.modelType.name, equals('T'));
   }
 
   void test_fieldInduction_extensionType() async {
@@ -100,6 +144,7 @@ class C(
     expect(c.instanceFields.named('x').documentation, contains('Doc for x.'));
     expect(c.instanceFields.named('y').documentation, contains('Doc for y.'));
     expect(c.instanceFields.named('z').isDeprecated, isTrue);
+    expect(c.constructors.first.parameters.named('z').isDeprecated, isTrue);
   }
 
   void test_metadata_propagation_enum() async {

--- a/test/primary_constructor_test.dart
+++ b/test/primary_constructor_test.dart
@@ -1,0 +1,136 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+import 'package:test_reflective_loader/test_reflective_loader.dart';
+
+import 'dartdoc_test_base.dart';
+import 'src/utils.dart';
+
+void main() {
+  defineReflectiveSuite(() {
+    defineReflectiveTests(PrimaryConstructorsTest);
+  });
+}
+
+@reflectiveTest
+class PrimaryConstructorsTest extends DartdocTestBase {
+  @override
+  String get libraryName => 'primary_constructors';
+
+  // ---------------------------------------------------------------------------
+  // Field Induction & Syntax
+  // ---------------------------------------------------------------------------
+
+  void test_fieldInduction_class() async {
+    var library = await bootPackageWithLibrary('''
+class C(var int x, final int y, int z);
+class Derived(super.x) extends C;
+''');
+
+    var c = library.classes.named('C');
+    expect(c.instanceFields.any((f) => f.name == 'x'), isTrue);
+    expect(c.instanceFields.any((f) => f.name == 'y'), isTrue);
+    expect(c.instanceFields.any((f) => f.name == 'z'), isFalse);
+
+    // Verify 'x' is not a newly induced field in the subclass
+    var derived = library.classes.named('Derived');
+    expect(derived.declaredFields.any((f) => f.name == 'x'), isFalse);
+    var constructor = derived.constructors.first;
+    expect(constructor.parameters.any((p) => p.name == 'x'), isTrue);
+  }
+
+  void test_fieldInduction_extensionType() async {
+    var library = await bootPackageWithLibrary('''
+extension type Id(int value) {}
+''');
+
+    var et = library.extensionTypes.named('Id');
+    expect(et.instanceFields.any((f) => f.name == 'value'), isTrue);
+  }
+
+  void test_bodyless_containers() async {
+    var library = await bootPackageWithLibrary('''
+class C(int x);
+class const Cc(final int x);
+enum E(int x) { v(1); }
+mixin M;
+mixin class MC();
+extension Ex on int;
+extension type ET(int x);
+''');
+
+    expect(library.classes.any((c) => c.name == 'C'), isTrue);
+    expect(library.enums.any((e) => e.name == 'E'), isTrue);
+    expect(library.mixins.any((m) => m.name == 'M'), isTrue);
+    expect(library.classes.any((c) => c.name == 'MC'), isTrue);
+    expect(library.extensions.any((e) => e.name == 'Ex'), isTrue);
+    expect(library.extensionTypes.any((e) => e.name == 'ET'), isTrue);
+
+    // Enum primary constructors are correctly identified as const.
+    var e = library.enums.named('E');
+    expect(e.constructors.first.isConst, isTrue);
+
+    var c = library.classes.named('Cc');
+    expect(c.constructors.first.isConst, isTrue);
+
+    var m = library.classes.named('MC');
+    expect(m.constructors, hasLength(1));
+    expect(m.constructors.first.parameters, isEmpty);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Metadata Propagation (Docs & Annotations)
+  // ---------------------------------------------------------------------------
+
+  void test_metadata_propagation() async {
+    var library = await bootPackageWithLibrary('''
+class C(
+  /// Doc for x.
+  var int x,
+  /// Doc for y.
+  final int y,
+  @deprecated
+  var int z
+);
+''');
+
+    var c = library.classes.named('C');
+    expect(c.instanceFields.named('x').documentation, contains('Doc for x.'));
+    expect(c.instanceFields.named('y').documentation, contains('Doc for y.'));
+    expect(c.instanceFields.named('z').isDeprecated, isTrue);
+  }
+
+  void test_metadata_propagation_enum() async {
+    var library = await bootPackageWithLibrary('''
+enum Status(
+  /// The [label] for this status.
+  @deprecated
+  final String label
+) {
+  active('Active');
+}
+''');
+
+    var e = library.enums.named('Status');
+    var field = e.instanceFields.named('label');
+    expect(field.documentation, contains('The [label] for this status.'));
+    expect(field.isDeprecated, isTrue);
+  }
+
+  void test_metadata_propagation_extensionType() async {
+    var library = await bootPackageWithLibrary('''
+extension type Id(
+  /// The underlying [value].
+  @deprecated
+  int value
+) {}
+''');
+
+    var et = library.extensionTypes.named('Id');
+    var field = et.instanceFields.named('value');
+    expect(field.documentation, contains('The underlying [value].'));
+    expect(field.isDeprecated, isTrue);
+  }
+}

--- a/test/primary_constructor_test.dart
+++ b/test/primary_constructor_test.dart
@@ -30,9 +30,7 @@ class Derived(super.x, super.y, super.z) extends C;
 ''');
 
     var c = library.classes.named('C');
-    expect(c.instanceFields.any((f) => f.name == 'x'), isTrue);
-    expect(c.instanceFields.any((f) => f.name == 'y'), isTrue);
-    expect(c.instanceFields.any((f) => f.name == 'z'), isFalse);
+    expect(c.declaredFields.map((f) => f.name), unorderedEquals(['x', 'y']));
 
     // Verify 'x' is not a newly induced field in the subclass
     var derived = library.classes.named('Derived');


### PR DESCRIPTION
Adding tests verifying that `dartdoc` correctly consumes this information from the analyzer without requiring structural changes to the model.

**This PR Covers:**
* Field induction from `var`/`final` parameters.
* Bodyless declarations (`;` syntax) across all container types.
* Doc comment and annotation propagation to induced fields.
* Enum `const` constructor identification.

**Deferred to future PRs:**
* Comment references
* Parsing the `this` block body 
* Secondary constructor keywords (`new`/`factory`).

