### PR TITLE
Add tests for private named parameters in primary constructors

### DIFF
--- a/lib/src/model/parameter.dart
+++ b/lib/src/model/parameter.dart
@@ -34,8 +34,6 @@ class Parameter extends ModelElement with HasNoPage {
 
   @override
   String? get documentedName {
-    // TODO(rnystrom): Allow private named declaring parameters in primary
-    // constructors here too.
     if (element case FieldFormalParameterElement(privateName: _?)) {
       return element.name;
     }

--- a/test/primary_constructor_test.dart
+++ b/test/primary_constructor_test.dart
@@ -268,7 +268,6 @@ class Derived(super.x) extends Base;
   void test_privateNamedParameter_becomesPublic() async {
     var library = await bootPackageWithLibrary(
       '''
-// @dart=3.12
 class C({
      /// Points to [_name].
     required var String _name

--- a/test/primary_constructor_test.dart
+++ b/test/primary_constructor_test.dart
@@ -262,6 +262,35 @@ class Derived(super.x) extends Base;
   }
 
   // ---------------------------------------------------------------------------
+  // Private Named Parameters
+  // ---------------------------------------------------------------------------
+
+  void test_privateNamedParameter_becomesPublic() async {
+    var library = await bootPackageWithLibrary(
+      '''
+// @dart=3.12
+class C({
+     /// Points to [_name].
+    required var String _name
+});
+''',
+      libraryPreamble: '// @dart=3.12',
+    );
+
+    var c = library.classes.named('C');
+
+    var field = c.instanceFields.named('_name');
+    expect(field.isPublic, isFalse);
+
+    var constructor = c.constructors.first;
+    var parameter = constructor.parameters.first;
+    expect(parameter.documentedName, equals('name')); // Parameter is public
+
+    var result = referenceLookup(c, '_name').referable as ModelElement;
+    expect(result.element, equals(field.element));
+  }
+
+  // ---------------------------------------------------------------------------
   // Primary Constructor Body (this block)
   // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
This PR adds test coverage for private named declaring parameters in primary constructors, continuing our coverage for the Primary Constructors feature.

Because the analyzer correctly populates the `privateName` property on `FieldFormalParameterElement` for primary constructors, `dartdoc`'s existing name resolution logic handles this perfectly out of the box.