### PR TITLE
Add tests for abbreviated constructor declarations

### DIFF
--- a/test/primary_constructor_test.dart
+++ b/test/primary_constructor_test.dart
@@ -295,4 +295,45 @@ class C(int x) {
     var result = referenceLookup(constructor, 'x').referable as ModelElement;
     expect(result.element, equals(xParam.element));
   }
+
+  // ---------------------------------------------------------------------------
+  // Abbreviated Constructors
+  // ---------------------------------------------------------------------------
+
+  void test_secondaryConstructors_new() async {
+    var library = await bootPackageWithLibrary('''
+class MyClass {
+  const new();
+  new name();
+  new redir(): this.name();
+}
+''');
+
+    var c = library.classes.named('MyClass');
+    expect(
+      c.constructors.map((cons) => cons.name),
+      unorderedEquals([
+        'MyClass.new',
+        'MyClass.name',
+        'MyClass.redir',
+      ]),
+    );
+  }
+
+  @FailingTest(reason: 'https://github.com/dart-lang/sdk/issues/63458')
+  void test_secondaryConstructors_factory() async {
+    var library = await bootPackageWithLibrary('''
+class MyClass {
+  const new();
+  factory fact() => .new();
+  const factory redirFact() = MyClass;
+}
+''');
+
+    var c = library.classes.named('MyClass');
+    expect(
+      c.constructors.map((cons) => cons.name),
+      unorderedEquals(['MyClass.new', 'MyClass.fact', 'MyClass.redirFact']),
+    );
+  }
 }

--- a/test/primary_constructor_test.dart
+++ b/test/primary_constructor_test.dart
@@ -320,15 +320,17 @@ class MyClass {
     );
   }
 
-  @FailingTest(reason: 'https://github.com/dart-lang/sdk/issues/63458')
   void test_secondaryConstructors_factory() async {
-    var library = await bootPackageWithLibrary('''
+    var library = await bootPackageWithLibrary(
+      '''
 class MyClass {
   const new();
   factory fact() => .new();
   const factory redirFact() = MyClass;
 }
-''');
+''',
+      libraryPreamble: '// @dart=3.12',
+    );
 
     var c = library.classes.named('MyClass');
     expect(


### PR DESCRIPTION
This PR adds tests for the new abbreviated constructor syntax, continuing our coverage for the Primary Constructors feature. 