### PR TITLE
Stop using modifiers on parameters.

### DIFF
--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -526,8 +526,8 @@ class PackageGraph with Referable {
   ///
   /// [alreadyTagged] is used internall to prevent visiting in cycles.
   void _tagExportsFor(
-    final Library publicLibrary,
-    final LibraryElement libraryElement, {
+    Library publicLibrary,
+    LibraryElement libraryElement, {
     Set<(Library, LibraryElement)>? alreadyTagged,
   }) {
     alreadyTagged ??= {};

--- a/tool/generate_data.dart
+++ b/tool/generate_data.dart
@@ -71,7 +71,7 @@ void main(List<String> args) async {
       for (var mIndex = 1; mIndex <= methodCount; mIndex++) {
         content.write('  void m$methodCounter(');
         content.write(
-            List.generate(parameterCount, (var pIndex) => 'int p$pIndex')
+            List.generate(parameterCount, (pIndex) => 'int p$pIndex')
                 .join(', '));
         content.writeln(') {}');
         methodCounter++;


### PR DESCRIPTION

The lines fail to compile when the code is included in the 3.13 SDK.

(Should the SDK version in pubspec.yaml be updated regularly?)
