### PR TITLE
Make `{@canonicalFor DeclName}` work without a library name.

### DIFF
--- a/doc/directives.md
+++ b/doc/directives.md
@@ -92,8 +92,9 @@ When that heuristic needs to be overridden, a user can use this directive.
 Example:
 
 ```none
-/// {@canonicalFor some_library.SomeClass}
+/// {@canonicalFor [some_library.]SomeName}
 ```
 
 When this directive is used on a library's doc comment, that library is marked
-as the canonical library for `some_library.SomeClass`.
+as the canonical library for `some_library.SomeName`. If `some_library` is
+omitted, the declaration is the one of that name exported by the current library.

--- a/lib/src/model/canonicalization.dart
+++ b/lib/src/model/canonicalization.dart
@@ -28,11 +28,15 @@ Library? canonicalLibraryCandidate(ModelElement modelElement) {
     }
     var exportedElement =
         library.element.exportNamespace.get2(publicElement.name);
+    // Canonicalize accessors to their variables, on both sides.
     if (exportedElement is PropertyAccessorElement) {
-      // Even if original declaration.
       exportedElement = exportedElement.variable;
     }
-    return exportedElement == _normalize(publicElement.element);
+    var element = publicElement.element;
+    if (element is PropertyAccessorElement) {
+      element = element.variable;
+    }
+    return exportedElement == element;
   }).toList();
 
   var definingLibrary =
@@ -155,8 +159,7 @@ final class _Canonicalization {
         ? _modelElement.originalFullyQualifiedName
         : _modelElement.fullyQualifiedName;
     var scoredCandidates = libraries
-        .map((library) => _scoreElementWithLibrary(
-            library,
+        .map((library) => _scoreElementWithLibrary(library,
             _modelElement.qualifiedName, elementQualifiedName, locationPieces,
             preferredPackage: _modelElement.library?.package,
             preferredLibraryName: _modelElement.element.library?.name,
@@ -187,11 +190,12 @@ final class _Canonicalization {
   // because it takes a lot of elements into account, like URIs, differing
   // package names, etc. Anyways, add more tests, in addition to the
   // `StringName` tests in `model_test.dart`.
-  static _ScoredCandidate _scoreElementWithLibrary(Library library,
+  static _ScoredCandidate _scoreElementWithLibrary(
+      Library library,
       String elementName,
-      String elementQualifiedName, Set<String> elementLocationPieces,
-      {
-      Package? preferredPackage,
+      String elementQualifiedName,
+      Set<String> elementLocationPieces,
+      {Package? preferredPackage,
       String? preferredLibraryName,
       LibraryElement? preferredLibrary}) {
     var scoredCandidate = _ScoredCandidate(library);

--- a/lib/src/model/canonicalization.dart
+++ b/lib/src/model/canonicalization.dart
@@ -13,7 +13,28 @@ const int _separatorChar = 0x3B;
 Library? canonicalLibraryCandidate(ModelElement modelElement) {
   var libraryElement = modelElement.element.library;
   if (libraryElement == null) return null;
-  var libraryExports = modelElement.packageGraph.libraryExports[libraryElement];
+  var libraryExports = modelElement.packageGraph.libraryExports[libraryElement]
+      ?.where((library) {
+    // If element is a member, find its toplevel enclosing declaration,
+    // to see if that's exported by the library.
+    var publicElement = modelElement;
+    while (true) {
+      if (publicElement.enclosingElement case final enclosing?
+          when enclosing is! Library) {
+        publicElement = enclosing;
+      } else {
+        break;
+      }
+    }
+    var exportedElement =
+        library.element.exportNamespace.get2(publicElement.name);
+    if (exportedElement is PropertyAccessorElement) {
+      // Even if original declaration.
+      exportedElement = exportedElement.variable;
+    }
+    return exportedElement == _normalize(publicElement.element);
+  }).toList();
+
   var definingLibrary =
       modelElement.packageGraph.findButDoNotCreateLibraryFor(libraryElement);
   var candidateList = {
@@ -135,9 +156,8 @@ final class _Canonicalization {
         : _modelElement.fullyQualifiedName;
     var scoredCandidates = libraries
         .map((library) => _scoreElementWithLibrary(
-            library, elementQualifiedName, locationPieces,
-            elementQualifiedNameInLibrary:
-                '${library.name}.${_modelElement.qualifiedName}',
+            library,
+            _modelElement.qualifiedName, elementQualifiedName, locationPieces,
             preferredPackage: _modelElement.library?.package,
             preferredLibraryName: _modelElement.element.library?.name,
             preferredLibrary: _modelElement.element.library))
@@ -168,8 +188,9 @@ final class _Canonicalization {
   // package names, etc. Anyways, add more tests, in addition to the
   // `StringName` tests in `model_test.dart`.
   static _ScoredCandidate _scoreElementWithLibrary(Library library,
+      String elementName,
       String elementQualifiedName, Set<String> elementLocationPieces,
-      {required String elementQualifiedNameInLibrary,
+      {
       Package? preferredPackage,
       String? preferredLibraryName,
       LibraryElement? preferredLibrary}) {
@@ -177,8 +198,9 @@ final class _Canonicalization {
 
     // Large boost for `@canonicalFor`, essentially overriding all other
     // concerns.
-    if (library.canonicalFor.contains(elementQualifiedNameInLibrary) ||
-        library.canonicalFor.contains(elementQualifiedName)) {
+    if (library.canonicalFor.contains('${library.name}.$elementName') ||
+        library.canonicalFor.contains(elementQualifiedName) ||
+        library.canonicalFor.contains(elementName)) {
       scoredCandidate._alterScore(10.0, _Reason.canonicalFor);
     }
 

--- a/lib/src/model/library.dart
+++ b/lib/src/model/library.dart
@@ -451,27 +451,68 @@ class Library extends ModelElement with TopLevelContainer {
 
   /// Checks [canonicalFor] for correctness and warn if it refers to non-
   /// existent elements (or those that this Library can not be canonical for).
+  ///
+  /// A `{@canonicalFor name}` is valid if it's `name` or `library_name.id`
+  /// where this library exports a declaration named `name`,
+  /// and either there is no library name, the `library_name` is the name
+  /// of this library ([name]), or it's the name of the library where
+  /// the exported declaration is declared.
   void checkCanonicalForIsValid() {
-    var elementNames = _allOriginalModelElementNames;
-    var notFoundInAllModelElements = {
-      for (var elementName in canonicalFor)
-        if (!elementNames.contains(elementName)) elementName,
-    };
-    for (var notFound in notFoundInAllModelElements) {
-      var message = notFound;
-      var lastDot = notFound.lastIndexOf('.');
-      if (lastDot != -1 && lastDot < notFound.length - 1) {
-        var suffix = notFound.substring(lastDot);
-        var possibleMatches =
-            elementNames.where((name) => name.endsWith(suffix));
-        if (possibleMatches.isNotEmpty) {
-          message = '$notFound (did you mean ${possibleMatches.join(', ')}?)';
+    // Element names not exported by this library.
+    // Either the library does not export something with that name,
+    // or it exports more than one thing of that name,
+    // or doesn't export the declaration from a library with the name given
+    // in the `{@canonicalFor library_name.id}` directive.
+    var notExportedElements = <String>{};
+
+    // Helper function to check if [element] was originally declared in
+    // library with name [libraryName].
+    bool hasLibraryName(Element element, String libraryName) {
+      var modelElement = packageGraph.getModelForElement(element);
+      var originalLibraryName = modelElement.originalMember?.library?.name;
+      return libraryName == originalLibraryName;
+    }
+
+    for (var canonicalName in canonicalFor) {
+      var libraryName = '';
+      var memberName = canonicalName;
+      var dotIndex = memberName.lastIndexOf('.');
+      if (dotIndex >= 0) {
+        libraryName = memberName.substring(0, dotIndex);
+        memberName = memberName.substring(dotIndex + 1);
+      }
+
+      var actualElement = element.exportNamespace.get2(memberName);
+      if (libraryName == name) libraryName = ''; // No need to check.
+      if (actualElement == null) {
+        notExportedElements.add(canonicalName);
+      } else if (libraryName.isNotEmpty) {
+        // Exported elements can't be multiply defined.
+        assert(actualElement is! MultiplyDefinedElement);
+        if (!hasLibraryName(element, libraryName)) {
+          /// Is exporting something of the correct name, but not from the
+          /// designated library.
+          notExportedElements.add(canonicalName);
         }
       }
-      warn(PackageWarning.ignoredCanonicalFor, message: message);
     }
-    // TODO(jcollins-g): warn if a macro/tool generates an unexpected
-    // canonicalFor?
+    if (notExportedElements.isNotEmpty) {
+      var elementNames = _allOriginalModelElementNames;
+      for (var notFound in notExportedElements) {
+        var message = notFound;
+        var lastDot = notFound.lastIndexOf('.');
+        if (lastDot < notFound.length - 1) {
+          var suffix =
+              (lastDot < 0) ? '.$notFound' : notFound.substring(lastDot);
+          var possibleMatches =
+              elementNames.where((name) => name.endsWith(suffix));
+          if (possibleMatches.isNotEmpty) {
+            message = '$notFound (did you mean ${possibleMatches.join(', ')}?)';
+          }
+        }
+        warn(PackageWarning.ignoredCanonicalFor, message: message);
+      }
+    }
   }
 
   /// The immediate elements of this library, resolved to their original names.

--- a/lib/src/model/package_graph.dart
+++ b/lib/src/model/package_graph.dart
@@ -525,7 +525,7 @@ class PackageGraph with Referable {
   /// Marks [publicLibrary] as a library that exports [libraryElement] and all
   /// libraries that [libraryElement] transitively exports.
   ///
-  /// [alreadyTagged] is used internall to prevent visiting in cycles.
+  /// [alreadyTagged] is used internally to prevent visiting in cycles.
   void _tagExportsFor(
     Library publicLibrary,
     LibraryElement libraryElement, {

--- a/test/canonical_for_test.dart
+++ b/test/canonical_for_test.dart
@@ -89,6 +89,34 @@ void someFunc() {}
     expect(someFunc.href, contains('b_canonical/someFunc.html'));
   }
 
+  /// Tests that @canonicalFor matches the unqualified name that is exported.
+  Future<void> test_canonicalFor_matchesUnqualifiedName() async {
+    var packageGraph = await bootPackageFromFiles([
+      d.file('lib/other.dart', '''
+void someFunc();
+void otherFunc();
+'''),
+      d.file('lib/a_first.dart', '''
+export 'src/internal.dart';
+'''),
+      d.file('lib/b_canonical.dart', '''
+/// {@canonicalFor b_canonical.someFunc}
+library b_canonical;
+export 'src/internal.dart';
+export 'other.dart' show otherFunc; // Hiding other.dart's someFunc.
+'''),
+      d.file('lib/src/internal.dart', '''
+void someFunc() {}
+'''),
+    ]);
+
+    var bCanonical = packageGraph.libraries.named('b_canonical');
+    var someFunc = bCanonical.functions.named('someFunc');
+
+    expect(someFunc.canonicalLibrary, equals(bCanonical));
+    expect(someFunc.href, contains('b_canonical/someFunc.html'));
+  }
+
   /// Tests that @canonicalFor suggests close matches when a library name is wrong.
   Future<void> test_canonicalFor_suggestsMatches() async {
     var packageGraph = await bootPackageFromFiles([

--- a/test/canonical_for_test.dart
+++ b/test/canonical_for_test.dart
@@ -198,4 +198,29 @@ String get myGetter => 'hello';
     expect(myGetter.canonicalLibrary, equals(httpServing));
     expect(myGetter.href, contains('http_serving/myGetter.html'));
   }
+
+  /// Tests that @canonicalFor works for explicit getters even when they are
+  /// re-exported and standard equality checks might fail,
+  /// also when not using the library name in the directive.
+  Future<void> test_canonicalFor_getter_reexported_noLibrary() async {
+    var packageGraph = await bootPackageFromFiles([
+      d.file('lib/google_cloud.dart', '''
+export 'http_serving.dart';
+'''),
+      d.file('lib/http_serving.dart', '''
+/// {@canonicalFor myGetter}
+library http_serving;
+export 'src/internal.dart';
+'''),
+      d.file('lib/src/internal.dart', '''
+String get myGetter => 'hello';
+'''),
+    ]);
+
+    var httpServing = packageGraph.libraries.named('http_serving');
+    var myGetter = httpServing.properties.named('myGetter');
+
+    expect(myGetter.canonicalLibrary, equals(httpServing));
+    expect(myGetter.href, contains('http_serving/myGetter.html'));
+  }
 }

--- a/test/src/utils.dart
+++ b/test/src/utils.dart
@@ -183,11 +183,8 @@ homepage: https://github.com/dart-lang
   var pathContext = resourceProvider.pathContext;
   var projectsFolder = resourceProvider.getFolder(pathContext.canonicalize(
       ResourceProviderExtension(resourceProvider).convertPath('/projects')));
-  var projectFolder = projectsFolder.getFolder(packageName)
-    ..create();
-  projectFolder
-      .getFile('pubspec.yaml')
-      .writeAsStringSync(pubspecContent);
+  var projectFolder = projectsFolder.getFolder(packageName)..create();
+  projectFolder.getFile('pubspec.yaml').writeAsStringSync(pubspecContent);
   var buffer = StringBuffer('''
 {
   "configVersion": 2,

--- a/tool/generate_data.dart
+++ b/tool/generate_data.dart
@@ -70,9 +70,8 @@ void main(List<String> args) async {
       content.writeln('class C$classCounter {');
       for (var mIndex = 1; mIndex <= methodCount; mIndex++) {
         content.write('  void m$methodCounter(');
-        content.write(
-            List.generate(parameterCount, (pIndex) => 'int p$pIndex')
-                .join(', '));
+        content.write(List.generate(parameterCount, (pIndex) => 'int p$pIndex')
+            .join(', '));
         content.writeln(') {}');
         methodCounter++;
       }


### PR DESCRIPTION
To make this more precise, candidates for canonical libraries only include libraries that actually export the member, not all libraries that export any member from the same library.

I'm guessing at what the intent is for qualified member names like `{@canonicalFor library.foo.bar}`.
Do check that it's not wrong.